### PR TITLE
pgstore: compare numerically when metadata filter value is numeric

### DIFF
--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -372,12 +372,18 @@ func testMetadataFilterMatches(t *testing.T, s memstore.Store) {
 	}
 }
 
-// testNumericMetadataComparisonDivergence documents a known backend
-// divergence: SQLite's json_extract compares numeric JSON values numerically,
-// while pgstore's jsonb text extraction makes the comparison text-typed and
-// pgx cannot bind a Go int against it. The subtest skips (with the error)
-// where numeric comparison is unsupported, and asserts correct results where
-// it works -- so it starts enforcing parity automatically if the gap is fixed.
+// testNumericMetadataComparisonDivergence pins the numeric metadata-filter
+// contract: when the filter value is a Go numeric type, comparison is numeric
+// (not lexicographic). The skip path remains for backends that have not yet
+// implemented numeric comparison -- on those backends the first List call
+// returns an error and the subtest skips rather than fails.
+//
+// Contract (must hold on every backend that passes):
+//   - chapter <= 3: low-chapter (1) included, high-chapter (9) excluded.
+//   - missing-key fact: excluded without IncludeNull, included with it.
+//   - non-numeric fact (chapter:"not-a-number"): excluded in both modes.
+//   - IncludeNull variant: returns low-chapter and missing-key; not high or
+//     non-numeric.
 func testNumericMetadataComparisonDivergence(t *testing.T, s memstore.Store) {
 	t.Helper()
 	ctx := context.Background()
@@ -390,7 +396,16 @@ func testNumericMetadataComparisonDivergence(t *testing.T, s memstore.Store) {
 		Content: "high chapter", Subject: "numeric", Category: "test",
 		Metadata: json.RawMessage(`{"chapter":9}`),
 	})
+	s.Insert(ctx, memstore.Fact{ //nolint:errcheck
+		Content: "missing chapter", Subject: "numeric", Category: "test",
+		Metadata: json.RawMessage(`{}`),
+	})
+	s.Insert(ctx, memstore.Fact{ //nolint:errcheck
+		Content: "non-numeric chapter", Subject: "numeric", Category: "test",
+		Metadata: json.RawMessage(`{"chapter":"not-a-number"}`),
+	})
 
+	// Plain filter: skip if backend does not support numeric comparison.
 	facts, err := s.List(ctx, memstore.QueryOpts{
 		MetadataFilters: []memstore.MetadataFilter{
 			{Key: "chapter", Op: "<=", Value: 3},
@@ -399,11 +414,58 @@ func testNumericMetadataComparisonDivergence(t *testing.T, s memstore.Store) {
 	if err != nil {
 		t.Skipf("known divergence: numeric metadata comparison unsupported on this backend: %v", err)
 	}
+
+	// Only low chapter (1) should be returned; missing and non-numeric are excluded.
 	if len(facts) != 1 {
-		t.Fatalf("got %d facts, want 1", len(facts))
+		t.Fatalf("chapter <= 3: got %d facts, want 1", len(facts))
 	}
 	if facts[0].Content != "low chapter" {
-		t.Errorf("Content = %q, want %q", facts[0].Content, "low chapter")
+		t.Errorf("chapter <= 3: Content = %q, want %q", facts[0].Content, "low chapter")
+	}
+
+	// Verify missing-key and non-numeric facts are not present.
+	for _, f := range facts {
+		if f.Content == "missing chapter" {
+			t.Error("chapter <= 3: missing-key fact should not match")
+		}
+		if f.Content == "non-numeric chapter" {
+			t.Error("chapter <= 3: non-numeric chapter fact should not match")
+		}
+	}
+
+	// IncludeNull variant: missing-key is included; non-numeric is still excluded.
+	factsInc, err := s.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{
+			{Key: "chapter", Op: "<=", Value: 3, IncludeNull: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("chapter <= 3 IncludeNull: %v", err)
+	}
+	var gotLow, gotMissing, gotHigh, gotNonNumeric bool
+	for _, f := range factsInc {
+		switch f.Content {
+		case "low chapter":
+			gotLow = true
+		case "missing chapter":
+			gotMissing = true
+		case "high chapter":
+			gotHigh = true
+		case "non-numeric chapter":
+			gotNonNumeric = true
+		}
+	}
+	if !gotLow {
+		t.Error("chapter <= 3 IncludeNull: expected low chapter fact, not found")
+	}
+	if !gotMissing {
+		t.Error("chapter <= 3 IncludeNull: expected missing-key fact (IncludeNull), not found")
+	}
+	if gotHigh {
+		t.Error("chapter <= 3 IncludeNull: high chapter should not match <= 3")
+	}
+	if gotNonNumeric {
+		t.Error("chapter <= 3 IncludeNull: non-numeric chapter should not match even with IncludeNull")
 	}
 }
 

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -1149,9 +1149,29 @@ var validMetadataOps = map[string]bool{
 	">": true, ">=": true,
 }
 
+// numericFilterValue reports whether a metadata filter value should use
+// numeric comparison. JSON-decoded values arrive as float64; Go callers may
+// pass any integer or float type.
+func numericFilterValue(v any) bool {
+	switch v.(type) {
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, json.Number:
+		return true
+	}
+	return false
+}
+
 // appendMetadataFilters adds jsonb-based WHERE clauses for each metadata
 // filter. Returns an error for invalid keys or operators, matching the
 // SQLite backend's behavior.
+//
+// When the filter value is numeric, the comparison uses a CASE expression
+// that casts the JSON value to numeric only when it is actually a JSON number.
+// This prevents cast errors on rows whose value for the key is non-numeric,
+// and reproduces SQLite's semantics: missing key -> excluded (or included
+// with IncludeNull); present non-numeric value -> excluded even with
+// IncludeNull (the value is not NULL).
 func appendMetadataFilters(b *queryBuilder, alias string, filters []memstore.MetadataFilter) error {
 	for _, mf := range filters {
 		if !validMetadataKey(mf.Key) {
@@ -1160,13 +1180,49 @@ func appendMetadataFilters(b *queryBuilder, alias string, filters []memstore.Met
 		if !validMetadataOps[mf.Op] {
 			return fmt.Errorf("pgstore: invalid metadata filter operator: %q", mf.Op)
 		}
-		b.args = append(b.args, mf.Key)
-		extract := fmt.Sprintf("jsonb_extract_path_text(%smetadata, $%d)", alias, len(b.args))
-		b.args = append(b.args, mf.Value)
-		if mf.IncludeNull {
-			b.q += fmt.Sprintf(` AND (%s IS NULL OR %s %s $%d)`, extract, extract, mf.Op, len(b.args))
+
+		if numericFilterValue(mf.Value) {
+			// Bind the key once; reuse the arg index for both the typeof check
+			// and the extract-and-cast expression.
+			b.args = append(b.args, mf.Key)
+			keyIdx := len(b.args)
+
+			// Convert json.Number to float64 for deterministic pgx encoding.
+			val := mf.Value
+			if n, ok := val.(json.Number); ok {
+				f, err := n.Float64()
+				if err != nil {
+					return fmt.Errorf("pgstore: cannot convert json.Number filter value: %w", err)
+				}
+				val = f
+			}
+			b.args = append(b.args, val)
+			valIdx := len(b.args)
+
+			// caseExpr evaluates to NULL when the key is absent or its JSON type
+			// is not 'number', so non-numeric rows are silently excluded.
+			caseExpr := fmt.Sprintf(
+				"CASE WHEN jsonb_typeof(jsonb_extract_path(%smetadata, $%d)) = 'number' THEN (jsonb_extract_path_text(%smetadata, $%d))::numeric END",
+				alias, keyIdx, alias, keyIdx,
+			)
+			if mf.IncludeNull {
+				// IncludeNull includes rows where the key is absent entirely.
+				// Present-but-non-numeric rows evaluate the caseExpr to NULL
+				// and are excluded, matching SQLite's reference behavior.
+				nullCheck := fmt.Sprintf("jsonb_extract_path(%smetadata, $%d) IS NULL", alias, keyIdx)
+				b.q += fmt.Sprintf(` AND (%s OR %s %s $%d)`, nullCheck, caseExpr, mf.Op, valIdx)
+			} else {
+				b.q += fmt.Sprintf(` AND %s %s $%d`, caseExpr, mf.Op, valIdx)
+			}
 		} else {
-			b.q += fmt.Sprintf(` AND %s %s $%d`, extract, mf.Op, len(b.args))
+			b.args = append(b.args, mf.Key)
+			extract := fmt.Sprintf("jsonb_extract_path_text(%smetadata, $%d)", alias, len(b.args))
+			b.args = append(b.args, mf.Value)
+			if mf.IncludeNull {
+				b.q += fmt.Sprintf(` AND (%s IS NULL OR %s %s $%d)`, extract, extract, mf.Op, len(b.args))
+			} else {
+				b.q += fmt.Sprintf(` AND %s %s $%d`, extract, mf.Op, len(b.args))
+			}
 		}
 	}
 	return nil

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -881,3 +881,116 @@ func TestConformance(t *testing.T) {
 		},
 	})
 }
+
+// TestList_NumericMetadataFilter verifies that pgstore compares numeric
+// metadata filter values numerically rather than as text. Requires a running
+// Postgres instance (MEMSTORE_TEST_PG).
+func TestList_NumericMetadataFilter(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	store.Insert(ctx, memstore.Fact{ //nolint:errcheck
+		Content: "low chapter", Subject: "numeric", Category: "test",
+		Metadata: json.RawMessage(`{"chapter":1}`),
+	})
+	store.Insert(ctx, memstore.Fact{ //nolint:errcheck
+		Content: "high chapter", Subject: "numeric", Category: "test",
+		Metadata: json.RawMessage(`{"chapter":9}`),
+	})
+	store.Insert(ctx, memstore.Fact{ //nolint:errcheck
+		Content: "missing chapter", Subject: "numeric", Category: "test",
+		Metadata: json.RawMessage(`{}`),
+	})
+	store.Insert(ctx, memstore.Fact{ //nolint:errcheck
+		Content: "non-numeric chapter", Subject: "numeric", Category: "test",
+		Metadata: json.RawMessage(`{"chapter":"not-a-number"}`),
+	})
+
+	// <= with int: only the low-chapter fact matches.
+	facts, err := store.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "chapter", Op: "<=", Value: 3}},
+	})
+	if err != nil {
+		t.Fatalf("List <= int: %v", err)
+	}
+	if len(facts) != 1 || facts[0].Content != "low chapter" {
+		t.Errorf("List <=3: got %d facts, want 1 (low chapter); contents: %v", len(facts), factContents(facts))
+	}
+
+	// = with float64 (JSON-decoded form): matches chapter:1.
+	facts, err = store.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "chapter", Op: "=", Value: float64(1)}},
+	})
+	if err != nil {
+		t.Fatalf("List = float64: %v", err)
+	}
+	if len(facts) != 1 || facts[0].Content != "low chapter" {
+		t.Errorf("List =1.0: got %d facts, want 1 (low chapter); contents: %v", len(facts), factContents(facts))
+	}
+
+	// > excludes all facts with chapter <= 3 and missing/non-numeric.
+	facts, err = store.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "chapter", Op: ">", Value: 3}},
+	})
+	if err != nil {
+		t.Fatalf("List > int: %v", err)
+	}
+	if len(facts) != 1 || facts[0].Content != "high chapter" {
+		t.Errorf("List >3: got %d facts, want 1 (high chapter); contents: %v", len(facts), factContents(facts))
+	}
+
+	// Without IncludeNull: missing-key and non-numeric facts are both excluded.
+	facts, err = store.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "chapter", Op: "<=", Value: 3, IncludeNull: false}},
+	})
+	if err != nil {
+		t.Fatalf("List <= without IncludeNull: %v", err)
+	}
+	for _, f := range facts {
+		if f.Content == "missing chapter" || f.Content == "non-numeric chapter" {
+			t.Errorf("List <= without IncludeNull: unexpected fact %q in results", f.Content)
+		}
+	}
+
+	// With IncludeNull: missing-key fact is included; non-numeric fact is still excluded.
+	facts, err = store.List(ctx, memstore.QueryOpts{
+		MetadataFilters: []memstore.MetadataFilter{{Key: "chapter", Op: "<=", Value: 3, IncludeNull: true}},
+	})
+	if err != nil {
+		t.Fatalf("List <= with IncludeNull: %v", err)
+	}
+	var gotLow, gotMissing, gotHigh, gotNonNumeric bool
+	for _, f := range facts {
+		switch f.Content {
+		case "low chapter":
+			gotLow = true
+		case "missing chapter":
+			gotMissing = true
+		case "high chapter":
+			gotHigh = true
+		case "non-numeric chapter":
+			gotNonNumeric = true
+		}
+	}
+	if !gotLow {
+		t.Error("List <= with IncludeNull: expected low chapter fact, not found")
+	}
+	if !gotMissing {
+		t.Error("List <= with IncludeNull: expected missing chapter fact (IncludeNull), not found")
+	}
+	if gotHigh {
+		t.Error("List <= with IncludeNull: high chapter fact should not match <= 3")
+	}
+	if gotNonNumeric {
+		t.Error("List <= with IncludeNull: non-numeric chapter should not match even with IncludeNull")
+	}
+}
+
+// factContents is a test helper that returns the Content fields of a slice.
+func factContents(facts []memstore.Fact) []string {
+	out := make([]string, len(facts))
+	for i, f := range facts {
+		out[i] = f.Content
+	}
+	return out
+}


### PR DESCRIPTION
Stacked on #83 (which stacks on #80 and #82) -- this branch builds on the conformance suite; its diff shrinks as those merge. Merge order: #80/#82, then #83, then this.

Fixes the divergence the conformance suite (#83) found on its first Postgres run: numeric metadata filters like {chapter <= 3} work on SQLite but errored on pgstore, because the jsonb extraction is text-typed and pgx cannot bind a numeric value against it (every MCP/HTTP caller sending a numeric filter hits this -- JSON values decode as float64).

When the filter value is numeric, pgstore now compares via a CASE expression guarded by jsonb_typeof = 'number', casting to ::numeric only when the JSON value actually is a number. This avoids cast errors on rows holding non-numeric values for the key and reproduces SQLite's corner semantics exactly: missing key excluded (included with IncludeNull, via an explicit key-absence check), present-but-non-numeric excluded in both modes. String filters keep the existing text path.

The NumericMetadataComparisonDivergence conformance subtest now passes on Postgres instead of skipping -- verified against a real pgvector container during review, along with the new env-gated TestList_NumericMetadataFilter and the full suite on both backends.

Plan: plans/008-pgstore-numeric-metadata-filters.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)