### PR TITLE
httpapi: cap request body size at 64MB

### DIFF
--- a/httpapi/handler.go
+++ b/httpapi/handler.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -46,6 +47,8 @@ type Handler struct {
 	recallPoolSize  int // recall candidate pool cap; 0 = built-in default
 	rerankDocBytes  int // search per-doc truncation budget; 0 = built-in default
 	recallDocBytes  int // recall per-doc truncation budget; 0 = built-in default
+
+	maxBodyBytes int64 // cap applied to every request body; default 64 MB
 }
 
 // HandlerOpt configures optional Handler fields.
@@ -96,14 +99,20 @@ func WithTokenVerifier(v TokenVerifier) HandlerOpt {
 	return func(h *Handler) { h.tokens = v }
 }
 
+// WithMaxBodyBytes caps the request body size accepted by any endpoint.
+func WithMaxBodyBytes(n int64) HandlerOpt {
+	return func(h *Handler) { h.maxBodyBytes = n }
+}
+
 // New creates an API handler backed by the given store.
 // If apiKey is non-empty, requests must include Authorization: Bearer <key>.
 func New(store memstore.Store, embedder embedding.Embedder, apiKey string, opts ...HandlerOpt) *Handler {
 	h := &Handler{
-		store:    store,
-		embedder: embedder,
-		apiKey:   apiKey,
-		mux:      http.NewServeMux(),
+		store:        store,
+		embedder:     embedder,
+		apiKey:       apiKey,
+		mux:          http.NewServeMux(),
+		maxBodyBytes: 64 << 20,
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -148,6 +157,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r = r.WithContext(WithIdentity(r.Context(), Identity{Name: "legacy", Source: "legacy"}))
 	}
 
+	if r.Body != nil {
+		r.Body = http.MaxBytesReader(w, r.Body, h.maxBodyBytes)
+	}
 	h.mux.ServeHTTP(w, r)
 }
 
@@ -666,6 +678,11 @@ func (h *Handler) handleDeleteLink(w http.ResponseWriter, r *http.Request) {
 
 func readJSON(r *http.Request, w http.ResponseWriter, v any) bool {
 	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return false
+		}
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return false
 	}

--- a/httpapi/handler_test.go
+++ b/httpapi/handler_test.go
@@ -418,3 +418,53 @@ func TestHealth_NoAuth(t *testing.T) {
 func itoa(id int64) string {
 	return fmt.Sprintf("%d", id)
 }
+
+// newTestHandlerWith builds a Handler like newTestHandler but accepts extra
+// HandlerOpts so individual tests can override defaults (e.g. body cap).
+func newTestHandlerWith(t *testing.T, opts ...httpapi.HandlerOpt) *httpapi.Handler {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	embedder := &mockEmbedder{dim: 4}
+	store, err := memstore.NewSQLiteStore(db, embedder, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return httpapi.New(store, embedder, "", opts...)
+}
+
+func TestBodyLimit_OversizedRequestRejected(t *testing.T) {
+	h := newTestHandlerWith(t, httpapi.WithMaxBodyBytes(1024))
+
+	// Build a JSON body that exceeds 1024 bytes.
+	big := map[string]any{
+		"content":  string(bytes.Repeat([]byte("x"), 2000)),
+		"subject":  "test",
+		"category": "note",
+	}
+	b, _ := json.Marshal(big)
+	req := httptest.NewRequest("POST", "/v1/facts", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", w.Result().StatusCode)
+	}
+}
+
+func TestBodyLimit_NormalRequestPasses(t *testing.T) {
+	h := newTestHandlerWith(t, httpapi.WithMaxBodyBytes(1024))
+
+	resp := doJSON(t, h, "POST", "/v1/facts", map[string]any{
+		"content":  "small fact",
+		"subject":  "test",
+		"category": "note",
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
No endpoint bounded the request body, so any token holder could stream an arbitrarily large JSON body and OOM the daemon. This wraps r.Body in http.MaxBytesReader at the ServeHTTP chokepoint (after auth), covering every route at once. The cap trips as 413 instead of 400, and WithMaxBodyBytes makes it configurable. Default is 64MB to clear large session transcripts on /v1/sessions/transcript.

Two new tests cover the rejection and pass-through paths.

Plan: plans/002-http-body-size-limits.md (improve-skill audit, 2026-06-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)