### PR TITLE
memstore-mcp: --no-embeddings flag for FTS-only mode

### DIFF
--- a/cmd/memstore-mcp/main.go
+++ b/cmd/memstore-mcp/main.go
@@ -54,6 +54,7 @@ func main() {
 	ollamaURL := flag.String("ollama", cfg.Ollama, "LLM API base URL for chat generation (local mode only)")
 	llmAPIKey := flag.String("llm-api-key", cfg.LLMAPIKey, "API key for the chat LLM provider (empty = no auth)")
 	genModel := flag.String("gen-model", cfg.GenModel, "LLM model for generation")
+	noEmbeddings := flag.Bool("no-embeddings", false, "run without an embedding endpoint; search degrades to FTS5-only (local mode)")
 	hookMode := flag.Bool("hook", false, "read Stop hook JSON from stdin, POST to memstored, exit")
 	transcriptPath := flag.String("transcript", "", "read JSONL transcript from path, POST to memstored, exit")
 	flag.Parse()
@@ -99,13 +100,19 @@ func main() {
 		// Single connection for WAL mode correctness with memstore's mutex.
 		db.SetMaxOpenConns(1)
 
-		embCfg, err := embedding.ConfigFromEnvPrefix("MEMSTORE_EMBED")
-		if err != nil {
-			log.Fatalf("memstore-mcp: embedder config: %v", err)
-		}
-		embedder, err = embedding.New(embCfg)
-		if err != nil {
-			log.Fatalf("memstore-mcp: create embedder: %v", err)
+		var embedDesc string
+		if *noEmbeddings {
+			embedDesc = "disabled (FTS-only)"
+		} else {
+			embCfg, err := embedding.ConfigFromEnvPrefix("MEMSTORE_EMBED")
+			if err != nil {
+				log.Fatalf("memstore-mcp: embedder config: %v", err)
+			}
+			embedder, err = embedding.New(embCfg)
+			if err != nil {
+				log.Fatalf("memstore-mcp: create embedder: %v", err)
+			}
+			embedDesc = embCfg.Model
 		}
 
 		sqlStore, err := memstore.NewSQLiteStore(db, embedder, *namespace)
@@ -114,7 +121,7 @@ func main() {
 		}
 		store = sqlStore
 		log.Printf("memstore-mcp starting in local mode (db=%s, namespace=%s, embed=%s)",
-			*dbPath, *namespace, embCfg.Model)
+			*dbPath, *namespace, embedDesc)
 	}
 
 	srvCfg := mcpserver.Config{}

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -713,7 +713,13 @@ func (ms *MemoryServer) HandleSearch(ctx context.Context, _ *mcp.CallToolRequest
 		},
 	}
 
-	results, err := ms.store.Search(ctx, input.Query, opts)
+	var results []memstore.SearchResult
+	var err error
+	if ms.embedder == nil {
+		results, err = ms.store.SearchFTS(ctx, input.Query, opts)
+	} else {
+		results, err = ms.store.Search(ctx, input.Query, opts)
+	}
 	if err != nil {
 		return textResult(fmt.Sprintf("Error searching: %v", err), true), nil, nil
 	}

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -455,6 +455,28 @@ func TestHandleSearch_EmptyQuery(t *testing.T) {
 	}
 }
 
+func TestHandleSearch_NoEmbedder_FallsBackToFTS(t *testing.T) {
+	_, store, emb := newTestServer(t)
+	ctx := context.Background()
+
+	insertFact(t, store, emb, "Matthew prefers dark mode", "matthew", "preference")
+	insertFact(t, store, emb, "The project uses SQLite for storage", "memstore", "project")
+
+	// Server with nil embedder = `memstore-mcp --no-embeddings`.
+	srvNoEmb := mcpserver.NewMemoryServer(store, nil)
+
+	result, _, err := srvNoEmb.HandleSearch(ctx, nil, mcpserver.SearchInput{Query: "dark mode"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("expected FTS fallback to succeed, got error: %s", resultText(t, result))
+	}
+	if text := resultText(t, result); !strings.Contains(text, "dark mode") {
+		t.Errorf("expected FTS result containing 'dark mode', got: %s", text)
+	}
+}
+
 // --- memory_list tests ---
 
 func TestHandleList_Basic(t *testing.T) {


### PR DESCRIPTION
## Summary

Fresh implementation of the FTS-only mode feature against current main, replacing the closed PR #49 (which predated the May 2026 embedding refactor and could not be cleanly rebased).

Two layered changes, separate commits for clean bisect:

1. **\`mcpserver\`: degrade \`HandleSearch\` to \`SearchFTS\` when no embedder configured.** Adds the same try-embedder-else-FTS pattern already used at \`server.go:1317\` for \`HandleGetContext\`. The library-level \`store.Search\` contract is unchanged — it still errors on nil embedder. The MCP server just routes around that error when its own embedder is nil.
2. **\`cmd/memstore-mcp\`: add \`--no-embeddings\` flag.** When set, local-mode startup skips \`embedding.ConfigFromEnvPrefix\` and \`embedding.New\` entirely. Without the flag, missing or unreachable embedding config remains fatal — preserves the loud-by-default behavior. Startup log shows \`embed=disabled (FTS-only)\` so the mode is obvious in operator logs.

## How it works end-to-end

The store (\`sqlite.go:53\`), the \`FactExtractor\` (\`extract.go:177,216\`), and \`SearchFTS\` (\`search.go:334\`) already tolerate a nil embedder — the codebase was nil-aware in three places but tripped on \`HandleSearch\`. This PR closes that gap and exposes the capability to operators.

## Use case

Environments where no embedding endpoint is reachable: offline development, sandboxed CI, environments without Ollama or an OpenAI-compatible gateway. The store still works for FTS5 keyword retrieval; only vector similarity is unavailable.

## Test plan

- [x] New test: \`TestHandleSearch_NoEmbedder_FallsBackToFTS\` — constructs a server with nil embedder against a populated store and confirms FTS search succeeds
- [x] Full test suite passes (\`GOWORK=off go test -race -count=1 ./...\` — all packages green)
- [x] \`go build ./...\` and \`go vet ./...\` clean
- [ ] Manual smoke: run \`memstore-mcp --no-embeddings\` against a populated DB, confirm \`memory_search\` returns FTS results
- [ ] Manual smoke: run \`memstore-mcp\` without the flag and with no embedding env set, confirm it still fails loudly (preserved behavior)