### PR TITLE
Add kind and subsystem as first-class fact columns (schema v8)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/matthewjhunter/memstore
 
 go 1.25.0
 
-toolchain go1.25.7
-
 require (
 	github.com/modelcontextprotocol/go-sdk v1.3.0
 	modernc.org/sqlite v1.45.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matthewjhunter/memstore
 
-go 1.25.0
+go 1.25.7
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.3.0

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -35,6 +35,8 @@ type StoreInput struct {
 	Content    string         `json:"content" jsonschema:"the factual claim or memory to store"`
 	Subject    string         `json:"subject" jsonschema:"the entity this fact is about (e.g. a person or project)"`
 	Category   string         `json:"category,omitempty" jsonschema:"fact category: preference, identity, project, capability, relationship, world, or note (default: note)"`
+	Kind       string         `json:"kind,omitempty" jsonschema:"structural type: convention | failure_mode | invariant | pattern | decision | trigger (empty = unclassified)"`
+	Subsystem  string         `json:"subsystem,omitempty" jsonschema:"optional project subsystem this fact belongs to (e.g. feeds, auth, storage)"`
 	Metadata   map[string]any `json:"metadata,omitempty" jsonschema:"optional key-value metadata to attach"`
 	Supersedes *int64         `json:"supersedes,omitempty" jsonschema:"ID of an existing fact that this new fact replaces (preserves history unlike delete)"`
 }
@@ -44,6 +46,8 @@ type SearchInput struct {
 	Query             string         `json:"query" jsonschema:"natural language search query"`
 	Subject           string         `json:"subject,omitempty" jsonschema:"filter results to a specific subject entity"`
 	Category          string         `json:"category,omitempty" jsonschema:"filter results to a specific category"`
+	Kind              string         `json:"kind,omitempty" jsonschema:"filter by kind: convention, failure_mode, invariant, pattern, decision, trigger (empty = all)"`
+	Subsystem         string         `json:"subsystem,omitempty" jsonschema:"filter by subsystem (e.g. feeds, auth)"`
 	Limit             int            `json:"limit,omitempty" jsonschema:"maximum number of results (default 10)"`
 	IncludeSuperseded bool           `json:"include_superseded,omitempty" jsonschema:"if true, include superseded facts in results (tagged with [SUPERSEDED])"`
 	Metadata          map[string]any `json:"metadata,omitempty" jsonschema:"filter by metadata fields (equality match, e.g. {\"source\": \"conversation\"})"`
@@ -51,10 +55,17 @@ type SearchInput struct {
 
 // ListInput is the input schema for the memory_list tool.
 type ListInput struct {
-	Subject  string         `json:"subject,omitempty" jsonschema:"filter by subject entity"`
-	Category string         `json:"category,omitempty" jsonschema:"filter by category"`
-	Limit    int            `json:"limit,omitempty" jsonschema:"maximum number of results (default 20)"`
-	Metadata map[string]any `json:"metadata,omitempty" jsonschema:"filter by metadata fields (equality match, e.g. {\"source\": \"conversation\"})"`
+	Subject   string         `json:"subject,omitempty" jsonschema:"filter by subject entity"`
+	Category  string         `json:"category,omitempty" jsonschema:"filter by category"`
+	Kind      string         `json:"kind,omitempty" jsonschema:"filter by kind: convention, failure_mode, invariant, pattern, decision, trigger (empty = all)"`
+	Subsystem string         `json:"subsystem,omitempty" jsonschema:"filter by subsystem (e.g. feeds, auth)"`
+	Limit     int            `json:"limit,omitempty" jsonschema:"maximum number of results (default 20)"`
+	Metadata  map[string]any `json:"metadata,omitempty" jsonschema:"filter by metadata fields (equality match, e.g. {\"source\": \"conversation\"})"`
+}
+
+// ListSubsystemsInput is the input schema for the memory_list_subsystems tool.
+type ListSubsystemsInput struct {
+	Subject string `json:"subject,omitempty" jsonschema:"filter to a specific subject entity (empty = all subjects)"`
 }
 
 // DeleteInput is the input schema for the memory_delete tool.
@@ -289,6 +300,16 @@ An empty label leaves the existing label unchanged.
 Metadata keys with non-nil values are set; keys with nil values are deleted.
 Use this to reveal hidden passages, change conditions, or annotate edges after creation.`,
 	}, ms.HandleUpdateLink)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "memory_list_subsystems",
+		Description: `List all distinct subsystem values present in the store, optionally filtered by subject.
+
+Use this to discover what structured knowledge exists for a project before starting a task.
+Returns a sorted list of subsystem names (e.g. ["auth", "feeds", "storage"]).
+
+Example: memory_list_subsystems(subject="herald") → all subsystems with facts stored for herald.`,
+	}, ms.HandleListSubsystems)
 }
 
 // --- Handlers ---
@@ -325,6 +346,8 @@ func (ms *MemoryServer) HandleStore(ctx context.Context, _ *mcp.CallToolRequest,
 		Content:   input.Content,
 		Subject:   input.Subject,
 		Category:  category,
+		Kind:      strings.TrimSpace(input.Kind),
+		Subsystem: strings.TrimSpace(input.Subsystem),
 		Embedding: emb,
 	}
 	if len(input.Metadata) > 0 {
@@ -371,6 +394,8 @@ func (ms *MemoryServer) HandleSearch(ctx context.Context, _ *mcp.CallToolRequest
 		MaxResults:      limit,
 		Subject:         input.Subject,
 		Category:        input.Category,
+		Kind:            input.Kind,
+		Subsystem:       input.Subsystem,
 		OnlyActive:      !input.IncludeSuperseded,
 		MetadataFilters: metadataFilters(input.Metadata),
 		// Stable facts (preference, identity) don't decay.
@@ -402,6 +427,12 @@ func (ms *MemoryServer) HandleSearch(ctx context.Context, _ *mcp.CallToolRequest
 			i+1, r.Fact.ID, r.Combined,
 			r.Fact.UseCount+1, r.Fact.ConfirmedCount, // +1 because Touch just ran
 			r.Fact.Subject, r.Fact.Category)
+		if r.Fact.Kind != "" {
+			fmt.Fprintf(&b, " | kind=%s", r.Fact.Kind)
+		}
+		if r.Fact.Subsystem != "" {
+			fmt.Fprintf(&b, " | subsystem=%s", r.Fact.Subsystem)
+		}
 		if r.Fact.SupersededBy != nil {
 			fmt.Fprintf(&b, " [SUPERSEDED by %d]", *r.Fact.SupersededBy)
 		}
@@ -425,6 +456,8 @@ func (ms *MemoryServer) HandleList(ctx context.Context, _ *mcp.CallToolRequest, 
 	opts := memstore.QueryOpts{
 		Subject:         input.Subject,
 		Category:        input.Category,
+		Kind:            input.Kind,
+		Subsystem:       input.Subsystem,
 		OnlyActive:      true,
 		Limit:           limit,
 		MetadataFilters: metadataFilters(input.Metadata),
@@ -441,9 +474,16 @@ func (ms *MemoryServer) HandleList(ctx context.Context, _ *mcp.CallToolRequest, 
 
 	var b strings.Builder
 	for _, f := range facts {
-		fmt.Fprintf(&b, "[id=%d, used=%d, confirmed=%d] %s | %s | %s\n",
+		fmt.Fprintf(&b, "[id=%d, used=%d, confirmed=%d] %s | %s",
 			f.ID, f.UseCount, f.ConfirmedCount,
-			f.Subject, f.Category, f.CreatedAt.Format("2006-01-02 15:04"))
+			f.Subject, f.Category)
+		if f.Kind != "" {
+			fmt.Fprintf(&b, " | kind=%s", f.Kind)
+		}
+		if f.Subsystem != "" {
+			fmt.Fprintf(&b, " | subsystem=%s", f.Subsystem)
+		}
+		fmt.Fprintf(&b, " | %s\n", f.CreatedAt.Format("2006-01-02"))
 		fmt.Fprintf(&b, "  %s\n", f.Content)
 		if len(f.Metadata) > 0 && string(f.Metadata) != "null" {
 			fmt.Fprintf(&b, "  metadata: %s\n", string(f.Metadata))
@@ -482,9 +522,13 @@ func (ms *MemoryServer) HandleStatus(ctx context.Context, _ *mcp.CallToolRequest
 
 	subjects := make(map[string]int)
 	categories := make(map[string]int)
+	kinds := make(map[string]int)
 	for _, f := range facts {
 		subjects[f.Subject]++
 		categories[f.Category]++
+		if f.Kind != "" {
+			kinds[f.Kind]++
+		}
 	}
 
 	var b strings.Builder
@@ -494,6 +538,14 @@ func (ms *MemoryServer) HandleStatus(ctx context.Context, _ *mcp.CallToolRequest
 		fmt.Fprintln(&b, "By category:")
 		for cat, n := range categories {
 			fmt.Fprintf(&b, "  %s: %d\n", cat, n)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	if len(kinds) > 0 {
+		fmt.Fprintln(&b, "By kind:")
+		for k, n := range kinds {
+			fmt.Fprintf(&b, "  %s: %d\n", k, n)
 		}
 		fmt.Fprintln(&b)
 	}
@@ -681,6 +733,7 @@ func (ms *MemoryServer) HandleTaskCreate(ctx context.Context, _ *mcp.CallToolReq
 		Content:   input.Content,
 		Subject:   "todo",
 		Category:  "note",
+		Kind:      "task",
 		Metadata:  metaJSON,
 		Embedding: emb,
 	})
@@ -735,16 +788,14 @@ func (ms *MemoryServer) HandleTaskUpdate(ctx context.Context, _ *mcp.CallToolReq
 }
 
 func (ms *MemoryServer) HandleTaskList(ctx context.Context, _ *mcp.CallToolRequest, input TaskListInput) (*mcp.CallToolResult, any, error) {
-	filters := []memstore.MetadataFilter{
-		{Key: "kind", Op: "=", Value: "task"},
-	}
-
 	status := input.Status
 	if status == "" {
 		status = "pending"
 	}
-	filters = append(filters, memstore.MetadataFilter{Key: "status", Op: "=", Value: status})
 
+	filters := []memstore.MetadataFilter{
+		{Key: "status", Op: "=", Value: status},
+	}
 	if input.Scope != "" {
 		filters = append(filters, memstore.MetadataFilter{Key: "scope", Op: "=", Value: input.Scope})
 	}
@@ -753,6 +804,7 @@ func (ms *MemoryServer) HandleTaskList(ctx context.Context, _ *mcp.CallToolReque
 	}
 
 	facts, err := ms.store.List(ctx, memstore.QueryOpts{
+		Kind:            "task",
 		OnlyActive:      true,
 		MetadataFilters: filters,
 	})
@@ -784,6 +836,25 @@ func (ms *MemoryServer) HandleTaskList(ctx context.Context, _ *mcp.CallToolReque
 	}
 	fmt.Fprintf(&b, "\n%d task(s).", len(facts))
 
+	return textResult(b.String(), false), nil, nil
+}
+
+func (ms *MemoryServer) HandleListSubsystems(ctx context.Context, _ *mcp.CallToolRequest, input ListSubsystemsInput) (*mcp.CallToolResult, any, error) {
+	subsystems, err := ms.store.ListSubsystems(ctx, input.Subject)
+	if err != nil {
+		return textResult(fmt.Sprintf("Error: %v", err), true), nil, nil
+	}
+	if len(subsystems) == 0 {
+		if input.Subject != "" {
+			return textResult(fmt.Sprintf("No subsystems found for subject %q.", input.Subject), false), nil, nil
+		}
+		return textResult("No subsystems found.", false), nil, nil
+	}
+	var b strings.Builder
+	for _, s := range subsystems {
+		fmt.Fprintln(&b, s)
+	}
+	fmt.Fprintf(&b, "\n%d subsystem(s).", len(subsystems))
 	return textResult(b.String(), false), nil, nil
 }
 

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -1394,8 +1394,8 @@ func TestHandleUpdateLink(t *testing.T) {
 	fmt.Sscanf(text, "Linked (link_id=%d", &linkID)
 
 	result, _, err := srv.HandleUpdateLink(ctx, nil, mcpserver.UpdateLinkInput{
-		LinkID: linkID,
-		Label:  "new label",
+		LinkID:   linkID,
+		Label:    "new label",
 		Metadata: map[string]any{"dc": 15},
 	})
 	if err != nil {

--- a/search.go
+++ b/search.go
@@ -74,7 +74,7 @@ func (s *SQLiteStore) searchFTS(ctx context.Context, query string, opts SearchOp
 		return nil, nil
 	}
 
-	q := `SELECT f.id, f.namespace, f.content, f.subject, f.category, f.metadata,
+	q := `SELECT f.id, f.namespace, f.content, f.subject, f.category, f.kind, f.subsystem, f.metadata,
 	             f.superseded_by, f.superseded_at, f.confirmed_count, f.last_confirmed_at,
 	             f.use_count, f.last_used_at, f.embedding, f.created_at, rank
 	      FROM memstore_facts_fts fts
@@ -94,6 +94,14 @@ func (s *SQLiteStore) searchFTS(ctx context.Context, query string, opts SearchOp
 	if opts.Category != "" {
 		q += ` AND f.category = ?`
 		args = append(args, opts.Category)
+	}
+	if opts.Kind != "" {
+		q += ` AND f.kind = ?`
+		args = append(args, opts.Kind)
+	}
+	if opts.Subsystem != "" {
+		q += ` AND f.subsystem = ?`
+		args = append(args, opts.Subsystem)
 	}
 	if err := appendMetadataFilters(&q, &args, "f.", opts.MetadataFilters); err != nil {
 		return nil, err
@@ -122,7 +130,7 @@ func (s *SQLiteStore) searchFTS(ctx context.Context, query string, opts SearchOp
 		var rank float64
 
 		err := rows.Scan(
-			&f.ID, &f.Namespace, &f.Content, &f.Subject, &f.Category,
+			&f.ID, &f.Namespace, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
 			&metadata, &supersededBy, &supersededAt,
 			&f.ConfirmedCount, &lastConfirmedAt,
 			&f.UseCount, &lastUsedAt,
@@ -181,6 +189,14 @@ func (s *SQLiteStore) searchVector(ctx context.Context, queryEmb []float32, opts
 	if opts.Category != "" {
 		q += ` AND category = ?`
 		args = append(args, opts.Category)
+	}
+	if opts.Kind != "" {
+		q += ` AND kind = ?`
+		args = append(args, opts.Kind)
+	}
+	if opts.Subsystem != "" {
+		q += ` AND subsystem = ?`
+		args = append(args, opts.Subsystem)
 	}
 	if err := appendMetadataFilters(&q, &args, "", opts.MetadataFilters); err != nil {
 		return nil, err

--- a/sqlite.go
+++ b/sqlite.go
@@ -833,7 +833,7 @@ func validMetadataKey(key string) bool {
 		return false
 	}
 	for _, c := range key {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' {
 			return false
 		}
 	}

--- a/sqlite.go
+++ b/sqlite.go
@@ -10,11 +10,11 @@ import (
 	"time"
 )
 
-const schemaVersion = 7
+const schemaVersion = 8
 
 // factColumns is the canonical SELECT list for fact queries.
 // searchFTS has its own column list because it joins and adds rank.
-const factColumns = `id, namespace, content, subject, category, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, embedding, created_at`
+const factColumns = `id, namespace, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, embedding, created_at`
 
 // SQLiteStore implements Store backed by a caller-provided SQLite database.
 // It creates memstore_* tables and uses its own version tracking table so it
@@ -117,12 +117,39 @@ func (s *SQLiteStore) migrate() error {
 		}
 	}
 
+	if version < 8 {
+		if err := s.migrateV8(); err != nil {
+			return err
+		}
+	}
+
 	if version == 0 {
 		_, err = s.db.Exec("INSERT INTO memstore_version (version) VALUES (?)", schemaVersion)
 	} else {
 		_, err = s.db.Exec("UPDATE memstore_version SET version = ?", schemaVersion)
 	}
 	return err
+}
+
+func (s *SQLiteStore) migrateV8() error {
+	stmts := []string{
+		`ALTER TABLE memstore_facts ADD COLUMN kind TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE memstore_facts ADD COLUMN subsystem TEXT NOT NULL DEFAULT ''`,
+		`CREATE INDEX IF NOT EXISTS idx_memstore_kind ON memstore_facts(kind)`,
+		`CREATE INDEX IF NOT EXISTS idx_memstore_subsystem ON memstore_facts(subsystem)`,
+		// Migrate existing metadata.kind values to the new column.
+		// This handles tasks (kind="task") and any other facts that used the metadata convention.
+		`UPDATE memstore_facts SET kind = json_extract(metadata, '$.kind')
+		 WHERE kind = ''
+		   AND json_extract(metadata, '$.kind') IS NOT NULL
+		   AND json_extract(metadata, '$.kind') != ''`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.Exec(stmt); err != nil {
+			return fmt.Errorf("memstore V8 migration: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *SQLiteStore) migrateV7() error {
@@ -316,9 +343,9 @@ func (s *SQLiteStore) Insert(ctx context.Context, f Fact) (int64, error) {
 	}
 
 	result, err := s.db.ExecContext(ctx,
-		`INSERT INTO memstore_facts (namespace, content, subject, category, metadata, superseded_by, embedding, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.namespace, f.Content, f.Subject, f.Category, metadata,
+		`INSERT INTO memstore_facts (namespace, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.namespace, f.Content, f.Subject, f.Category, f.Kind, f.Subsystem, metadata,
 		f.SupersededBy, embBlob, f.CreatedAt.Format(time.RFC3339),
 	)
 	if err != nil {
@@ -340,8 +367,8 @@ func (s *SQLiteStore) InsertBatch(ctx context.Context, facts []Fact) error {
 	defer tx.Rollback()
 
 	stmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO memstore_facts (namespace, content, subject, category, metadata, superseded_by, embedding, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO memstore_facts (namespace, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	)
 	if err != nil {
 		return fmt.Errorf("memstore: preparing insert: %w", err)
@@ -366,7 +393,7 @@ func (s *SQLiteStore) InsertBatch(ctx context.Context, facts []Fact) error {
 		}
 
 		result, err := stmt.ExecContext(ctx,
-			s.namespace, facts[i].Content, facts[i].Subject, facts[i].Category, metadata,
+			s.namespace, facts[i].Content, facts[i].Subject, facts[i].Category, facts[i].Kind, facts[i].Subsystem, metadata,
 			facts[i].SupersededBy, embBlob, facts[i].CreatedAt.Format(time.RFC3339),
 		)
 		if err != nil {
@@ -568,6 +595,14 @@ func (s *SQLiteStore) List(ctx context.Context, opts QueryOpts) ([]Fact, error) 
 	if opts.Category != "" {
 		q += ` AND category = ?`
 		args = append(args, opts.Category)
+	}
+	if opts.Kind != "" {
+		q += ` AND kind = ?`
+		args = append(args, opts.Kind)
+	}
+	if opts.Subsystem != "" {
+		q += ` AND subsystem = ?`
+		args = append(args, opts.Subsystem)
 	}
 	if opts.OnlyActive {
 		q += ` AND superseded_by IS NULL`
@@ -957,6 +992,37 @@ func (s *SQLiteStore) historyBySubject(ctx context.Context, subject string) ([]H
 	return entries, nil
 }
 
+// ListSubsystems returns all distinct non-empty subsystem values,
+// optionally filtered by subject (empty = all subjects).
+func (s *SQLiteStore) ListSubsystems(ctx context.Context, subject string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	q := `SELECT DISTINCT subsystem FROM memstore_facts WHERE namespace = ? AND superseded_by IS NULL AND subsystem != ''`
+	args := []any{s.namespace}
+	if subject != "" {
+		q += ` AND subject = ?`
+		args = append(args, subject)
+	}
+	q += ` ORDER BY subsystem`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("memstore: listing subsystems: %w", err)
+	}
+	defer rows.Close()
+
+	var subsystems []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("memstore: scanning subsystem: %w", err)
+		}
+		subsystems = append(subsystems, s)
+	}
+	return subsystems, rows.Err()
+}
+
 // Close is a no-op; the caller owns the database connection.
 func (s *SQLiteStore) Close() error {
 	return nil
@@ -1187,7 +1253,7 @@ func scanFact(row scanner) (*Fact, error) {
 	var createdAt string
 
 	err := row.Scan(
-		&f.ID, &f.Namespace, &f.Content, &f.Subject, &f.Category,
+		&f.ID, &f.Namespace, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
 		&metadata, &supersededBy, &supersededAt,
 		&f.ConfirmedCount, &lastConfirmedAt,
 		&f.UseCount, &lastUsedAt,

--- a/store.go
+++ b/store.go
@@ -13,6 +13,8 @@ type Fact struct {
 	Content         string          // the factual claim
 	Subject         string          // entity being described
 	Category        string          // freeform: "character", "preference", "identity", etc.
+	Kind            string          // structural type: convention | failure_mode | invariant | pattern | decision | trigger | task | ""
+	Subsystem       string          // optional project subsystem (e.g. "feeds", "auth"); scopes facts within a subject
 	Metadata        json.RawMessage // domain-specific extensions (nullable)
 	SupersededBy    *int64          // points to replacing fact
 	SupersededAt    *time.Time      // when supersession occurred
@@ -42,6 +44,8 @@ type SearchOpts struct {
 	MaxResults      int                      // default 20
 	Subject         string                   // filter by subject (empty = all)
 	Category        string                   // filter (empty = all)
+	Kind            string                   // filter by kind (empty = all)
+	Subsystem       string                   // filter by subsystem (empty = all)
 	OnlyActive      bool                     // exclude superseded
 	Namespaces      []string                 // search only these namespaces; empty means the store's own namespace
 	MetadataFilters []MetadataFilter         // filter on metadata JSON fields
@@ -65,6 +69,8 @@ type SearchResult struct {
 type QueryOpts struct {
 	Subject         string           // filter by subject (empty = all)
 	Category        string           // filter by category (empty = all)
+	Kind            string           // filter by kind (empty = all)
+	Subsystem       string           // filter by subsystem (empty = all)
 	OnlyActive      bool             // exclude superseded
 	Namespaces      []string         // list only these namespaces; empty means the store's own namespace
 	MetadataFilters []MetadataFilter // filter on metadata JSON fields
@@ -139,6 +145,10 @@ type Store interface {
 	// Results are ranked by BM25 score. Useful when Ollama is unavailable
 	// or when low-latency retrieval is required (e.g. hook contexts).
 	SearchFTS(ctx context.Context, query string, opts SearchOpts) ([]SearchResult, error)
+
+	// ListSubsystems returns all distinct non-empty subsystem values,
+	// optionally filtered by subject (empty = all subjects).
+	ListSubsystems(ctx context.Context, subject string) ([]string, error)
 
 	// Embedding pipeline
 	NeedingEmbedding(ctx context.Context, limit int) ([]Fact, error)


### PR DESCRIPTION
## Summary

Closes #9, closes #10.

- Adds `kind` and `subsystem` as indexed `TEXT` columns on `memstore_facts` (schema v8 migration)
- `kind` captures the structural type of a fact (e.g. `task`, `convention`, `pattern`, `decision`) — previously a metadata convention
- `subsystem` scopes facts within a subject to a project area (e.g. `auth`, `feeds`) — previously a metadata convention
- Both fields are first-class filter dimensions in `SearchOpts`, `QueryOpts`, and the `Fact` struct
- FTS and vector search both support `kind`/`subsystem` WHERE filters with B-tree index backing
- New `ListSubsystems` method and `memory_list_subsystems` MCP tool
- `memory_task_list` now filters by the `kind` column directly instead of a `json_extract` metadata workaround
- Data migration backfills `kind` from `metadata.kind` for existing task facts
- Also includes a lint fix (QF1001 De Morgan's law in `validMetadataKey`) and removal of the `toolchain` directive that caused Go version mismatch in CI

## Test plan

- [ ] `go test -race ./...` passes
- [ ] Schema migrates cleanly from v7 (existing tasks surface via `memory_task_list`)
- [ ] `memory_list_subsystems` tool returns distinct subsystem values
- [ ] Kind/subsystem filters work in search and list operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)