### PR TITLE
history: terminate chain walks on supersession cycles

### DIFF
--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -734,10 +734,8 @@ func (s *PostgresStore) historyByID(ctx context.Context, id int64) ([]memstore.H
 	// Walk forward.
 	if anchor.SupersededBy != nil {
 		next := *anchor.SupersededBy
-		for {
-			if visited[next] {
-				break // cycle detected
-			}
+		// Walk until the chain ends or repeats.
+		for !visited[next] {
 			row := s.pool.QueryRow(ctx,
 				`SELECT `+factColumns+` FROM memstore_facts WHERE id = $1 AND namespace = $2`,
 				next, s.namespace)

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -706,6 +706,7 @@ func (s *PostgresStore) historyByID(ctx context.Context, id int64) ([]memstore.H
 	}
 
 	// Walk backward.
+	visited := map[int64]bool{anchor.ID: true}
 	var backward []memstore.Fact
 	current := anchor.ID
 	for {
@@ -716,6 +717,10 @@ func (s *PostgresStore) historyByID(ctx context.Context, id int64) ([]memstore.H
 		if err != nil {
 			break
 		}
+		if visited[pred.ID] {
+			break // cycle detected
+		}
+		visited[pred.ID] = true
 		backward = append(backward, *pred)
 		current = pred.ID
 	}
@@ -730,6 +735,9 @@ func (s *PostgresStore) historyByID(ctx context.Context, id int64) ([]memstore.H
 	if anchor.SupersededBy != nil {
 		next := *anchor.SupersededBy
 		for {
+			if visited[next] {
+				break // cycle detected
+			}
 			row := s.pool.QueryRow(ctx,
 				`SELECT `+factColumns+` FROM memstore_facts WHERE id = $1 AND namespace = $2`,
 				next, s.namespace)
@@ -737,6 +745,7 @@ func (s *PostgresStore) historyByID(ctx context.Context, id int64) ([]memstore.H
 			if err != nil {
 				break
 			}
+			visited[succ.ID] = true
 			chain = append(chain, *succ)
 			if succ.SupersededBy == nil {
 				break

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -468,6 +468,57 @@ func TestHistory_BySubject(t *testing.T) {
 	}
 }
 
+func TestHistory_CycleTerminates(t *testing.T) {
+	ctx := context.Background()
+	dsn := testDSN(t)
+
+	// Build a dedicated pool for raw SQL manipulation.
+	rawPool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting for raw SQL: %v", err)
+	}
+	defer rawPool.Close()
+
+	// Clean slate (newTestStore also does this, but we need our own store instance).
+	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_links CASCADE`)
+	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
+	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
+	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+
+	store, err := pgstore.New(ctx, rawPool, &mockEmbedder{dim: 4}, "test", 4, 512)
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+
+	idA, err := store.Insert(ctx, memstore.Fact{Content: "fact A", Subject: "X", Category: "test"})
+	if err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	idB, err := store.Insert(ctx, memstore.Fact{Content: "fact B", Subject: "X", Category: "test"})
+	if err != nil {
+		t.Fatalf("insert B: %v", err)
+	}
+
+	// Force a cycle: A -> B -> A via raw SQL.
+	if _, err := rawPool.Exec(ctx, `UPDATE memstore_facts SET superseded_by = $1 WHERE id = $2`, idB, idA); err != nil {
+		t.Fatalf("set A->B: %v", err)
+	}
+	if _, err := rawPool.Exec(ctx, `UPDATE memstore_facts SET superseded_by = $1 WHERE id = $2`, idA, idB); err != nil {
+		t.Fatalf("set B->A: %v", err)
+	}
+
+	entries, err := store.History(ctx, idA, "")
+	if err != nil {
+		t.Fatalf("History returned error on cyclic data: %v", err)
+	}
+	if len(entries) > 3 {
+		t.Errorf("expected at most 3 entries for a 2-node cycle, got %d", len(entries))
+	}
+	if len(entries) == 0 {
+		t.Error("expected at least 1 entry (the anchor itself)")
+	}
+}
+
 func TestListSubsystems(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/sqlite.go
+++ b/sqlite.go
@@ -1129,10 +1129,8 @@ func (s *SQLiteStore) historyByID(ctx context.Context, id int64) ([]HistoryEntry
 	current = anchor.ID
 	if anchor.SupersededBy != nil {
 		next := *anchor.SupersededBy
-		for {
-			if visited[next] {
-				break // cycle detected
-			}
+		// Walk until the chain ends or repeats.
+		for !visited[next] {
 			row := s.db.QueryRowContext(ctx,
 				`SELECT `+factColumns+` FROM memstore_facts WHERE id = ? AND namespace = ?`,
 				next, s.namespace)

--- a/sqlite.go
+++ b/sqlite.go
@@ -1099,6 +1099,7 @@ func (s *SQLiteStore) historyByID(ctx context.Context, id int64) ([]HistoryEntry
 	}
 
 	// Walk backward: find predecessors (facts whose superseded_by points to us).
+	visited := map[int64]bool{anchor.ID: true}
 	var backward []Fact
 	current := anchor.ID
 	for {
@@ -1109,6 +1110,10 @@ func (s *SQLiteStore) historyByID(ctx context.Context, id int64) ([]HistoryEntry
 		if err != nil {
 			break // no more predecessors
 		}
+		if visited[pred.ID] {
+			break // cycle detected
+		}
+		visited[pred.ID] = true
 		backward = append(backward, *pred)
 		current = pred.ID
 	}
@@ -1125,6 +1130,9 @@ func (s *SQLiteStore) historyByID(ctx context.Context, id int64) ([]HistoryEntry
 	if anchor.SupersededBy != nil {
 		next := *anchor.SupersededBy
 		for {
+			if visited[next] {
+				break // cycle detected
+			}
 			row := s.db.QueryRowContext(ctx,
 				`SELECT `+factColumns+` FROM memstore_facts WHERE id = ? AND namespace = ?`,
 				next, s.namespace)
@@ -1132,6 +1140,7 @@ func (s *SQLiteStore) historyByID(ctx context.Context, id int64) ([]HistoryEntry
 			if err != nil {
 				break
 			}
+			visited[succ.ID] = true
 			chain = append(chain, *succ)
 			if succ.SupersededBy == nil {
 				break

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -1508,6 +1508,49 @@ func TestHistory_NeitherIDNorSubject(t *testing.T) {
 	}
 }
 
+func TestHistory_CycleTerminates(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store, err := memstore.NewSQLiteStore(db, nil, "test")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+
+	ctx := context.Background()
+
+	idA, err := store.Insert(ctx, memstore.Fact{Content: "fact A", Subject: "X", Category: "test"})
+	if err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	idB, err := store.Insert(ctx, memstore.Fact{Content: "fact B", Subject: "X", Category: "test"})
+	if err != nil {
+		t.Fatalf("insert B: %v", err)
+	}
+
+	// Force a cycle: A -> B -> A via raw SQL.
+	if _, err := db.ExecContext(ctx, `UPDATE memstore_facts SET superseded_by = ? WHERE id = ?`, idB, idA); err != nil {
+		t.Fatalf("set A->B: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE memstore_facts SET superseded_by = ? WHERE id = ?`, idA, idB); err != nil {
+		t.Fatalf("set B->A: %v", err)
+	}
+
+	entries, err := store.History(ctx, idA, "")
+	if err != nil {
+		t.Fatalf("History returned error on cyclic data: %v", err)
+	}
+	if len(entries) > 3 {
+		t.Errorf("expected at most 3 entries for a 2-node cycle, got %d", len(entries))
+	}
+	if len(entries) == 0 {
+		t.Error("expected at least 1 entry (the anchor itself)")
+	}
+}
+
 // --- Confirm tests ---
 
 func TestConfirm_Basic(t *testing.T) {


### PR DESCRIPTION
Both backends' historyByID walked superseded_by chains with no cycle guard: one corrupt pointer pair (A -> B -> A, creatable via Import or raw SQL) hung the call forever -- in daemon mode, a request goroutine and connection pinned until process death. Both walks now track a visited set and stop where the chain repeats, so corrupt data degrades to a finite chain instead of a hang. Valid data is unaffected.

TestHistory_CycleTerminates forces a real cycle via raw SQL on both backends; the pgstore side was verified against a real pgvector container during review.

Plan: plans/005-history-cycle-guard.md (improve-skill audit, 2026-06-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)