### PR TITLE
ci: drop unusable approve step from dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -46,5 +46,10 @@ jobs:
           fi
 
           echo "All checks passed, merging PR #$PR_NUMBER"
-          gh pr review --approve "$PR_NUMBER" -R "$REPO"
+          # Cannot call `gh pr review --approve` here: GITHUB_TOKEN is not
+          # permitted to approve PRs (GraphQL: addPullRequestReview), and
+          # the shell runs with `bash -e` so a failed approve aborts the
+          # merge. Branch protection on this repo does not require an
+          # approving review, so merge directly. If review enforcement is
+          # ever added, route approve through a PAT secret instead.
           gh pr merge --squash "$PR_NUMBER" -R "$REPO"


### PR DESCRIPTION
## Problem

The dependabot auto-merge workflow was provably broken. Every dependabot PR was sitting green and unmerged — most recently #54, which I just merged manually to clear the backlog.

The workflow logs (run `25984680639` for #54) show:

```
failed to create review: GraphQL: GitHub Actions is not permitted to approve pull requests. (addPullRequestReview)
##[error]Process completed with exit code 1.
```

Root cause: `gh pr review --approve` from a workflow uses `GITHUB_TOKEN`, which is not permitted to approve PRs. The shell runs with `bash -e`, so the failed approve aborted the step before `gh pr merge --squash` ever executed.

## Fix

Drop the `gh pr review --approve` line. Branch protection on this repo does not require an approving review (`reviewDecision` is empty on PRs), so `gh pr merge --squash` succeeds directly.

A long comment now documents the constraint so future workflow iterations don't re-add the line. If review enforcement is ever added, the right path is a PAT secret — `GITHUB_TOKEN` will never work for approval.

## Note

This is the second time this exact failure has bitten this repo. It's recorded in memory (`reference_github_actions_pr_approve.md`) but didn't surface during the original auto-merge implementation (#50). The inline comment is the durable fix.

## Test plan

- [x] Diff is a no-op for the success path's merge call (only removes a step that always failed)
- [x] Comment documents the constraint clearly
- [ ] Will be validated on the next dependabot PR — if it auto-merges within ~1 min of CI completing, the fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)