### PR TITLE
Add multi-harness installers (Cursor, Zed, Codex) and experimental Codex notify adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ memstore setup
 
 `memstore setup` detects your environment, installs Claude Code hooks, registers the MCP server, and creates a config file. Run it again after updating to deploy the latest hooks. See [docs/installation.md](docs/installation.md) for manual setup and troubleshooting.
 
+**Other harnesses.** Memstore-mcp is a standard MCP stdio server and works in any host that speaks MCP. The Taskfile has per-harness installers:
+
+```bash
+task install:claude     # Claude Code: hooks + MCP (calls memstore setup)
+task install:cursor     # Cursor: writes ~/.cursor/mcp.json
+task install:zed        # Zed: prints settings.json snippet (manual paste)
+task install:codex      # Codex: installs experimental notify shim + prints config.toml snippet
+task install:harnesses  # run all of the above
+```
+
+Only Claude Code has a full hook lifecycle; the others get tools-only or an experimental adapter (Codex). See [`examples/codex/README.md`](examples/codex/README.md) for the Codex caveats.
+
 ## What It Does
 
 Memstore gives AI agents durable memory that persists across sessions. It stores facts in SQLite with automatic vector embeddings, enabling hybrid full-text and semantic search. Facts form supersession chains — when knowledge evolves, the old version is preserved in history while the new version takes precedence. An integrated task system with startup surfacing ensures pending work survives session boundaries.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -74,3 +74,105 @@ tasks:
       - diff -q githooks/pre-commit .git/hooks/pre-commit
       - test -f .git/hooks/pre-push
       - diff -q githooks/pre-push .git/hooks/pre-push
+
+  # --- Harness integration ------------------------------------------------
+  # Each install:<harness> task wires memstore-mcp (and where supported,
+  # passive hooks) into one AI coding harness. They are idempotent and
+  # safe to re-run. Harnesses with shared config files (Zed, Codex) print
+  # the snippet for manual paste rather than mutating user config; the
+  # rest write config directly.
+  #
+  # MEMSTORE_MCP_BIN can be overridden in the environment to point at a
+  # non-PATH binary.
+
+  install:claude:
+    desc: Install memstore Claude Code hooks + MCP entry (via ./memstore setup)
+    deps: [install]
+    cmds:
+      - memstore setup
+    preconditions:
+      - sh: command -v claude
+        msg: "Claude Code CLI not found on PATH — install claude first"
+
+  install:cursor:
+    desc: Register memstore-mcp in ~/.cursor/mcp.json (idempotent jq merge)
+    vars:
+      MEMSTORE_MCP_BIN:
+        sh: echo "${MEMSTORE_MCP_BIN:-$(command -v memstore-mcp || echo $HOME/go/bin/memstore-mcp)}"
+    cmds:
+      - mkdir -p "$HOME/.cursor"
+      - test -s "$HOME/.cursor/mcp.json" || echo '{"mcpServers":{}}' > "$HOME/.cursor/mcp.json"
+      - |
+        jq --arg bin "{{.MEMSTORE_MCP_BIN}}" \
+           '.mcpServers.memstore = {"command":$bin,"args":[],"env":{}}' \
+           "$HOME/.cursor/mcp.json" > "$HOME/.cursor/mcp.json.tmp"
+      - mv "$HOME/.cursor/mcp.json.tmp" "$HOME/.cursor/mcp.json"
+      - 'echo "Registered memstore-mcp in ~/.cursor/mcp.json (bin: {{.MEMSTORE_MCP_BIN}})"'
+    preconditions:
+      - sh: command -v jq
+        msg: "jq is required for safe JSON merging — install jq"
+      - sh: test -x "$(echo ${MEMSTORE_MCP_BIN:-$HOME/go/bin/memstore-mcp})" || command -v memstore-mcp
+        msg: "memstore-mcp not found — run 'task install' first or set MEMSTORE_MCP_BIN"
+
+  install:zed:
+    desc: Print Zed context_servers snippet (settings.json is JSONC, no safe auto-merge)
+    vars:
+      MEMSTORE_MCP_BIN:
+        sh: echo "${MEMSTORE_MCP_BIN:-$(command -v memstore-mcp || echo $HOME/go/bin/memstore-mcp)}"
+    cmds:
+      - |
+        cat <<EOF
+
+        Zed's settings.json is JSONC with extensive user content; auto-merge
+        is unsafe. Paste this into the top-level object of
+        ~/.config/zed/settings.json (merge with any existing context_servers
+        block):
+
+          "context_servers": {
+            "memstore": {
+              "command": "{{.MEMSTORE_MCP_BIN}}",
+              "args": [],
+              "env": {}
+            }
+          }
+
+        Then restart Zed (or save settings.json — Zed hot-reloads).
+        Zed has no per-prompt hook surface; this enables tools only.
+
+        EOF
+
+  install:codex:
+    desc: Install experimental Codex notify shim + print config.toml snippet
+    vars:
+      MEMSTORE_MCP_BIN:
+        sh: echo "${MEMSTORE_MCP_BIN:-$(command -v memstore-mcp || echo $HOME/go/bin/memstore-mcp)}"
+      SHIM_DEST: '{{.HOME}}/.codex/hooks/codex-notify-memstore.mjs'
+    cmds:
+      - install -Dm755 examples/codex/codex-notify-memstore.mjs "$HOME/.codex/hooks/codex-notify-memstore.mjs"
+      - |
+        cat <<EOF
+
+        Experimental notify shim installed to:
+          ~/.codex/hooks/codex-notify-memstore.mjs
+
+        Add to ~/.codex/config.toml (creates if absent):
+
+          notify = ["node", "$HOME/.codex/hooks/codex-notify-memstore.mjs"]
+
+          [mcp_servers.memstore]
+          command = "{{.MEMSTORE_MCP_BIN}}"
+          args = []
+          env = {}
+
+        See examples/codex/README.md for caveats (per-turn re-upload,
+        silent nudges, recursion safety).
+
+        EOF
+
+  install:harnesses:
+    desc: Run all harness installers (Claude, Cursor, Zed, Codex)
+    cmds:
+      - task: install:claude
+      - task: install:cursor
+      - task: install:zed
+      - task: install:codex

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -1,0 +1,133 @@
+# Codex notify → memstore (experimental)
+
+> **Status: experimental.** Wires OpenAI's Codex CLI into memstore by
+> abusing Codex's per-turn `notify` callback as a substitute for the
+> session-end hook that Codex doesn't expose. Works, but with the caveats
+> below; not part of the supported install flow.
+
+Claude Code has a `Stop` hook (one event per assistant turn settle), and
+`memstore-mcp --hook` consumes that shape on stdin: `{session_id, cwd,
+transcript_path}`. It reads the transcript JSONL from disk and posts to
+memstored, which extracts facts server-side with local LLMs.
+
+Codex has no equivalent. Its `notify` config calls an external program once
+per `agent-turn-complete`, passing a single JSON argument with `type`,
+`thread-id`, `turn-id`, `cwd`, `input-messages`, and
+`last-assistant-message`. No transcript file on disk (just a global
+`~/.codex/history.jsonl`), and no session-end event at all.
+
+`codex-notify-memstore.mjs` bridges the two:
+
+1. Filters for `type === "agent-turn-complete"`.
+2. Appends a Claude-Code-shaped JSONL pair (user + assistant) to
+   `~/.cache/memstore/codex-sessions/<thread-id>.jsonl`.
+3. Synthesizes a Claude Code Stop-hook payload and pipes it to
+   `memstore-mcp --hook`.
+4. Detaches the child so Codex doesn't block on the upload.
+
+No changes to `memstore-mcp` or memstored — the server treats Codex turns
+exactly like Claude turns.
+
+## Install
+
+```bash
+# 1. Make sure memstore-mcp is on PATH (or set MEMSTORE_MCP_BIN).
+which memstore-mcp
+
+# 2. Drop the shim somewhere stable. Out-of-tree is fine; this examples/
+#    location is canonical, but ~/.codex/hooks/ is more idiomatic for Codex.
+install -Dm755 examples/codex/codex-notify-memstore.mjs \
+    ~/.codex/hooks/codex-notify-memstore.mjs
+
+# 3. Register it in Codex's config.
+cat >> ~/.codex/config.toml <<'EOF'
+notify = ["node", "/home/<you>/.codex/hooks/codex-notify-memstore.mjs"]
+EOF
+```
+
+Verify by running the shim by hand:
+
+```bash
+node ~/.codex/hooks/codex-notify-memstore.mjs '{
+  "type": "agent-turn-complete",
+  "thread-id": "smoke-test-1",
+  "cwd": "/tmp",
+  "input-messages": ["hello"],
+  "last-assistant-message": "hi"
+}'
+# Should create ~/.cache/memstore/codex-sessions/smoke-test-1.jsonl
+# and spawn memstore-mcp --hook in the background.
+```
+
+## What memstore sees
+
+The thread-id becomes the memstored `session_id`. Each turn appends to the
+per-thread transcript and re-posts it. The Go binary's per-session state
+file (in `~/.cache/memstore/sessions/`) tracks message count and emits the
+8-message "store your decisions" nudge to stderr — Codex's TUI will not
+surface that nudge as a system message the way Claude Code does, so the
+nudge is best-effort logging only inside Codex.
+
+Persona is set by the OS user (`os/user.Current()` in the Go binary), so
+facts attribute to the right person even though Codex has no concept of
+the memstored user model.
+
+## Caveats
+
+**Per-turn re-upload.** Codex has no session-end event, so the shim fires on
+every turn and re-uploads the *growing* transcript each time. memstored
+dedups at the fact level, so no duplicate memories accumulate, but the
+upload bandwidth is wasted. Three mitigations, in increasing effort:
+
+- **Default: accept it.** Codex sessions tend to be short; the wasted I/O
+  is small.
+- **Debounce in the shim.** Append every turn, but only call
+  `memstore-mcp --hook` every N turns or after T seconds of idle. Add a
+  `.pending` sidecar file and a `setTimeout` shaped chain. Not implemented.
+- **Native Codex mode in `memstore-mcp`.** Add a `--codex-notify` flag that
+  takes Codex's JSON shape directly and tracks an incremental cursor
+  server-side. Cleanest, but a real change. Skip until per-turn cost bites.
+
+**No nudge feedback loop.** The store-your-decisions nudge writes to
+stderr; Codex doesn't render it as a system message the way Claude Code
+does. The nudge is passive — Codex won't tell the model "you should call
+`memory_store` now."
+
+**Failure mode is silent.** A memstored outage or a bad spawn produces a
+single stderr line and Codex continues. The shim never fails the
+parent — a memory-system problem must not break Codex output. Check
+`~/.cache/memstore/codex-sessions/` and memstored logs if memories aren't
+showing up.
+
+**Thread-id pinning.** The shim rejects thread-ids that aren't
+`[A-Za-z0-9._-]{1,128}` because they end up as filesystem path components.
+Codex emits UUIDs, so this is not lossy in practice, but a custom-shaped
+thread-id from a Codex variant would be skipped — visible in stderr as
+`unsafe thread-id: ...`.
+
+**Recursion / paid-LLM rule compliance.** Extraction happens server-side
+in memstored using local Gemma/Qwen via Lemonade or Ollama. No paid LLMs
+are called from this path. The shim itself does not call any model
+provider, so it cannot recurse. Aligned with the rules in
+`memory/feedback_no_post_session_hooks.md` and
+`memory/feedback_llms_in_memstore.md`.
+
+## Tests
+
+```bash
+node --test examples/codex/codex-notify-memstore.test.mjs
+```
+
+Unit tests cover only the pure logic — event classification, transcript
+line shape, hook-payload shape. The spawn / filesystem path is integration
+work and would need a live memstored to test; do that by hand using the
+smoke-test invocation above.
+
+## Why this is in `examples/`
+
+The shim is small, single-file, has no memstore-side dependencies, and
+hasn't been used in production for long enough to bake into the supported
+`memstore setup` flow. If it proves stable, the obvious next step is
+either to fold it into the Go binary as `memstore-mcp --codex-notify`
+(removing Node from the deploy footprint) or to grow `memstore setup` to
+detect a Codex install and offer to install the shim.

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -30,12 +30,23 @@ exactly like Claude turns.
 
 ## Install
 
+The canonical install path is the Taskfile:
+
+```bash
+task install:codex
+```
+
+This copies the shim to `~/.codex/hooks/` and prints the `~/.codex/config.toml`
+snippet you need to paste (`notify = [...]` plus an `[mcp_servers.memstore]`
+block for the runtime MCP tools).
+
+Manual equivalent if you'd rather not use Task:
+
 ```bash
 # 1. Make sure memstore-mcp is on PATH (or set MEMSTORE_MCP_BIN).
 which memstore-mcp
 
-# 2. Drop the shim somewhere stable. Out-of-tree is fine; this examples/
-#    location is canonical, but ~/.codex/hooks/ is more idiomatic for Codex.
+# 2. Drop the shim somewhere stable.
 install -Dm755 examples/codex/codex-notify-memstore.mjs \
     ~/.codex/hooks/codex-notify-memstore.mjs
 

--- a/examples/codex/codex-notify-memstore.mjs
+++ b/examples/codex/codex-notify-memstore.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+//
+// codex-notify-memstore.mjs — EXPERIMENTAL
+//
+// Bridge OpenAI Codex CLI's `notify` event to memstore so cross-session
+// memory works inside Codex the way it does inside Claude Code.
+//
+// Codex invokes the configured `notify` program once per `agent-turn-complete`
+// event, passing a single JSON argument with thread-id, turn-id, cwd,
+// input-messages, and last-assistant-message (see the Codex config docs).
+//
+// This shim:
+//   1. Filters for type == "agent-turn-complete".
+//   2. Appends one user + one assistant entry, in Claude-Code-shaped JSONL,
+//      to ~/.cache/memstore/codex-sessions/<thread-id>.jsonl.
+//   3. Synthesizes a Claude Code Stop-hook payload (session_id, cwd,
+//      transcript_path) and pipes it to `memstore-mcp --hook`, which
+//      handles persona, upload, dedup, retry, and the optional nudge.
+//
+// The child is spawned detached so Codex doesn't block on the upload.
+//
+// Status: experimental. See examples/codex/README.md.
+
+import { spawn } from 'node:child_process';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const SESSIONS_DIR = join(homedir(), '.cache', 'memstore', 'codex-sessions');
+const MEMSTORE_MCP_BIN = process.env.MEMSTORE_MCP_BIN || 'memstore-mcp';
+
+// classifyEvent inspects the parsed Codex notify payload and returns either
+// {action: "skip", reason} or {action: "forward", threadId, cwd, userText,
+// assistantText}. Pure function; tested directly.
+export function classifyEvent(event) {
+  if (event == null || typeof event !== 'object') {
+    return { action: 'skip', reason: 'event is not an object' };
+  }
+  if (event.type !== 'agent-turn-complete') {
+    return { action: 'skip', reason: `unhandled type=${event.type}` };
+  }
+  const threadId = event['thread-id'];
+  if (!threadId || typeof threadId !== 'string') {
+    return { action: 'skip', reason: 'missing thread-id' };
+  }
+  // thread-id ends up in a filesystem path; reject anything that isn't a
+  // safe identifier. Codex emits UUIDs, so this constraint is not lossy.
+  if (!/^[A-Za-z0-9._-]{1,128}$/.test(threadId)) {
+    return { action: 'skip', reason: `unsafe thread-id: ${threadId}` };
+  }
+  const cwd = typeof event.cwd === 'string' && event.cwd.length > 0 ? event.cwd : process.cwd();
+  const userText = Array.isArray(event['input-messages'])
+    ? event['input-messages'].map(String).join('\n')
+    : String(event['input-messages'] ?? '');
+  const assistantText = String(event['last-assistant-message'] ?? '');
+  return { action: 'forward', threadId, cwd, userText, assistantText };
+}
+
+// buildTranscriptLines returns the two JSONL entries (user, assistant) to
+// append, shaped like Claude Code transcripts. Returned as a single string
+// ending in a newline so appendFile is one syscall.
+export function buildTranscriptLines(userText, assistantText) {
+  const user = {
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'text', text: userText }] },
+  };
+  const assistant = {
+    type: 'assistant',
+    message: { role: 'assistant', content: [{ type: 'text', text: assistantText }] },
+  };
+  return JSON.stringify(user) + '\n' + JSON.stringify(assistant) + '\n';
+}
+
+// buildHookPayload returns the JSON string fed to `memstore-mcp --hook`.
+// memstored's runHookCapture reads session_id, cwd, transcript_path.
+export function buildHookPayload(threadId, cwd, transcriptPath) {
+  return JSON.stringify({
+    session_id: threadId,
+    cwd,
+    transcript_path: transcriptPath,
+  });
+}
+
+function forward(threadId, cwd, userText, assistantText) {
+  mkdirSync(SESSIONS_DIR, { recursive: true, mode: 0o700 });
+  const transcriptPath = join(SESSIONS_DIR, `${threadId}.jsonl`);
+  appendFileSync(transcriptPath, buildTranscriptLines(userText, assistantText), { mode: 0o600 });
+
+  const payload = buildHookPayload(threadId, cwd, transcriptPath);
+  // Detached so we return immediately and Codex isn't held on memstored I/O.
+  // Errors from the child go to stderr where Codex may log them; we never
+  // fail the parent — a memstore outage shouldn't break Codex turn output.
+  const child = spawn(MEMSTORE_MCP_BIN, ['--hook'], {
+    stdio: ['pipe', 'ignore', 'inherit'],
+    detached: true,
+  });
+  child.on('error', (err) => {
+    process.stderr.write(`codex-notify-memstore: spawn ${MEMSTORE_MCP_BIN} failed: ${err.message}\n`);
+  });
+  child.stdin.end(payload);
+  child.unref();
+}
+
+// main is exported so the test file can stub it; the script is launched
+// only when run directly, not when imported.
+export function main(argv = process.argv) {
+  const arg = argv[2];
+  if (!arg) {
+    process.stderr.write('codex-notify-memstore: no JSON arg\n');
+    return 0;
+  }
+
+  let event;
+  try {
+    event = JSON.parse(arg);
+  } catch (err) {
+    process.stderr.write(`codex-notify-memstore: invalid JSON arg: ${err.message}\n`);
+    return 0;
+  }
+
+  const decision = classifyEvent(event);
+  if (decision.action === 'skip') {
+    // Stay silent on the common "skip" reason (non-turn-complete events)
+    // so logs aren't noisy; surface the loud ones for debugging.
+    if (decision.reason && !decision.reason.startsWith('unhandled type=')) {
+      process.stderr.write(`codex-notify-memstore: ${decision.reason}\n`);
+    }
+    return 0;
+  }
+
+  try {
+    forward(decision.threadId, decision.cwd, decision.userText, decision.assistantText);
+  } catch (err) {
+    process.stderr.write(`codex-notify-memstore: forward failed: ${err.message}\n`);
+  }
+  return 0;
+}
+
+// Run only when invoked as a script.
+const invokedDirectly = import.meta.url === `file://${process.argv[1]}`;
+if (invokedDirectly) {
+  process.exit(main());
+}

--- a/examples/codex/codex-notify-memstore.test.mjs
+++ b/examples/codex/codex-notify-memstore.test.mjs
@@ -1,0 +1,134 @@
+// Unit tests for codex-notify-memstore.mjs pure-logic exports.
+// Run: node --test examples/codex/codex-notify-memstore.test.mjs
+//
+// We do not exercise the spawn / filesystem path here — those are integration
+// concerns that require Codex + memstored to be live. The unit tests cover
+// the JSON-shape decisions where regressions would silently corrupt
+// transcripts or upload the wrong session id.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyEvent,
+  buildTranscriptLines,
+  buildHookPayload,
+} from './codex-notify-memstore.mjs';
+
+describe('classifyEvent', () => {
+  it('forwards a well-formed agent-turn-complete', () => {
+    const decision = classifyEvent({
+      type: 'agent-turn-complete',
+      'thread-id': '01HXYZ-deadbeef',
+      'turn-id': 't-1',
+      cwd: '/home/matthew/git/memstore',
+      'input-messages': ['Refactor extract.go', 'and add tests'],
+      'last-assistant-message': 'Done — see commit abc123.',
+    });
+    assert.deepEqual(decision, {
+      action: 'forward',
+      threadId: '01HXYZ-deadbeef',
+      cwd: '/home/matthew/git/memstore',
+      userText: 'Refactor extract.go\nand add tests',
+      assistantText: 'Done — see commit abc123.',
+    });
+  });
+
+  it('skips non-turn-complete event types', () => {
+    const decision = classifyEvent({ type: 'session-started', 'thread-id': 'x' });
+    assert.equal(decision.action, 'skip');
+    assert.match(decision.reason, /^unhandled type=session-started/);
+  });
+
+  it('skips events with missing thread-id', () => {
+    const decision = classifyEvent({ type: 'agent-turn-complete' });
+    assert.equal(decision.action, 'skip');
+    assert.equal(decision.reason, 'missing thread-id');
+  });
+
+  it('skips events whose thread-id is unsafe for a path', () => {
+    const decision = classifyEvent({
+      type: 'agent-turn-complete',
+      'thread-id': '../etc/passwd',
+    });
+    assert.equal(decision.action, 'skip');
+    assert.match(decision.reason, /^unsafe thread-id/);
+  });
+
+  it('skips a null event', () => {
+    assert.equal(classifyEvent(null).action, 'skip');
+    assert.equal(classifyEvent(undefined).action, 'skip');
+    assert.equal(classifyEvent('string').action, 'skip');
+  });
+
+  it('coerces a missing input-messages to an empty string', () => {
+    const decision = classifyEvent({
+      type: 'agent-turn-complete',
+      'thread-id': 't1',
+      'last-assistant-message': 'hi',
+    });
+    assert.equal(decision.action, 'forward');
+    assert.equal(decision.userText, '');
+    assert.equal(decision.assistantText, 'hi');
+  });
+
+  it('coerces a non-array input-messages to a string', () => {
+    const decision = classifyEvent({
+      type: 'agent-turn-complete',
+      'thread-id': 't1',
+      'input-messages': 'single',
+      'last-assistant-message': '',
+    });
+    assert.equal(decision.action, 'forward');
+    assert.equal(decision.userText, 'single');
+  });
+
+  it('falls back to cwd of process when event.cwd is missing', () => {
+    const decision = classifyEvent({
+      type: 'agent-turn-complete',
+      'thread-id': 't1',
+      'last-assistant-message': '',
+    });
+    assert.equal(decision.action, 'forward');
+    assert.equal(decision.cwd, process.cwd());
+  });
+});
+
+describe('buildTranscriptLines', () => {
+  it('emits one JSONL line per role, newline-terminated', () => {
+    const out = buildTranscriptLines('hello', 'world');
+    const lines = out.split('\n');
+    // Two JSON entries plus the trailing empty element from the final newline.
+    assert.equal(lines.length, 3);
+    assert.equal(lines[2], '');
+
+    const user = JSON.parse(lines[0]);
+    assert.equal(user.type, 'user');
+    assert.equal(user.message.role, 'user');
+    assert.equal(user.message.content[0].text, 'hello');
+
+    const assistant = JSON.parse(lines[1]);
+    assert.equal(assistant.type, 'assistant');
+    assert.equal(assistant.message.role, 'assistant');
+    assert.equal(assistant.message.content[0].text, 'world');
+  });
+
+  it('preserves embedded newlines in user input', () => {
+    const out = buildTranscriptLines('line one\nline two', 'ack');
+    const user = JSON.parse(out.split('\n')[0]);
+    assert.equal(user.message.content[0].text, 'line one\nline two');
+  });
+});
+
+describe('buildHookPayload', () => {
+  it('emits the three fields memstore-mcp --hook reads', () => {
+    const payload = JSON.parse(
+      buildHookPayload('thread-1', '/tmp/work', '/tmp/transcript.jsonl'),
+    );
+    assert.deepEqual(payload, {
+      session_id: 'thread-1',
+      cwd: '/tmp/work',
+      transcript_path: '/tmp/transcript.jsonl',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New `task install:*` targets for Claude (existing setup), Cursor (jq merge into `~/.cursor/mcp.json`), Zed (prints snippet — JSONC merge is unsafe), and Codex (installs experimental notify shim + prints `config.toml` snippet). `task install:harnesses` runs all four.
- New `examples/codex/codex-notify-memstore.mjs` shim: bridges OpenAI Codex CLI into memstore by abusing the per-turn `notify` callback as a stand-in for the session-end hook Codex doesn't expose. Filters for `agent-turn-complete`, appends Claude-Code-shaped JSONL to `~/.cache/memstore/codex-sessions/`, then pipes a synthesized Stop payload to `memstore-mcp --hook`. Detached spawn, won't block Codex.
- No changes to `memstore-mcp` or `memstored`. README and `examples/codex/README.md` document the install paths and the Codex-specific caveats (per-turn re-upload cost, silent nudge, failure mode).

## Test plan

- [x] `task install:cursor` is idempotent (re-run produces no diff)
- [x] `task install:cursor` writes a valid `~/.cursor/mcp.json`
- [x] Unit tests in `examples/codex/codex-notify-memstore.test.mjs` cover the pure-logic exports
- [ ] Live verification of Codex shim end-to-end requires a running `memstored` (integration, manual)