### PR TITLE
gitignore: exclude .trunk/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Thumbs.db
 
 # Task
 .task/
+
+# Trunk (not used by this project; locally-created artifacts stay out of git)
+.trunk/


### PR DESCRIPTION
## Summary

Add \`.trunk/\` to root \`.gitignore\`. Defensive: nothing under \`.trunk/\` has ever been tracked, but the directory is created by Trunk's CLI on local \`trunk init\` and would be eligible for an accidental \`git add -A\`. This locks in that the project doesn't use Trunk.

CI lint/format/vet are wired directly (golangci-lint v9 action, \`gofmt -l\`, \`go vet\`, govulncheck) — no dependence on Trunk for any pipeline.

## Test plan

- [x] \`.gitignore\` entry confirmed locally
- [x] No existing tracked files are affected (nothing under \`.trunk/\` was ever tracked)