### PR TITLE
build: bump Go to 1.25.11 (crypto/x509 stdlib security fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matthewjhunter/memstore
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/jackc/pgx/v5 v5.9.2


### PR DESCRIPTION
Bumps the effective Go toolchain to **1.25.11**, which patches the disclosed `crypto/x509` hostname-parsing advisory (GO-2026-5037) and related stdlib fixes that `govulncheck` flags on 1.25.x < .11. Effective version change only — no language-version bump.

Part of a fleet-wide remediation sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)