### PR TITLE
Add --no-embeddings flag for FTS-only mode

### DIFF
--- a/cmd/memstore-mcp/main.go
+++ b/cmd/memstore-mcp/main.go
@@ -50,6 +50,7 @@ func main() {
 	model := flag.String("model", cfg.Model, "embedding model name (local mode only)")
 	llmAPIKey := flag.String("llm-api-key", cfg.LLMAPIKey, "API key for the LLM provider (empty = no auth)")
 	genModel := flag.String("gen-model", cfg.GenModel, "LLM model for generation; enables memory_learn")
+	noEmbeddings := flag.Bool("no-embeddings", false, "run without embeddings (FTS-only search, no vector similarity)")
 	hookMode := flag.Bool("hook", false, "read Stop hook JSON from stdin, POST to memstored, exit")
 	transcriptPath := flag.String("transcript", "", "read JSONL transcript from path, POST to memstored, exit")
 	flag.Parse()
@@ -89,7 +90,9 @@ func main() {
 		// Single connection for WAL mode correctness with memstore's mutex.
 		db.SetMaxOpenConns(1)
 
-		embedder = memstore.NewOpenAIEmbedder(*ollamaURL, *llmAPIKey, *model)
+		if !*noEmbeddings {
+			embedder = memstore.NewOpenAIEmbedder(*ollamaURL, *llmAPIKey, *model)
+		}
 
 		sqlStore, err := memstore.NewSQLiteStore(db, embedder, *namespace)
 		if err != nil {

--- a/search.go
+++ b/search.go
@@ -12,18 +12,21 @@ import (
 )
 
 // Search performs hybrid FTS5 + vector search, merging and deduplicating results.
-// Requires an embedder; returns an error if none is configured.
+// When no embedder is configured, falls back to FTS-only (keyword) search.
 func (s *SQLiteStore) Search(ctx context.Context, query string, opts SearchOpts) ([]SearchResult, error) {
-	if s.embedder == nil {
-		return nil, fmt.Errorf("memstore: Search requires an embedder")
-	}
-
 	if opts.MaxResults <= 0 {
 		opts.MaxResults = 20
 	}
 	if opts.FTSWeight == 0 && opts.VecWeight == 0 {
 		opts.FTSWeight = 0.6
 		opts.VecWeight = 0.4
+	}
+
+	// FTS-only fallback when no embedder is available.
+	if s.embedder == nil {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return s.searchFTS(ctx, query, opts)
 	}
 
 	queryEmb, err := Single(ctx, s.embedder, query)


### PR DESCRIPTION
## Summary

- New `--no-embeddings` flag on `memstore-mcp` for environments without an embedding provider. Falls back to FTS5 keyword search instead of erroring when no embedder is configured.
- Small diff: `cmd/memstore-mcp/main.go` (+5), `search.go` (+13/-6).

## Caveats

**Stale branch.** This commit is from 2026-03-27 and predates the May embedding refactor (`embedding.ConfigFromEnvPrefix`, `go-embedding` v0.3.0 migration). The patch may or may not still apply cleanly against current `main` — review before merging. If the embedder-init path has moved enough that the fallback logic no longer fits naturally, consider closing this and re-doing the feature against the current architecture instead.

## Test plan

- [ ] Verify the patch still applies and tests pass on current `main`
- [ ] Manual: start `memstore-mcp --no-embeddings`, confirm search works via FTS only
- [ ] Manual: confirm the normal (embedder-configured) path is unchanged