### PR TITLE
rerank: per-path document truncation budgets

### DIFF
--- a/cmd/memstore-mcp/main.go
+++ b/cmd/memstore-mcp/main.go
@@ -145,6 +145,8 @@ func main() {
 		srvCfg.RerankThreshold = pol.Threshold
 		srvCfg.RerankCandidates = pol.Candidates
 		srvCfg.RerankRecallCandidates = pol.RecallCandidates
+		srvCfg.RerankDocBytes = pol.DocBytes
+		srvCfg.RerankRecallDocBytes = pol.RecallDocBytes
 	}
 	if *remote != "" {
 		// Daemon mode: generation and feedback go through memstored.

--- a/cmd/memstored/main.go
+++ b/cmd/memstored/main.go
@@ -123,9 +123,10 @@ func run(ctx context.Context, args []string, stderr io.Writer, onListening func(
 			}
 			return "default"
 		}
-		log.Printf("reranker configured (backend=%s, model=%s, normalize=%t, mode=%s, threshold=%.3f, search-candidates=%s, recall-candidates=%s)",
+		log.Printf("reranker configured (backend=%s, model=%s, normalize=%t, mode=%s, threshold=%.3f, search-candidates=%s, recall-candidates=%s, search-doc-bytes=%s, recall-doc-bytes=%s)",
 			rcfg.Backend, rcfg.Model, rcfg.NormalizeScores, cmp.Or(string(rerankPolicy.Mode), "off"),
-			rerankPolicy.Threshold, poolLabel(rerankPolicy.Candidates), poolLabel(rerankPolicy.RecallCandidates))
+			rerankPolicy.Threshold, poolLabel(rerankPolicy.Candidates), poolLabel(rerankPolicy.RecallCandidates),
+			poolLabel(rerankPolicy.DocBytes), poolLabel(rerankPolicy.RecallDocBytes))
 		if !rcfg.NormalizeScores {
 			log.Printf("WARNING: reranker NormalizeScores is off — correct only if the backend " +
 				"already returns [0,1] scores (Cohere/Jina/TEI). A raw-logit backend such as " +

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.10
 
 require (
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/matthewjhunter/go-embedding v0.4.5
+	github.com/matthewjhunter/go-embedding v0.4.6
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/openai/openai-go v1.12.0
 	github.com/pgvector/pgvector-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/matthewjhunter/go-embedding v0.4.5 h1:ZgsSm52Dl0aDrtHWbtCHK2RymzdYsz22WTKoyJzERKQ=
 github.com/matthewjhunter/go-embedding v0.4.5/go.mod h1:h9rBrHQC+8iz9izNS7NDOumw3u+OlWReb/uvLUFnfZ8=
+github.com/matthewjhunter/go-embedding v0.4.6 h1:1EiqXDyKkNnQcBTkIkImejWvTUH4K2r2C+8XmTT0jM4=
+github.com/matthewjhunter/go-embedding v0.4.6/go.mod h1:h9rBrHQC+8iz9izNS7NDOumw3u+OlWReb/uvLUFnfZ8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=

--- a/httpapi/handler.go
+++ b/httpapi/handler.go
@@ -44,6 +44,8 @@ type Handler struct {
 	rerankThreshold float64
 	rerankPoolSize  int // search candidate pool cap; 0 = built-in default
 	recallPoolSize  int // recall candidate pool cap; 0 = built-in default
+	rerankDocBytes  int // search per-doc truncation budget; 0 = built-in default
+	recallDocBytes  int // recall per-doc truncation budget; 0 = built-in default
 }
 
 // HandlerOpt configures optional Handler fields.
@@ -82,6 +84,8 @@ func WithReranker(rr embedding.Reranker, pol memstore.RerankPolicy) HandlerOpt {
 		h.rerankThreshold = pol.Threshold
 		h.rerankPoolSize = pol.Candidates
 		h.recallPoolSize = pol.RecallCandidates
+		h.rerankDocBytes = pol.DocBytes
+		h.recallDocBytes = pol.RecallDocBytes
 	}
 }
 
@@ -466,6 +470,9 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if opts.RerankCandidates <= 0 && h.rerankPoolSize > 0 {
 		opts.RerankCandidates = h.rerankPoolSize
 	}
+	if opts.RerankDocBytes <= 0 && h.rerankDocBytes > 0 {
+		opts.RerankDocBytes = h.rerankDocBytes
+	}
 	results, err := h.store.Search(r.Context(), input.Query, opts)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -505,6 +512,7 @@ type searchRequest struct {
 	RerankThreshold  float64                   `json:"rerank_threshold"`
 	RerankCandidates int                       `json:"rerank_candidates"`
 	RerankWeight     float64                   `json:"rerank_weight"`
+	RerankDocBytes   int                       `json:"rerank_doc_bytes"`
 	OnlyActive       bool                      `json:"only_active"`
 	MetadataFilters  []memstore.MetadataFilter `json:"metadata_filters"`
 	CreatedAfter     string                    `json:"created_after"`
@@ -524,6 +532,7 @@ func (s *searchRequest) opts() memstore.SearchOpts {
 		RerankThreshold:  s.RerankThreshold,
 		RerankCandidates: s.RerankCandidates,
 		RerankWeight:     s.RerankWeight,
+		RerankDocBytes:   s.RerankDocBytes,
 		OnlyActive:       s.OnlyActive,
 		MetadataFilters:  s.MetadataFilters,
 	}

--- a/httpapi/recall.go
+++ b/httpapi/recall.go
@@ -24,6 +24,12 @@ import (
 // the result. Raise it via env where the latency budget allows.
 const recallRerankPool = 16
 
+// defaultRecallDocBytes truncates recall rerank documents hard — ~384 tokens of
+// lead content — when RERANK_RECALL_DOC_BYTES is unset. Cross-encoder latency is
+// superlinear in document length, and recall runs on every prompt under a tight
+// hook timeout, so it trades tail content for staying interactive.
+const defaultRecallDocBytes = 1500
+
 // recallRequest is the input for POST /v1/recall.
 type recallRequest struct {
 	Prompt    string `json:"prompt"`
@@ -464,7 +470,15 @@ func (h *Handler) rerankCandidates(ctx context.Context, prompt string, candidate
 		}
 	}
 
-	results, err := h.reranker.Rerank(ctx, embedding.RerankRequest{Query: prompt, Documents: docs})
+	docBytes := defaultRecallDocBytes
+	if h.recallDocBytes > 0 {
+		docBytes = h.recallDocBytes
+	}
+	results, err := h.reranker.Rerank(ctx, embedding.RerankRequest{
+		Query:            prompt,
+		Documents:        docs,
+		MaxDocumentBytes: docBytes,
+	})
 	if err != nil {
 		// Degrade rather than fail injection. A non-availability error (caller
 		// bug) is logged; an outage is silent (expected, handled).

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -577,6 +577,9 @@ func searchBody(query string, opts memstore.SearchOpts) map[string]any {
 	if opts.RerankWeight > 0 {
 		body["rerank_weight"] = opts.RerankWeight
 	}
+	if opts.RerankDocBytes > 0 {
+		body["rerank_doc_bytes"] = opts.RerankDocBytes
+	}
 	if opts.OnlyActive {
 		body["only_active"] = true
 	}

--- a/mcpserver/rerank_internal_test.go
+++ b/mcpserver/rerank_internal_test.go
@@ -20,6 +20,8 @@ func TestHandleRerankSettings_SetsAllTunables(t *testing.T) {
 		Weight:           ptrF(0.8),
 		SearchCandidates: ptrI(32),
 		RecallCandidates: ptrI(10),
+		SearchDocBytes:   ptrI(2800),
+		RecallDocBytes:   ptrI(1500),
 		TimeoutSeconds:   ptrF(4),
 	})
 	if err != nil {
@@ -30,7 +32,8 @@ func TestHandleRerankSettings_SetsAllTunables(t *testing.T) {
 	}
 	got := ms.tunables()
 	if got.mode != memstore.RerankDominant || got.threshold != 0.25 || got.weight != 0.8 ||
-		got.searchCandidates != 32 || got.recallCandidates != 10 || got.timeout != 4*time.Second {
+		got.searchCandidates != 32 || got.recallCandidates != 10 ||
+		got.searchDocBytes != 2800 || got.recallDocBytes != 1500 || got.timeout != 4*time.Second {
 		t.Errorf("tunables not all applied: %+v", got)
 	}
 
@@ -69,7 +72,7 @@ func TestHandleRerankSettings_ReportsCurrent(t *testing.T) {
 		t.Fatal("no-arg get should not error")
 	}
 	report := ms.tunablesReport()
-	for _, want := range []string{"mode=off", "search_candidates=default", "recall_candidates=default", "timeout=none"} {
+	for _, want := range []string{"mode=off", "search_candidates=default", "recall_candidates=default", "search_doc_bytes=default", "recall_doc_bytes=default", "timeout=none"} {
 		if !strings.Contains(report, want) {
 			t.Errorf("report %q missing %q", report, want)
 		}

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -61,6 +61,11 @@ type Config struct {
 	// per session via memory_rerank_settings.
 	RerankCandidates       int
 	RerankRecallCandidates int
+	// RerankDocBytes and RerankRecallDocBytes seed the per-document truncation
+	// budgets for memory_search and memory_get_context (0 = the store's default).
+	// Runtime-tunable via memory_rerank_settings.
+	RerankDocBytes       int
+	RerankRecallDocBytes int
 }
 
 // MemoryServer bridges MCP tool calls to a memstore.Store.
@@ -83,6 +88,8 @@ type MemoryServer struct {
 	rerankWeight     float64       // balanced-fusion weight; 0 = engine default
 	searchCandidates int           // memory_search pool; 0 = store default
 	recallCandidates int           // memory_get_context pool; 0 = store default
+	searchDocBytes   int           // memory_search per-doc truncation; 0 = store default
+	recallDocBytes   int           // memory_get_context per-doc truncation; 0 = store default
 	rerankTimeout    time.Duration // deadline on search/get_context; 0 = none
 }
 
@@ -93,6 +100,8 @@ type rerankTunables struct {
 	weight           float64
 	searchCandidates int
 	recallCandidates int
+	searchDocBytes   int
+	recallDocBytes   int
 	timeout          time.Duration
 }
 
@@ -119,6 +128,7 @@ func NewMemoryServerWithConfig(store memstore.Store, embedder embedding.Embedder
 		curator: curator, generator: cfg.Generator, sessionStore: cfg.SessionStore,
 		rerankMode: cfg.RerankMode, rerankThreshold: cfg.RerankThreshold,
 		searchCandidates: cfg.RerankCandidates, recallCandidates: cfg.RerankRecallCandidates,
+		searchDocBytes: cfg.RerankDocBytes, recallDocBytes: cfg.RerankRecallDocBytes,
 	}
 }
 
@@ -139,6 +149,8 @@ func (ms *MemoryServer) tunables() rerankTunables {
 		weight:           ms.rerankWeight,
 		searchCandidates: ms.searchCandidates,
 		recallCandidates: ms.recallCandidates,
+		searchDocBytes:   ms.searchDocBytes,
+		recallDocBytes:   ms.recallDocBytes,
 		timeout:          ms.rerankTimeout,
 	}
 }
@@ -258,6 +270,8 @@ type RerankSettingsInput struct {
 	Weight           *float64 `json:"weight,omitempty" jsonschema:"balanced-fusion weight 0-1: rerank's share vs the first-stage score (0 resets to the engine default; omit to leave unchanged)"`
 	SearchCandidates *int     `json:"search_candidates,omitempty" jsonschema:"how many first-stage candidates memory_search reranks per pass; more = better recall, slower (0 resets to default; omit to leave unchanged)"`
 	RecallCandidates *int     `json:"recall_candidates,omitempty" jsonschema:"how many candidates memory_get_context reranks per pass (0 resets to default; omit to leave unchanged)"`
+	SearchDocBytes   *int     `json:"search_doc_bytes,omitempty" jsonschema:"truncate each memory_search rerank document to this many bytes; rerank cost is superlinear in length, so this is the strongest latency lever (0 resets to default; omit to leave unchanged)"`
+	RecallDocBytes   *int     `json:"recall_doc_bytes,omitempty" jsonschema:"same, for memory_get_context; keep it small for a tight injection budget (0 resets to default; omit to leave unchanged)"`
 	TimeoutSeconds   *float64 `json:"timeout_seconds,omitempty" jsonschema:"max seconds to wait for rerank before degrading to first-stage order (0 disables the deadline; omit to leave unchanged)"`
 }
 
@@ -419,6 +433,8 @@ Results show a rerank=N.NNN score (0-1) when reranking is active — use it to j
 - weight: 0-1; in balanced mode, rerank's share vs the first-stage score. Higher trusts the cross-encoder more. 0 resets to the engine default.
 - search_candidates: how many first-stage candidates memory_search reranks. More improves recall but each is a CPU pass, so it costs latency. 0 resets to the default.
 - recall_candidates: same, for memory_get_context. Keep it smaller than search if you call get_context on a tight budget.
+- search_doc_bytes: truncate each search document to this many bytes before scoring. Rerank cost is superlinear in document length, so this is the strongest latency lever — lower it if search feels slow, raise it if long facts are mis-ranked on their lead content alone.
+- recall_doc_bytes: same, for memory_get_context. Usually smaller than search.
 - timeout_seconds: cap on how long to wait for rerank; on timeout the result degrades to first-stage order rather than blocking. 0 disables the cap.
 
 Omit a field to leave it unchanged. Watch the rerank=N.NNN scores in memory_search output to calibrate threshold and weight.`,
@@ -833,6 +849,7 @@ func (ms *MemoryServer) HandleSearch(ctx context.Context, _ *mcp.CallToolRequest
 		RerankThreshold:  threshold,
 		RerankCandidates: tun.searchCandidates,
 		RerankWeight:     tun.weight,
+		RerankDocBytes:   tun.searchDocBytes,
 		// Stable facts (preference, identity) don't decay.
 		// Ephemeral notes get 30-day half-life.
 		CategoryDecay: map[string]time.Duration{
@@ -931,6 +948,12 @@ func (ms *MemoryServer) HandleRerankSettings(_ context.Context, _ *mcp.CallToolR
 	if input.RecallCandidates != nil && *input.RecallCandidates < 0 {
 		return textResult("Error: recall_candidates must be >= 0", true), nil, nil
 	}
+	if input.SearchDocBytes != nil && *input.SearchDocBytes < 0 {
+		return textResult("Error: search_doc_bytes must be >= 0", true), nil, nil
+	}
+	if input.RecallDocBytes != nil && *input.RecallDocBytes < 0 {
+		return textResult("Error: recall_doc_bytes must be >= 0", true), nil, nil
+	}
 	if input.TimeoutSeconds != nil && *input.TimeoutSeconds < 0 {
 		return textResult("Error: timeout_seconds must be >= 0", true), nil, nil
 	}
@@ -950,6 +973,12 @@ func (ms *MemoryServer) HandleRerankSettings(_ context.Context, _ *mcp.CallToolR
 	}
 	if input.RecallCandidates != nil {
 		ms.recallCandidates = *input.RecallCandidates
+	}
+	if input.SearchDocBytes != nil {
+		ms.searchDocBytes = *input.SearchDocBytes
+	}
+	if input.RecallDocBytes != nil {
+		ms.recallDocBytes = *input.RecallDocBytes
 	}
 	if input.TimeoutSeconds != nil {
 		ms.rerankTimeout = time.Duration(*input.TimeoutSeconds * float64(time.Second))
@@ -981,8 +1010,9 @@ func (ms *MemoryServer) tunablesReport() string {
 	if t.timeout > 0 {
 		timeoutStr = t.timeout.String()
 	}
-	return fmt.Sprintf("Rerank tunables: mode=%s threshold=%.3f weight=%s search_candidates=%s recall_candidates=%s timeout=%s",
-		modeStr, t.threshold, weightStr, pool(t.searchCandidates), pool(t.recallCandidates), timeoutStr)
+	return fmt.Sprintf("Rerank tunables: mode=%s threshold=%.3f weight=%s search_candidates=%s recall_candidates=%s search_doc_bytes=%s recall_doc_bytes=%s timeout=%s",
+		modeStr, t.threshold, weightStr, pool(t.searchCandidates), pool(t.recallCandidates),
+		pool(t.searchDocBytes), pool(t.recallDocBytes), timeoutStr)
 }
 
 func (ms *MemoryServer) HandleList(ctx context.Context, _ *mcp.CallToolRequest, input ListInput) (*mcp.CallToolResult, any, error) {
@@ -1549,6 +1579,7 @@ func (ms *MemoryServer) HandleGetContext(ctx context.Context, _ *mcp.CallToolReq
 		RerankThreshold:  threshold,
 		RerankCandidates: tun.recallCandidates,
 		RerankWeight:     tun.weight,
+		RerankDocBytes:   tun.recallDocBytes,
 	}
 	if tun.timeout > 0 {
 		var cancel context.CancelFunc

--- a/rerank.go
+++ b/rerank.go
@@ -23,15 +23,17 @@ type RerankPolicy struct {
 	Threshold        float64
 	Candidates       int // search candidate pool
 	RecallCandidates int // recall (per-prompt injection) candidate pool
+	DocBytes         int // search per-document truncation budget (bytes)
+	RecallDocBytes   int // recall per-document truncation budget (bytes)
 }
 
-// RerankPolicyFromEnv reads the rerank policy from the {prefix}_MODE /
-// {prefix}_THRESHOLD / {prefix}_CANDIDATES / {prefix}_RECALL_CANDIDATES env
-// vars, cascading to the bare RERANK_* names. These are memstore search policy
-// (how rerank scores are fused, filtered, and how big each candidate pass is),
-// distinct from go-embedding's RerankConfig (which backend to call). Unset
-// values yield zero (use built-in defaults). A malformed mode, an out-of-[0,1]
-// threshold, or a non-positive candidate count is an error.
+// RerankPolicyFromEnv reads the rerank policy from {prefix}_MODE / _THRESHOLD /
+// _CANDIDATES / _RECALL_CANDIDATES / _DOC_BYTES / _RECALL_DOC_BYTES, cascading to
+// the bare RERANK_* names. These are memstore search policy (how rerank scores
+// are fused and filtered, and how big/long each candidate pass is), distinct
+// from go-embedding's RerankConfig (which backend to call). Unset values yield
+// zero (use built-in defaults). A malformed mode, an out-of-[0,1] threshold, or
+// a non-positive candidate/byte count is an error.
 func RerankPolicyFromEnv(prefix string) (RerankPolicy, error) {
 	get := func(suffix string) string {
 		if v := os.Getenv(prefix + suffix); v != "" {
@@ -80,6 +82,12 @@ func RerankPolicyFromEnv(prefix string) (RerankPolicy, error) {
 		return RerankPolicy{}, err
 	}
 	if pol.RecallCandidates, err = parsePool("_RECALL_CANDIDATES", "recall candidates"); err != nil {
+		return RerankPolicy{}, err
+	}
+	if pol.DocBytes, err = parsePool("_DOC_BYTES", "doc bytes"); err != nil {
+		return RerankPolicy{}, err
+	}
+	if pol.RecallDocBytes, err = parsePool("_RECALL_DOC_BYTES", "recall doc bytes"); err != nil {
 		return RerankPolicy{}, err
 	}
 	return pol, nil

--- a/score.go
+++ b/score.go
@@ -23,6 +23,13 @@ const (
 	// DefaultRerankWeight is rerank's fusion share used in RerankBalanced when
 	// SearchOpts.RerankWeight is unset.
 	DefaultRerankWeight = 0.7
+	// DefaultRerankDocBytes is the per-document truncation budget for the search
+	// path when SearchOpts.RerankDocBytes is unset. Rerank cost is superlinear in
+	// document length, so search caps each candidate at ~700 tokens of lead
+	// content (a fact's subject and decision usually sit up front) to keep a
+	// 40-candidate pass within a few seconds on CPU. The recall path sets its own
+	// tighter budget for its per-prompt latency target.
+	DefaultRerankDocBytes = 2800
 	// rerankTieBreak scales the first-stage score into RerankDominant's rank key
 	// so it only separates equal rerank scores, never overturns them.
 	rerankTieBreak = 1e-6
@@ -148,7 +155,15 @@ func fuseRerank(ctx context.Context, rr embedding.Reranker, query string, merged
 		docs[i] = merged[i].Fact.Content
 	}
 
-	results, err := rr.Rerank(ctx, embedding.RerankRequest{Query: query, Documents: docs})
+	docBytes := opts.RerankDocBytes
+	if docBytes <= 0 {
+		docBytes = DefaultRerankDocBytes
+	}
+	results, err := rr.Rerank(ctx, embedding.RerankRequest{
+		Query:            query,
+		Documents:        docs,
+		MaxDocumentBytes: docBytes,
+	})
 	if err != nil {
 		if !embedding.IsRerankAvailable(err) {
 			return merged, nil // degrade: first-stage order, no threshold filtering

--- a/score_test.go
+++ b/score_test.go
@@ -254,12 +254,15 @@ func TestRerankPolicyFromEnv(t *testing.T) {
 	t.Setenv("MEMSTORE_RERANK_THRESHOLD", "0.3")
 	t.Setenv("MEMSTORE_RERANK_CANDIDATES", "24")
 	t.Setenv("MEMSTORE_RERANK_RECALL_CANDIDATES", "12")
+	t.Setenv("MEMSTORE_RERANK_DOC_BYTES", "2800")
+	t.Setenv("MEMSTORE_RERANK_RECALL_DOC_BYTES", "1500")
 	pol, err := RerankPolicyFromEnv("MEMSTORE_RERANK")
 	if err != nil {
 		t.Fatalf("RerankPolicyFromEnv: %v", err)
 	}
-	if pol.Mode != RerankDominant || pol.Threshold != 0.3 || pol.Candidates != 24 || pol.RecallCandidates != 12 {
-		t.Errorf("got %+v, want {dominant 0.3 24 12}", pol)
+	if pol.Mode != RerankDominant || pol.Threshold != 0.3 || pol.Candidates != 24 ||
+		pol.RecallCandidates != 12 || pol.DocBytes != 2800 || pol.RecallDocBytes != 1500 {
+		t.Errorf("got %+v, want {dominant 0.3 24 12 2800 1500}", pol)
 	}
 
 	// Cascade to the bare RERANK_* names when the prefix is unset.

--- a/store.go
+++ b/store.go
@@ -124,6 +124,12 @@ type SearchOpts struct {
 	// in [0,1]: Combined = RerankWeight*rerankScore + (1-RerankWeight)*firstStage.
 	// 0 uses the default (0.7). Ignored by RerankDominant and RerankGate.
 	RerankWeight float64
+	// RerankDocBytes, when > 0, truncates each candidate document to this many
+	// bytes before the cross-encoder scores it (passed through as the reranker's
+	// MaxDocumentBytes). Rerank latency is superlinear in document length, so
+	// this is the per-call latency lever; 0 falls back to the reranker model's
+	// registered budget. Truncation ranks on each document's lead content.
+	RerankDocBytes int
 	// RerankThreshold, when > 0, drops any reranked fact whose normalized [0,1]
 	// rerank score is below it — the "don't surface wrong context" filter. It
 	// applies in every rerank mode and only when rerank actually ran (a degraded


### PR DESCRIPTION
Follow-up to #67. Deploying the reranker exposed that **document length, not pool size, is the dominant rerank latency factor**: reranking 12 full-length facts (~1500–2000 tokens) takes ~66s on CPU vs ~1s for 12 short docs (cross-encoder cost is superlinear in sequence length). With the prior 18000-byte truncation budget, normal long facts sailed through and recall blew its ~3s per-prompt hook budget (measured 14–34s → empty injection).

## Changes
- **go-embedding v0.4.6**: `RerankRequest.MaxDocumentBytes` per-call truncation override (already tagged/pushed).
- **Per-path budgets**: search caps documents at ~700 tokens (`DefaultRerankDocBytes` 2800B); recall harder at ~384 tokens (`defaultRecallDocBytes` 1500B), since it runs on every prompt. Wired via `RerankPolicy` (`RERANK_DOC_BYTES` / `RERANK_RECALL_DOC_BYTES`, cascading) and `SearchOpts.RerankDocBytes` through the HTTP path.
- **Runtime tunable**: `memory_rerank_settings` gains `search_doc_bytes` and `recall_doc_bytes` so the model tunes the latency/relevance trade live.

Documents are ranked on their lead content (subject/decision are usually front-loaded); signal in long tails is dropped — the design doc's intended short-chunk trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)