### PR TITLE
docker: float golang:1.25 base to satisfy go.mod toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM golang:1.25.9-alpine AS build
+# Float the 1.25.x patch so the image always satisfies go.mod's `go` directive
+# (Alpine sets GOTOOLCHAIN=local, so a pinned patch behind go.mod fails the
+# build). Dependabot does not manage Docker here, so a pinned tag would go
+# stale on every go-directive bump.
+FROM golang:1.25-alpine AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Problem
The `Docker` workflow has been failing on `main` since the `go` directive was bumped to 1.25.10 — unrelated to any code change. The Dockerfile built from `golang:1.25.9-alpine`, but `go.mod` requires `go 1.25.10`. Alpine images set `GOTOOLCHAIN=local`, so `go mod download` refuses to fetch a newer toolchain:

```
go: go.mod requires go >= 1.25.10 (running go 1.25.9; GOTOOLCHAIN=local)
```

(The `CI` workflow — test/vet/lint/fmt/govulncheck — was unaffected and passing.)

## Fix
Float the patch: `golang:1.25-alpine`. The image then stays at or ahead of the `go` directive across future patch bumps. Dependabot manages `gomod` and `github-actions` here but **not** Docker, so a pinned tag would just re-break on each go-directive bump with nothing to update it.

Verified with a local `docker build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)