### PR TITLE
sqlite: release store lock during embedding network calls

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -896,6 +896,19 @@ func (s *SQLiteStore) MarkEmbedFailed(ctx context.Context, id int64, reason stri
 
 // EmbedFacts generates embeddings for all facts that don't have one yet,
 // processing in batches for efficiency. Uses the store's configured embedder.
+//
+// Lock discipline: three windows, not one.
+//  1. Read phase  -- RLock: SELECT the pending-fact IDs and contents.
+//  2. Embed phase -- no lock: call the embedding API (network I/O).
+//  3. Write phase -- Lock (per batch): recordEmbedder + UPDATE transaction.
+//
+// This matches the discipline in Search (see search.go:35-36) and prevents the
+// embed phase from blocking every reader and writer for the duration of N
+// network round-trips.
+//
+// TOCTOU note: facts deleted between the read and write phases produce no-op
+// UPDATEs (zero rows affected, not an error). Facts inserted after the read
+// phase are picked up by the next EmbedFacts call.
 func (s *SQLiteStore) EmbedFacts(ctx context.Context, batchSize int) (int, error) {
 	if s.embedder == nil {
 		return 0, fmt.Errorf("memstore: no embedder configured")
@@ -904,33 +917,39 @@ func (s *SQLiteStore) EmbedFacts(ctx context.Context, batchSize int) (int, error
 		batchSize = 50
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, content FROM memstore_facts WHERE embedding IS NULL AND namespace = ? ORDER BY id`,
-		s.namespace)
-	if err != nil {
-		return 0, fmt.Errorf("memstore: querying unembedded facts: %w", err)
-	}
-
+	// Phase 1: read phase -- hold only the read lock while querying.
 	type idContent struct {
 		id      int64
 		content string
 	}
 	var pending []idContent
 
-	for rows.Next() {
-		var ic idContent
-		if err := rows.Scan(&ic.id, &ic.content); err != nil {
-			rows.Close()
-			return 0, fmt.Errorf("memstore: scanning fact: %w", err)
+	if err := func() error {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+
+		rows, err := s.db.QueryContext(ctx,
+			`SELECT id, content FROM memstore_facts WHERE embedding IS NULL AND namespace = ? ORDER BY id`,
+			s.namespace)
+		if err != nil {
+			return fmt.Errorf("memstore: querying unembedded facts: %w", err)
 		}
-		pending = append(pending, ic)
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return 0, fmt.Errorf("memstore: iterating facts: %w", err)
+
+		for rows.Next() {
+			var ic idContent
+			if err := rows.Scan(&ic.id, &ic.content); err != nil {
+				rows.Close()
+				return fmt.Errorf("memstore: scanning fact: %w", err)
+			}
+			pending = append(pending, ic)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("memstore: iterating facts: %w", err)
+		}
+		return nil
+	}(); err != nil {
+		return 0, err
 	}
 
 	if len(pending) == 0 {
@@ -947,6 +966,7 @@ func (s *SQLiteStore) EmbedFacts(ctx context.Context, batchSize int) (int, error
 			texts[j] = ic.content
 		}
 
+		// Phase 2: embed phase -- no lock held during network I/O.
 		embeddings, err := embedding.EmbedWithRetry(ctx, s.embedder, texts)
 		if err != nil {
 			return total, err
@@ -956,38 +976,49 @@ func (s *SQLiteStore) EmbedFacts(ctx context.Context, batchSize int) (int, error
 			return total, fmt.Errorf("memstore: embedding count mismatch: got %d, want %d", len(embeddings), len(batch))
 		}
 
-		// Record model+dim on first embedding operation.
-		if total == 0 && i == 0 && len(embeddings[0]) > 0 {
-			if err := s.recordEmbedder(len(embeddings[0])); err != nil {
-				return 0, err
+		// Phase 3: write phase -- take the write lock for DB writes, scoped to
+		// this batch via a closure so defer always fires before the next embed.
+		batchTotal, err := func() (int, error) {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+
+			// Record model+dim on first embedding operation.
+			if total == 0 && i == 0 && len(embeddings[0]) > 0 {
+				if err := s.recordEmbedder(len(embeddings[0])); err != nil {
+					return 0, err
+				}
 			}
-		}
 
-		tx, err := s.db.BeginTx(ctx, nil)
-		if err != nil {
-			return total, fmt.Errorf("memstore: beginning tx: %w", err)
-		}
+			tx, err := s.db.BeginTx(ctx, nil)
+			if err != nil {
+				return 0, fmt.Errorf("memstore: beginning tx: %w", err)
+			}
 
-		stmt, err := tx.Prepare(`UPDATE memstore_facts SET embedding = ? WHERE id = ?`)
-		if err != nil {
-			tx.Rollback()
-			return total, fmt.Errorf("memstore: preparing update: %w", err)
-		}
-
-		for j, emb := range embeddings {
-			if _, err := stmt.Exec(embedding.EncodeFloat32s(emb), batch[j].id); err != nil {
-				stmt.Close()
+			stmt, err := tx.Prepare(`UPDATE memstore_facts SET embedding = ? WHERE id = ?`)
+			if err != nil {
 				tx.Rollback()
-				return total, fmt.Errorf("memstore: updating fact %d: %w", batch[j].id, err)
+				return 0, fmt.Errorf("memstore: preparing update: %w", err)
 			}
-		}
 
-		stmt.Close()
-		if err := tx.Commit(); err != nil {
-			return total, fmt.Errorf("memstore: committing batch: %w", err)
-		}
+			for j, emb := range embeddings {
+				if _, err := stmt.Exec(embedding.EncodeFloat32s(emb), batch[j].id); err != nil {
+					stmt.Close()
+					tx.Rollback()
+					return 0, fmt.Errorf("memstore: updating fact %d: %w", batch[j].id, err)
+				}
+			}
 
-		total += len(batch)
+			stmt.Close()
+			if err := tx.Commit(); err != nil {
+				return 0, fmt.Errorf("memstore: committing batch: %w", err)
+			}
+
+			return len(batch), nil
+		}()
+		if err != nil {
+			return total, err
+		}
+		total += batchTotal
 	}
 
 	return total, nil

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -567,6 +568,91 @@ func TestEmbedFacts_NoEmbedder(t *testing.T) {
 	if err == nil {
 		t.Error("expected error when no embedder configured")
 	}
+}
+
+// slowEmbedder sleeps per call so the embed phase genuinely overlaps with
+// concurrent writers, making lock-scope bugs detectable by the race detector.
+type slowEmbedder struct {
+	inner *mockEmbedder
+	delay time.Duration
+}
+
+func (s *slowEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	time.Sleep(s.delay)
+	return s.inner.Embed(ctx, texts)
+}
+
+func (s *slowEmbedder) Model() string { return s.inner.Model() }
+
+func (s *slowEmbedder) Fingerprint() embedding.Fingerprint { return s.inner.Fingerprint() }
+
+// TestEmbedFacts_ConcurrentWithInsert verifies that EmbedFacts releases the
+// store lock during the embedding network call so concurrent Insert and
+// SearchFTS calls are not blocked. The assertion is deadlock-free completion
+// and a clean -race run; no timing assertions are made.
+func TestEmbedFacts_ConcurrentWithInsert(t *testing.T) {
+	embedder := &slowEmbedder{
+		inner: &mockEmbedder{dim: 4},
+		delay: 10 * time.Millisecond,
+	}
+
+	// Use SetMaxOpenConns(1) so the in-memory SQLite DB is always reached via
+	// the same connection regardless of which goroutine is calling in.
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+
+	store, err := memstore.NewSQLiteStore(db, embedder, "test")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Seed facts that need embedding.
+	for i := range 10 {
+		if _, err := store.Insert(ctx, memstore.Fact{
+			Content:  fmt.Sprintf("concurrent fact %d", i),
+			Subject:  "concurrent",
+			Category: "test",
+		}); err != nil {
+			t.Fatalf("Insert: %v", err)
+		}
+	}
+
+	var wg sync.WaitGroup
+
+	// Goroutine 1: embed all pending facts (sleeps 10ms per batch call).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if _, err := store.EmbedFacts(ctx, 3); err != nil {
+			t.Errorf("EmbedFacts: %v", err)
+		}
+	}()
+
+	// Goroutine 2: interleave Insert and SearchFTS while embedding runs.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := range 5 {
+			if _, err := store.Insert(ctx, memstore.Fact{
+				Content:  fmt.Sprintf("writer fact %d", i),
+				Subject:  "writer",
+				Category: "test",
+			}); err != nil {
+				t.Errorf("Insert: %v", err)
+			}
+			if _, err := store.SearchFTS(ctx, "concurrent", memstore.SearchOpts{}); err != nil {
+				t.Errorf("SearchFTS: %v", err)
+			}
+		}
+	}()
+
+	wg.Wait()
 }
 
 func TestEmbedderModelValidation(t *testing.T) {


### PR DESCRIPTION
SQLiteStore.EmbedFacts held the store-wide write lock across every batched embedding HTTP call, freezing all reads and writes for the duration of the backlog (seconds to tens of seconds). It now uses three lock windows -- RLock for the pending-facts SELECT, no lock during embedding network I/O, and a per-batch write lock for recordEmbedder plus the UPDATE transaction -- matching the locking discipline Search already documents and follows. Behavior is unchanged apart from lock granularity; the benign TOCTOU window is documented in a comment.

Adds TestEmbedFacts_ConcurrentWithInsert: a slow mock embedder overlapping a concurrent writer goroutine under -race.

Plan: plans/004-embedfacts-lock-scope.md (improve-skill audit, 2026-06-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)