### PR TITLE
Modernize CI: action pins, go directive, dependabot grouping, auto-merge gating

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,20 @@
 version: 2
 updates:
   - package-ecosystem: gomod
-    directory: /
+    directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      go-deps:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
-    directory: /
+    directory: "/"
     schedule:
       interval: weekly
+    groups:
+      gha:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -46,9 +46,9 @@ jobs:
   vet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -58,9 +58,9 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -76,22 +76,22 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
 
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,9 @@
 name: Auto-merge Dependabot PRs
 
-on: pull_request
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 permissions:
   contents: write
@@ -8,12 +11,40 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: >
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: dependabot/fetch-metadata@v3
-        id: metadata
-      - run: gh pr merge --auto --squash "$PR_URL"
+      - name: Find PR and check all workflows
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          PR_NUMBER=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "No PR found for commit, skipping"
+            exit 0
+          fi
+
+          sleep 10
+          CHECKS=$(gh api "repos/$REPO/commits/$SHA/check-runs" \
+            --jq '[.check_runs[] | select(.name != "auto-merge") | {name: .name, status: .status, conclusion: .conclusion}]')
+
+          PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status != "completed")] | length')
+          FAILED=$(echo "$CHECKS" | jq '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped")] | length')
+
+          if [ "$PENDING" != "0" ]; then
+            echo "Some checks still pending, will retry on next workflow completion"
+            exit 0
+          fi
+
+          if [ "$FAILED" != "0" ]; then
+            echo "Some checks failed, skipping merge"
+            exit 1
+          fi
+
+          echo "All checks passed, merging PR #$PR_NUMBER"
+          gh pr review --approve "$PR_NUMBER" -R "$REPO"
+          gh pr merge --squash "$PR_NUMBER" -R "$REPO"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
   build-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: docker/login-action@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matthewjhunter/memstore
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/jackc/pgx/v5 v5.9.2


### PR DESCRIPTION
## Summary

Bring CI and dependabot configuration in line with the polish standard used on the other recently-cleaned projects (newsletter, contact, oidclient, dicta). Four logical commits:

1. **Go directive 1.25.9 → 1.25.10** — matches the other projects.
2. **Action pins** — \`actions/checkout@v4→v6\`, \`actions/setup-go@v5→v6\`, \`golangci/golangci-lint-action@v7→v9\`. \`golangci-lint\` itself stays pinned at \`v2.10.1\`. Touches both \`ci.yml\` and \`docker.yml\`.
3. **Dependabot grouping** — collapses gomod bumps into one weekly PR and github-actions bumps into another; caps gomod at 5 concurrent open PRs.
4. **Auto-merge workflow rewrite** — switches from \`on: pull_request\` (which fires before CI completes and relies entirely on branch protection) to \`on: workflow_run\` gated on the CI workflow succeeding *and* all check-runs on the head SHA having passed. Matches the pattern on newsletter/contact/dicta.

## Test plan

- [x] \`go build ./...\` passes locally on go1.25.10
- [x] \`go vet ./...\` clean
- [ ] CI passes on this PR (test, vet, fmt, lint, govulncheck) — the real validation of the action-pin bumps
- [ ] Confirm the new auto-merge workflow behaves correctly on the next dependabot PR (will be visible when PR #46 or #47 next re-runs after these land)