### PR TITLE
ci: allow parallel golangci-lint runners

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,6 @@ linters:
     - staticcheck
     - unused
     - ineffassign
+
+run:
+  allow-parallel-runners: true


### PR DESCRIPTION
Adds `run.allow-parallel-runners: true`. With multiple self-hosted runners per CI host, concurrent `golangci-lint` jobs trip its single-instance lock (`parallel golangci-lint is running`). Caches are per-runner-home, so parallel runs are safe.

Part of the runner-scaling follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)