### PR TITLE
pgstore: error on invalid metadata filters to match sqlite

### DIFF
--- a/pgstore/search.go
+++ b/pgstore/search.go
@@ -150,7 +150,9 @@ func (s *PostgresStore) searchFTS(ctx context.Context, query string, opts memsto
 	if opts.Subsystem != "" {
 		b.write(` AND f.subsystem = `, opts.Subsystem)
 	}
-	appendMetadataFilters(&b, "f.", opts.MetadataFilters)
+	if err := appendMetadataFilters(&b, "f.", opts.MetadataFilters); err != nil {
+		return nil, err
+	}
 	appendTemporalFilters(&b, "f.", opts.CreatedAfter, opts.CreatedBefore)
 
 	b.write(` ORDER BY rank DESC LIMIT `, memstore.FetchLimit(opts))
@@ -230,7 +232,9 @@ func (s *PostgresStore) searchVector(ctx context.Context, queryEmb []float32, op
 	if opts.Subsystem != "" {
 		b.write(` AND subsystem = `, opts.Subsystem)
 	}
-	appendMetadataFilters(&b, "", opts.MetadataFilters)
+	if err := appendMetadataFilters(&b, "", opts.MetadataFilters); err != nil {
+		return nil, err
+	}
 	appendTemporalFilters(&b, "", opts.CreatedAfter, opts.CreatedBefore)
 
 	b.write(` ORDER BY embedding <=> `, qv)

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -481,7 +481,9 @@ func (s *PostgresStore) List(ctx context.Context, opts memstore.QueryOpts) ([]me
 		b.write(` AND id = ANY(`, opts.IDs)
 		b.q += `::bigint[])`
 	}
-	appendMetadataFilters(&b, "", opts.MetadataFilters)
+	if err := appendMetadataFilters(&b, "", opts.MetadataFilters); err != nil {
+		return nil, err
+	}
 	appendTemporalFilters(&b, "", opts.CreatedAfter, opts.CreatedBefore)
 
 	b.q += ` ORDER BY id`
@@ -1140,21 +1142,27 @@ var validMetadataOps = map[string]bool{
 	">": true, ">=": true,
 }
 
-// appendMetadataFilters adds jsonb-based WHERE clauses using the ->> operator.
-func appendMetadataFilters(b *queryBuilder, alias string, filters []memstore.MetadataFilter) {
+// appendMetadataFilters adds jsonb-based WHERE clauses for each metadata
+// filter. Returns an error for invalid keys or operators, matching the
+// SQLite backend's behavior.
+func appendMetadataFilters(b *queryBuilder, alias string, filters []memstore.MetadataFilter) error {
 	for _, mf := range filters {
-		if !validMetadataKey(mf.Key) || !validMetadataOps[mf.Op] {
-			continue // silently skip invalid filters to match SQLite behavior
+		if !validMetadataKey(mf.Key) {
+			return fmt.Errorf("pgstore: invalid metadata filter key: %q", mf.Key)
 		}
-		extract := fmt.Sprintf("%smetadata->>'%s'", alias, mf.Key)
+		if !validMetadataOps[mf.Op] {
+			return fmt.Errorf("pgstore: invalid metadata filter operator: %q", mf.Op)
+		}
+		b.args = append(b.args, mf.Key)
+		extract := fmt.Sprintf("jsonb_extract_path_text(%smetadata, $%d)", alias, len(b.args))
+		b.args = append(b.args, mf.Value)
 		if mf.IncludeNull {
-			b.args = append(b.args, mf.Value)
 			b.q += fmt.Sprintf(` AND (%s IS NULL OR %s %s $%d)`, extract, extract, mf.Op, len(b.args))
 		} else {
-			b.args = append(b.args, mf.Value)
 			b.q += fmt.Sprintf(` AND %s %s $%d`, extract, mf.Op, len(b.args))
 		}
 	}
+	return nil
 }
 
 func appendTemporalFilters(b *queryBuilder, alias string, after, before *time.Time) {

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -384,6 +384,65 @@ func TestList_OnlyActive(t *testing.T) {
 	}
 }
 
+func TestList_InvalidMetadataFilterErrors(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	store.Insert(ctx, memstore.Fact{
+		Content: "alpha fact", Subject: "test", Category: "note",
+		Metadata: json.RawMessage(`{"tier":"gold"}`),
+	})
+	store.Insert(ctx, memstore.Fact{
+		Content: "beta fact", Subject: "test", Category: "note",
+		Metadata: json.RawMessage(`{"tier":"silver"}`),
+	})
+
+	// Invalid key must error, not silently drop the filter.
+	_, err := store.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "bad-key!", Op: "=", Value: "x"}},
+	})
+	if err == nil {
+		t.Fatal("List with invalid metadata key: expected error, got nil")
+	}
+
+	// Invalid operator must error too.
+	_, err = store.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "tier", Op: "LIKE", Value: "x"}},
+	})
+	if err == nil {
+		t.Fatal("List with invalid metadata operator: expected error, got nil")
+	}
+
+	// SearchFTS must reject the same invalid filters.
+	_, err = store.SearchFTS(ctx, "alpha", memstore.SearchOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "bad-key!", Op: "=", Value: "x"}},
+	})
+	if err == nil {
+		t.Fatal("SearchFTS with invalid metadata key: expected error, got nil")
+	}
+	_, err = store.SearchFTS(ctx, "alpha", memstore.SearchOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "tier", Op: "LIKE", Value: "x"}},
+	})
+	if err == nil {
+		t.Fatal("SearchFTS with invalid metadata operator: expected error, got nil")
+	}
+
+	// A valid filter still works -- this also proves jsonb_extract_path_text
+	// is equivalent to the ->> operator for top-level keys.
+	facts, err := store.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "tier", Op: "=", Value: "gold"}},
+	})
+	if err != nil {
+		t.Fatalf("List with valid metadata filter: %v", err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("valid filter: expected 1 fact, got %d", len(facts))
+	}
+	if facts[0].Content != "alpha fact" {
+		t.Fatalf("valid filter: expected alpha fact, got %q", facts[0].Content)
+	}
+}
+
 func TestBySubject(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -1021,6 +1021,46 @@ func TestList_MetadataFilterIncludeNull(t *testing.T) {
 	}
 }
 
+func TestList_InvalidMetadataFilterErrors(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	store.Insert(ctx, memstore.Fact{
+		Content: "A", Subject: "X", Category: "test",
+		Metadata: json.RawMessage(`{"tier":"gold"}`),
+	})
+
+	// Invalid key must error, not silently drop the filter.
+	_, err := store.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "bad-key!", Op: "=", Value: "x"}},
+	})
+	if err == nil {
+		t.Fatal("List with invalid metadata key: expected error, got nil")
+	}
+
+	// Invalid operator must error too.
+	_, err = store.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "tier", Op: "LIKE", Value: "x"}},
+	})
+	if err == nil {
+		t.Fatal("List with invalid metadata operator: expected error, got nil")
+	}
+
+	// SearchFTS must reject the same invalid filters.
+	_, err = store.SearchFTS(ctx, "A", memstore.SearchOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "bad-key!", Op: "=", Value: "x"}},
+	})
+	if err == nil {
+		t.Fatal("SearchFTS with invalid metadata key: expected error, got nil")
+	}
+	_, err = store.SearchFTS(ctx, "A", memstore.SearchOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "tier", Op: "LIKE", Value: "x"}},
+	})
+	if err == nil {
+		t.Fatal("SearchFTS with invalid metadata operator: expected error, got nil")
+	}
+}
+
 func TestList_TemporalFilter(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
The two backends disagreed about invalid metadata filters: SQLite errors, pgstore silently dropped the filter and returned the unfiltered superset -- with a comment claiming the silent skip matched SQLite. pgstore now validates and errors with the same semantics. The jsonb key extraction also moves from string interpolation to a bound parameter via jsonb_extract_path_text as defense in depth (the key was already allowlisted to [a-zA-Z0-9_]).

New invalid-filter tests on both backends; the pgstore side was verified against a real pgvector container during review, including the jsonb_extract_path_text equivalence with ->> for valid filters.

Plan: plans/003-metadata-filter-parity.md (improve-skill audit, 2026-06-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)