### PR TITLE
README: fix embedding-model inconsistency in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ Persistent memory system for AI agents with hybrid semantic search, fact superse
 go install github.com/matthewjhunter/memstore/cmd/memstore@latest
 go install github.com/matthewjhunter/memstore/cmd/memstore-mcp@latest
 
-# Pull an embedding model
-ollama pull embeddinggemma
+# Pull an embedding model. Any Ollama or OpenAI-compatible embedding model
+# works (nomic-embed-text, embeddinggemma, mxbai-embed-large, etc.). The
+# chosen model and its vector dimension are locked on first use, so pick
+# one and stick with it. See "Installation" for the env vars.
+ollama pull nomic-embed-text
 
 # Set up everything: hooks, MCP registration, config
 memstore setup


### PR DESCRIPTION
## Summary

The Quick Start instructed \`ollama pull embeddinggemma\` while the Installation section and the actual code default both use \`nomic-embed-text\`. Fixed the Quick Start to match, and used the opportunity to make the framing explicit: memstore doesn't bind to any specific embedding model — the operator picks one, pulls it, and points memstore at it via \`MEMSTORE_EMBED_MODEL\`. The chosen model + dimension are locked on first use, so the choice should be made deliberately rather than treated as a throwaway default.

\`nomic-embed-text\` stays as the shipped fallback because it's small, widely-available on Ollama, and 768-dim (consistent with the dimension lock and supported by both pgvector and the SQLite vector path), but the README now makes it clear that's a default, not a recommendation.

## Test plan

- [x] README renders correctly on GitHub (markdown-only change)
- [x] Quick Start instructions are now consistent with Installation and code defaults