### PR TITLE
extract: batch embedding calls in the extraction pipeline

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -27,7 +27,7 @@ type ExtractOpts struct {
 // ExtractResult summarizes the outcome of an extraction run.
 type ExtractResult struct {
 	Inserted   []Fact
-	Duplicates int     // skipped via Exists()
+	Duplicates int     // skipped via Exists() or in-batch dedup
 	Superseded int     // count of old facts auto-superseded by new ones
 	Errors     []error // per-fact parse/insert failures
 }
@@ -73,7 +73,7 @@ type extractedFact struct {
 // ExtractFacts uses a generator to extract structured facts from text
 // without persisting them. Returns parsed facts with subject and category
 // populated, ready for caller-managed insertion. The returned facts have
-// no embeddings or IDs — the caller handles those.
+// no embeddings or IDs -- the caller handles those.
 func ExtractFacts(ctx context.Context, gen Generator, text string, opts ExtractOpts) ([]Fact, error) {
 	prompt := defaultPrompt(text, opts.Hints)
 
@@ -115,7 +115,20 @@ func ExtractFacts(ctx context.Context, gen Generator, text string, opts ExtractO
 	return facts, nil
 }
 
+// candidate is a fact that has passed the dedup check and is ready for embedding and insertion.
+type candidate struct {
+	Fact
+}
+
 // Extract distills text into structured facts and persists them.
+// It runs four phases:
+//
+//  1. Resolve and dedup -- skip empty content, resolve subject/category defaults,
+//     check existence, and drop in-batch duplicates.
+//  2. Batch embed -- one EmbedWithRetry call for all surviving candidates.
+//  3. Insert -- persist each candidate.
+//  4. Supersession -- one SearchBatch call per distinct subject to find and
+//     supersede near-duplicate existing facts.
 func (e *FactExtractor) Extract(ctx context.Context, text string, opts ExtractOpts) (*ExtractResult, error) {
 	promptFn := e.promptFn
 	if promptFn == nil {
@@ -140,6 +153,10 @@ func (e *FactExtractor) Extract(ctx context.Context, text string, opts ExtractOp
 		Errors: parseErrs,
 	}
 
+	// --- Phase A: resolve and dedup ---
+	seen := make(map[string]bool)
+	var candidates []candidate
+
 	for _, ef := range facts {
 		if strings.TrimSpace(ef.Content) == "" {
 			continue
@@ -155,7 +172,15 @@ func (e *FactExtractor) Extract(ctx context.Context, text string, opts ExtractOp
 			category = "note"
 		}
 
-		// Dedup check.
+		// In-batch dedup: same content+subject pair seen earlier in this batch.
+		dedupKey := ef.Content + "\x00" + subject
+		if seen[dedupKey] {
+			result.Duplicates++
+			continue
+		}
+		seen[dedupKey] = true
+
+		// Existence check against the store.
 		exists, err := e.store.Exists(ctx, ef.Content, subject)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("exists check for %q: %w", ef.Content, err))
@@ -166,70 +191,137 @@ func (e *FactExtractor) Extract(ctx context.Context, text string, opts ExtractOp
 			continue
 		}
 
-		fact := Fact{
+		candidates = append(candidates, candidate{Fact: Fact{
 			Content:  ef.Content,
 			Subject:  subject,
 			Category: category,
 			Metadata: opts.Metadata,
-		}
+		}})
+	}
 
-		// Compute embedding (if embedder is available).
-		if e.embedder != nil {
-			emb, err := embedding.Single(ctx, e.embedder, ef.Content)
-			if err != nil {
-				result.Errors = append(result.Errors, fmt.Errorf("embedding %q: %w", ef.Content, err))
-				continue
-			}
-			fact.Embedding = emb
-		}
+	if len(candidates) == 0 {
+		return result, nil
+	}
 
-		// Persist.
-		id, err := e.store.Insert(ctx, fact)
+	// --- Phase B: batch embed ---
+	if e.embedder != nil {
+		contents := make([]string, len(candidates))
+		for i, c := range candidates {
+			contents[i] = c.Content
+		}
+		embs, err := embedding.EmbedWithRetry(ctx, e.embedder, contents)
 		if err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("inserting %q: %w", ef.Content, err))
+			result.Errors = append(result.Errors, fmt.Errorf("memstore: batch embedding %d facts: %w", len(contents), err))
+			return result, nil
+		}
+		if len(embs) != len(contents) {
+			result.Errors = append(result.Errors, fmt.Errorf("memstore: batch embedding %d facts: got %d embeddings, want %d", len(contents), len(embs), len(contents)))
+			return result, nil
+		}
+		for i := range candidates {
+			candidates[i].Embedding = embs[i]
+		}
+	}
+
+	// --- Phase C: insert ---
+	// batchIndexByID maps each inserted fact's ID to its position in the candidates
+	// slice. Used in Phase D to prevent later batch-mates from superseding earlier ones.
+	batchIndexByID := make(map[int64]int)
+
+	for i, c := range candidates {
+		id, err := e.store.Insert(ctx, c.Fact)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("inserting %q: %w", c.Content, err))
 			continue
 		}
-		fact.ID = id
+		candidates[i].ID = id
+		batchIndexByID[id] = i
+		result.Inserted = append(result.Inserted, candidates[i].Fact)
+	}
 
-		// Auto-supersession: after insert so we have the new fact's ID.
-		if supersededID, err := e.trySupersedeExisting(ctx, fact); err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("supersede check for %q: %w", ef.Content, err))
-		} else if supersededID != nil {
-			result.Superseded++
+	// --- Phase D: supersession ---
+	// Skip entirely when no embedder is configured (no embeddings to compare).
+	if e.embedder == nil || len(result.Inserted) == 0 {
+		return result, nil
+	}
+
+	// Group inserted facts by subject for one SearchBatch call per distinct subject.
+	type insertedFact struct {
+		fact       Fact
+		batchIndex int
+	}
+	bySubject := make(map[string][]insertedFact)
+	for _, f := range result.Inserted {
+		if len(f.Embedding) == 0 {
+			continue
+		}
+		idx := batchIndexByID[f.ID]
+		bySubject[f.Subject] = append(bySubject[f.Subject], insertedFact{fact: f, batchIndex: idx})
+	}
+
+	// supersededInRun tracks IDs already superseded in this batch to prevent chains.
+	supersededInRun := make(map[int64]bool)
+
+	for subj, group := range bySubject {
+		contents := make([]string, len(group))
+		for i, g := range group {
+			contents[i] = g.fact.Content
 		}
 
-		result.Inserted = append(result.Inserted, fact)
+		neighborSets, err := e.store.SearchBatch(ctx, contents, SearchOpts{
+			MaxResults: 10,
+			Subject:    subj,
+			OnlyActive: true,
+		})
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("supersede search for subject %q: %w", subj, err))
+			continue
+		}
+
+		for i, g := range group {
+			if i >= len(neighborSets) {
+				break
+			}
+			neighbors := neighborSets[i]
+			supersededID := e.pickSupersessionTarget(g.fact, g.batchIndex, neighbors, batchIndexByID, supersededInRun)
+			if supersededID == nil {
+				continue
+			}
+			if err := e.store.Supersede(ctx, *supersededID, g.fact.ID); err != nil {
+				result.Errors = append(result.Errors, fmt.Errorf("supersede check for %q: %w", g.fact.Content, err))
+				continue
+			}
+			supersededInRun[*supersededID] = true
+			result.Superseded++
+		}
 	}
 
 	return result, nil
 }
 
-// trySupersedeExisting searches for same-subject active facts with high
-// embedding similarity and supersedes the best match. Returns the superseded
-// fact's ID if one was found, or nil if no match exceeded the threshold.
+// pickSupersessionTarget examines pre-fetched search results for newFact and
+// returns the ID of the best candidate to supersede, or nil if none qualifies.
 //
-// Metadata acts as a context discriminator: if both facts have metadata and
-// any shared keys have different values, supersession is skipped. This prevents
-// facts from different contexts (e.g., different projects or sources) from
-// incorrectly superseding each other.
-func (e *FactExtractor) trySupersedeExisting(ctx context.Context, newFact Fact) (*int64, error) {
-	if e.embedder == nil || len(newFact.Embedding) == 0 || newFact.ID == 0 {
-		return nil, nil
-	}
-
-	// Search for same-subject active facts.
-	results, err := e.store.Search(ctx, newFact.Content, SearchOpts{
-		MaxResults: 10,
-		Subject:    newFact.Subject,
-		OnlyActive: true,
-	})
-	if err != nil {
-		return nil, err
-	}
-
+// Filters applied (in order):
+//   - Skip self
+//   - Skip facts with no embedding
+//   - Skip MetadataConflicts
+//   - Skip batch-mates that have a later batch index (prevents A->B->A cycles)
+//   - Skip facts already superseded in this run
+//
+// Among the remaining candidates, the one with the highest cosine similarity
+// above similarityThreshold is chosen.
+func (e *FactExtractor) pickSupersessionTarget(
+	newFact Fact,
+	newBatchIndex int,
+	neighbors []SearchResult,
+	batchIndexByID map[int64]int,
+	supersededInRun map[int64]bool,
+) *int64 {
 	var bestID int64
 	var bestSim float64
-	for _, r := range results {
+
+	for _, r := range neighbors {
 		if r.Fact.ID == newFact.ID {
 			continue // skip self
 		}
@@ -237,7 +329,16 @@ func (e *FactExtractor) trySupersedeExisting(ctx context.Context, newFact Fact) 
 			continue
 		}
 		if MetadataConflicts(newFact.Metadata, r.Fact.Metadata) {
-			continue // different contexts — don't auto-supersede
+			continue // different contexts -- don't auto-supersede
+		}
+		// If the candidate is a batch-mate with a later index, skip it to
+		// preserve sequential semantics and prevent A->B->A cycles.
+		if laterIdx, isBatchMate := batchIndexByID[r.Fact.ID]; isBatchMate && laterIdx > newBatchIndex {
+			continue
+		}
+		// Skip facts already superseded in this run.
+		if supersededInRun[r.Fact.ID] {
+			continue
 		}
 		sim := embedding.CosineSimilarity(newFact.Embedding, r.Fact.Embedding)
 		if sim > bestSim {
@@ -247,13 +348,9 @@ func (e *FactExtractor) trySupersedeExisting(ctx context.Context, newFact Fact) 
 	}
 
 	if bestSim < similarityThreshold || bestID == 0 {
-		return nil, nil
+		return nil
 	}
-
-	if err := e.store.Supersede(ctx, bestID, newFact.ID); err != nil {
-		return nil, err
-	}
-	return &bestID, nil
+	return &bestID
 }
 
 // MetadataConflicts returns true if both metadata values are non-empty JSON
@@ -266,7 +363,7 @@ func MetadataConflicts(a, b json.RawMessage) bool {
 	}
 	var ma, mb map[string]any
 	if json.Unmarshal(a, &ma) != nil || json.Unmarshal(b, &mb) != nil {
-		return false // can't parse — don't block
+		return false // can't parse -- don't block
 	}
 	for k, va := range ma {
 		if vb, ok := mb[k]; ok {
@@ -319,12 +416,12 @@ func parseExtractResponse(raw string) ([]extractedFact, []error) {
 	return nil, []error{fmt.Errorf("memstore: failed to parse extraction response: %q", truncate(raw, 200))}
 }
 
-// truncate returns s trimmed to maxLen bytes, with "…" appended if truncated.
+// truncate returns s trimmed to maxLen bytes, with "..." appended if truncated.
 func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "…"
+	return s[:maxLen] + "..."
 }
 
 // defaultPrompt builds the extraction prompt for the LLM.

--- a/extract_test.go
+++ b/extract_test.go
@@ -699,11 +699,181 @@ func TestExtract_AutoSupersede_NilEmbedder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
-	// Fact inserted but no supersession (nil embedder → no embedding → skipped).
+	// Fact inserted but no supersession (nil embedder -> no embedding -> skipped).
 	if result.Superseded != 0 {
 		t.Errorf("superseded = %d, want 0", result.Superseded)
 	}
 	if len(result.Inserted) != 1 {
 		t.Errorf("inserted = %d, want 1", len(result.Inserted))
+	}
+}
+
+// countingEmbedder wraps another embedder and records each Embed call.
+type countingEmbedder struct {
+	inner     embedding.Embedder
+	callCount int
+}
+
+func (c *countingEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	c.callCount++
+	return c.inner.Embed(ctx, texts)
+}
+
+func (c *countingEmbedder) Model() string { return c.inner.Model() }
+
+func (c *countingEmbedder) Fingerprint() embedding.Fingerprint { return c.inner.Fingerprint() }
+
+func TestExtract_EmbedderCallCount(t *testing.T) {
+	// 3 distinct facts sharing one subject. Phase B should produce 1 Embed call
+	// for the batch; Phase D SearchBatch should produce 1 more Embed call (for
+	// the 3-query batch), totalling 2 calls to Embed across the whole Extract run.
+	inner := &identityEmbedder{dim: 4}
+	counter := &countingEmbedder{inner: inner}
+	store := openTestStoreWith(t, counter)
+	ctx := context.Background()
+
+	gen := &mockGenerator{
+		response: `[
+			{"content": "fact alpha", "subject": "X", "category": "note"},
+			{"content": "fact beta",  "subject": "X", "category": "note"},
+			{"content": "fact gamma", "subject": "X", "category": "note"}
+		]`,
+	}
+	ext := memstore.NewFactExtractor(store, counter, gen)
+	result, err := ext.Extract(ctx, "some text", memstore.ExtractOpts{Subject: "X"})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Inserted) != 3 {
+		t.Fatalf("inserted = %d, want 3", len(result.Inserted))
+	}
+	// 1 call for phase-B batch + 1 call for phase-D SearchBatch = 2 total.
+	if counter.callCount != 2 {
+		t.Errorf("embedder call count = %d, want 2 (1 phase-B + 1 phase-D SearchBatch)", counter.callCount)
+	}
+}
+
+func TestExtract_InBatchDuplicates(t *testing.T) {
+	// Generator returns the same content+subject pair twice.
+	// Only the first should be inserted; the second is an in-batch duplicate.
+	store := openTestStore(t)
+	embedder := &mockEmbedder{dim: 4}
+	ctx := context.Background()
+
+	gen := &mockGenerator{
+		response: `[
+			{"content": "Matthew drinks coffee", "subject": "Matthew", "category": "preference"},
+			{"content": "Matthew drinks coffee", "subject": "Matthew", "category": "preference"}
+		]`,
+	}
+	ext := memstore.NewFactExtractor(store, embedder, gen)
+	result, err := ext.Extract(ctx, "some text", memstore.ExtractOpts{Subject: "Matthew"})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if result.Duplicates != 1 {
+		t.Errorf("duplicates = %d, want 1", result.Duplicates)
+	}
+	if len(result.Inserted) != 1 {
+		t.Fatalf("inserted = %d, want 1", len(result.Inserted))
+	}
+}
+
+func TestExtract_InBatchSupersessionNoCycle(t *testing.T) {
+	// Verify that supersededInRun prevents the same pre-existing fact from
+	// being targeted twice. Two batch facts, same subject, identical embeddings
+	// (via identityEmbedder). One pre-existing fact with identical embedding.
+	//
+	// Processing order: neovim (index 0) supersedes emacs; emacs enters
+	// supersededInRun. helix (index 1) then cannot pick emacs again (it's in
+	// supersededInRun). helix's best remaining target is neovim (index 0,
+	// earlier batch-mate), which it may supersede -- that is sequential
+	// semantics, not a cycle.
+	//
+	// The no-cycle invariant: neovim (index 0) processed before helix was
+	// inserted, so helix never appears in neovim's SearchBatch results.
+	// There is no A->B->A path.
+	embedder := &identityEmbedder{dim: 4}
+	store := openTestStoreWith(t, embedder)
+	ctx := context.Background()
+
+	// Pre-insert one existing fact; same embedding as batch facts.
+	emb, _ := embedding.Single(ctx, embedder, "old")
+	_, err := store.Insert(ctx, memstore.Fact{
+		Content:   "Matthew uses emacs",
+		Subject:   "Matthew",
+		Category:  "preference",
+		Embedding: emb,
+	})
+	if err != nil {
+		t.Fatalf("pre-insert: %v", err)
+	}
+
+	gen := &mockGenerator{
+		response: `[
+			{"content": "Matthew uses neovim",  "subject": "Matthew", "category": "preference"},
+			{"content": "Matthew uses helix",   "subject": "Matthew", "category": "preference"}
+		]`,
+	}
+	ext := memstore.NewFactExtractor(store, embedder, gen)
+	result, err := ext.Extract(ctx, "some text", memstore.ExtractOpts{})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Inserted) != 2 {
+		t.Fatalf("inserted = %d, want 2", len(result.Inserted))
+	}
+	// emacs gets superseded once (by neovim, the first batch fact); helix may
+	// then supersede neovim (sequential chaining). supersededInRun prevents
+	// both batch facts from targeting emacs -- total superseded = 2.
+	// The point is no cycle: none of the superseded facts re-supersede their
+	// successor. Verify by checking that exactly the batch facts are active.
+	active, err := store.BySubject(ctx, "Matthew", true)
+	if err != nil {
+		t.Fatalf("BySubject: %v", err)
+	}
+	// With identityEmbedder, helix supersedes neovim (sequential chaining).
+	// Final active = only helix.
+	if len(active) != 1 {
+		t.Errorf("active facts = %d, want 1 (helix active; emacs and neovim superseded by chain)", len(active))
+	}
+	if active[0].Content != "Matthew uses helix" {
+		t.Errorf("active content = %q, want %q", active[0].Content, "Matthew uses helix")
+	}
+	// Total supersessions: emacs->neovim->helix chain = 2.
+	if result.Superseded != 2 {
+		t.Errorf("superseded = %d, want 2", result.Superseded)
+	}
+}
+
+func TestExtract_BatchEmbedFailure(t *testing.T) {
+	// When the embedder returns an error, Extract should return zero inserts
+	// and record the error. It must not panic.
+	errEmbedder := &mockEmbedder{dim: 4, err: fmt.Errorf("embedding service down")}
+	store := openTestStoreWith(t, errEmbedder)
+	ctx := context.Background()
+
+	gen := &mockGenerator{
+		response: `[
+			{"content": "some fact", "subject": "X", "category": "note"},
+			{"content": "another fact", "subject": "X", "category": "note"}
+		]`,
+	}
+	ext := memstore.NewFactExtractor(store, errEmbedder, gen)
+	result, err := ext.Extract(ctx, "some text", memstore.ExtractOpts{Subject: "X"})
+	if err != nil {
+		t.Fatalf("Extract should not return a top-level error on embedder failure: %v", err)
+	}
+	if len(result.Inserted) != 0 {
+		t.Errorf("inserted = %d, want 0 on embedding failure", len(result.Inserted))
+	}
+	if len(result.Errors) == 0 {
+		t.Error("expected at least one error in result.Errors on embedding failure")
 	}
 }

--- a/httpapi/extractqueue.go
+++ b/httpapi/extractqueue.go
@@ -267,46 +267,7 @@ func (q *ExtractQueue) processJob(job extractJob) {
 	q.summarizeAndPersist(ctx, job, projectName)
 
 	// 5. A-MEM linking: link each new fact to related existing facts.
-	linked := 0
-	if len(result.Inserted) > 0 {
-		contents := make([]string, len(result.Inserted))
-		for i, f := range result.Inserted {
-			contents[i] = f.Content
-		}
-		neighborSets, err := q.store.SearchBatch(ctx, contents, memstore.SearchOpts{
-			Subject:    projectName,
-			MaxResults: 4,
-			OnlyActive: true,
-		})
-		if err != nil {
-			log.Printf("extract: session %s: link search failed: %v", job.SessionID, err)
-			// skip linking stage
-		} else {
-			for i, fact := range result.Inserted {
-				if i >= len(neighborSets) {
-					break
-				}
-				count := 0
-				for _, r := range neighborSets[i] {
-					if r.Fact.ID == fact.ID {
-						continue
-					}
-					if r.VecScore < 0.6 {
-						continue
-					}
-					if _, err := q.store.LinkFacts(ctx, fact.ID, r.Fact.ID, "related", true, "", nil); err != nil {
-						log.Printf("extract: session %s: link %d->%d failed: %v", job.SessionID, fact.ID, r.Fact.ID, err)
-						continue
-					}
-					count++
-					if count >= 3 {
-						break
-					}
-				}
-				linked += count
-			}
-		}
-	}
+	linked := q.linkInserted(ctx, job.SessionID, projectName, result.Inserted)
 
 	errCount := len(result.Errors)
 	log.Printf("extract: session %s: %d inserted, %d superseded, %d linked, %d errors",
@@ -316,6 +277,54 @@ func (q *ExtractQueue) processJob(job extractJob) {
 	if q.hintStore != nil {
 		q.generateHints(ctx, job, projectName)
 	}
+}
+
+// linkInserted runs the A-MEM linking stage: one SearchBatch over all
+// inserted fact contents, then up to 3 "related" links per fact to neighbors
+// scoring >= 0.6. A SearchBatch error logs and skips linking entirely.
+// Returns the number of links created.
+func (q *ExtractQueue) linkInserted(ctx context.Context, sessionID, projectName string, inserted []memstore.Fact) int {
+	if len(inserted) == 0 {
+		return 0
+	}
+	contents := make([]string, len(inserted))
+	for i, f := range inserted {
+		contents[i] = f.Content
+	}
+	neighborSets, err := q.store.SearchBatch(ctx, contents, memstore.SearchOpts{
+		Subject:    projectName,
+		MaxResults: 4,
+		OnlyActive: true,
+	})
+	if err != nil {
+		log.Printf("extract: session %s: link search failed: %v", sessionID, err)
+		return 0
+	}
+	linked := 0
+	for i, fact := range inserted {
+		if i >= len(neighborSets) {
+			break
+		}
+		count := 0
+		for _, r := range neighborSets[i] {
+			if r.Fact.ID == fact.ID {
+				continue
+			}
+			if r.VecScore < 0.6 {
+				continue
+			}
+			if _, err := q.store.LinkFacts(ctx, fact.ID, r.Fact.ID, "related", true, "", nil); err != nil {
+				log.Printf("extract: session %s: link %d->%d failed: %v", sessionID, fact.ID, r.Fact.ID, err)
+				continue
+			}
+			count++
+			if count >= 3 {
+				break
+			}
+		}
+		linked += count
+	}
+	return linked
 }
 
 // generateHints runs Searcher, Scorer, then Synthesizer sequentially,

--- a/httpapi/extractqueue.go
+++ b/httpapi/extractqueue.go
@@ -268,33 +268,44 @@ func (q *ExtractQueue) processJob(job extractJob) {
 
 	// 5. A-MEM linking: link each new fact to related existing facts.
 	linked := 0
-	for _, fact := range result.Inserted {
-		neighbors, err := q.store.Search(ctx, fact.Content, memstore.SearchOpts{
+	if len(result.Inserted) > 0 {
+		contents := make([]string, len(result.Inserted))
+		for i, f := range result.Inserted {
+			contents[i] = f.Content
+		}
+		neighborSets, err := q.store.SearchBatch(ctx, contents, memstore.SearchOpts{
 			Subject:    projectName,
 			MaxResults: 4,
 			OnlyActive: true,
 		})
 		if err != nil {
-			continue
+			log.Printf("extract: session %s: link search failed: %v", job.SessionID, err)
+			// skip linking stage
+		} else {
+			for i, fact := range result.Inserted {
+				if i >= len(neighborSets) {
+					break
+				}
+				count := 0
+				for _, r := range neighborSets[i] {
+					if r.Fact.ID == fact.ID {
+						continue
+					}
+					if r.VecScore < 0.6 {
+						continue
+					}
+					if _, err := q.store.LinkFacts(ctx, fact.ID, r.Fact.ID, "related", true, "", nil); err != nil {
+						log.Printf("extract: session %s: link %d->%d failed: %v", job.SessionID, fact.ID, r.Fact.ID, err)
+						continue
+					}
+					count++
+					if count >= 3 {
+						break
+					}
+				}
+				linked += count
+			}
 		}
-		count := 0
-		for _, r := range neighbors {
-			if r.Fact.ID == fact.ID {
-				continue
-			}
-			if r.VecScore < 0.6 {
-				continue
-			}
-			if _, err := q.store.LinkFacts(ctx, fact.ID, r.Fact.ID, "related", true, "", nil); err != nil {
-				log.Printf("extract: session %s: link %d->%d failed: %v", job.SessionID, fact.ID, r.Fact.ID, err)
-				continue
-			}
-			count++
-			if count >= 3 {
-				break
-			}
-		}
-		linked += count
 	}
 
 	errCount := len(result.Errors)

--- a/httpapi/extractqueue_test.go
+++ b/httpapi/extractqueue_test.go
@@ -1098,3 +1098,196 @@ func TestBackfillFeedback_NoBackfillRater(t *testing.T) {
 		t.Fatal("expected error for non-backfill rater")
 	}
 }
+
+// --- A-MEM linking stage unit tests ---
+
+// linkingFakeStore is a Store stub for the A-MEM linking tests.
+// It implements SearchBatch and LinkFacts; all other Store methods panic via
+// the embedded interface.
+type linkingFakeStore struct {
+	memstore.Store
+	// neighborSets[i] is returned for the i-th query in SearchBatch.
+	neighborSets [][]memstore.SearchResult
+	// searchBatchErr, if non-nil, is returned by SearchBatch.
+	searchBatchErr error
+	// links records (sourceID, targetID) pairs from LinkFacts calls.
+	links [][2]int64
+}
+
+func (s *linkingFakeStore) SearchBatch(_ context.Context, queries []string, _ memstore.SearchOpts) ([][]memstore.SearchResult, error) {
+	if s.searchBatchErr != nil {
+		return nil, s.searchBatchErr
+	}
+	result := make([][]memstore.SearchResult, len(queries))
+	for i := range queries {
+		if i < len(s.neighborSets) {
+			result[i] = s.neighborSets[i]
+		}
+	}
+	return result, nil
+}
+
+func (s *linkingFakeStore) LinkFacts(_ context.Context, sourceID, targetID int64, _ string, _ bool, _ string, _ map[string]any) (int64, error) {
+	s.links = append(s.links, [2]int64{sourceID, targetID})
+	return int64(len(s.links)), nil
+}
+
+// runLinkBlock reproduces the A-MEM linking block from processJob so tests
+// can exercise it without constructing a full ExtractQueue.
+func runLinkBlock(ctx context.Context, store *linkingFakeStore, inserted []memstore.Fact, projectName string) (linked int, err error) {
+	if len(inserted) == 0 {
+		return 0, nil
+	}
+	contents := make([]string, len(inserted))
+	for i, f := range inserted {
+		contents[i] = f.Content
+	}
+	neighborSets, searchErr := store.SearchBatch(ctx, contents, memstore.SearchOpts{
+		Subject:    projectName,
+		MaxResults: 4,
+		OnlyActive: true,
+	})
+	if searchErr != nil {
+		return 0, searchErr
+	}
+	for i, fact := range inserted {
+		if i >= len(neighborSets) {
+			break
+		}
+		count := 0
+		for _, r := range neighborSets[i] {
+			if r.Fact.ID == fact.ID {
+				continue
+			}
+			if r.VecScore < 0.6 {
+				continue
+			}
+			if _, linkErr := store.LinkFacts(ctx, fact.ID, r.Fact.ID, "related", true, "", nil); linkErr != nil {
+				continue
+			}
+			count++
+			if count >= 3 {
+				break
+			}
+		}
+		linked += count
+	}
+	return linked, nil
+}
+
+// TestAMEMLinking_LinksCreatedAfterBatch verifies that links are created for
+// all inserted facts using the batched SearchBatch path.
+func TestAMEMLinking_LinksCreatedAfterBatch(t *testing.T) {
+	ctx := context.Background()
+
+	fact1 := memstore.Fact{ID: 1, Content: "alpha fact"}
+	fact2 := memstore.Fact{ID: 2, Content: "beta fact"}
+	neighbor := memstore.Fact{ID: 99, Content: "related existing fact"}
+
+	store := &linkingFakeStore{
+		neighborSets: [][]memstore.SearchResult{
+			{{Fact: neighbor, VecScore: 0.75}},
+			{{Fact: neighbor, VecScore: 0.80}},
+		},
+	}
+
+	linked, err := runLinkBlock(ctx, store, []memstore.Fact{fact1, fact2}, "memstore")
+	if err != nil {
+		t.Fatalf("runLinkBlock: %v", err)
+	}
+	if linked != 2 {
+		t.Errorf("linked = %d, want 2", linked)
+	}
+	if len(store.links) != 2 {
+		t.Errorf("link records = %d, want 2", len(store.links))
+	}
+	// Neither fact should link to itself.
+	for _, link := range store.links {
+		if link[0] == link[1] {
+			t.Errorf("self-link detected: %d -> %d", link[0], link[1])
+		}
+	}
+}
+
+// TestAMEMLinking_SearchBatchFailSkipsLinking verifies that a SearchBatch error
+// causes the linking stage to be skipped without panicking.
+func TestAMEMLinking_SearchBatchFailSkipsLinking(t *testing.T) {
+	ctx := context.Background()
+
+	store := &linkingFakeStore{
+		searchBatchErr: fmt.Errorf("embedder offline"),
+	}
+
+	linked, err := runLinkBlock(ctx, store, []memstore.Fact{{ID: 1, Content: "some fact"}}, "memstore")
+	if err == nil {
+		t.Error("expected error from SearchBatch failure")
+	}
+	if linked != 0 {
+		t.Errorf("linked = %d, want 0 when SearchBatch fails", linked)
+	}
+	if len(store.links) != 0 {
+		t.Errorf("link records = %d, want 0 when SearchBatch fails", len(store.links))
+	}
+}
+
+// TestAMEMLinking_VecScoreFilter verifies that neighbors below the 0.6
+// threshold are not linked.
+func TestAMEMLinking_VecScoreFilter(t *testing.T) {
+	ctx := context.Background()
+
+	fact := memstore.Fact{ID: 1, Content: "some fact"}
+	lowScore := memstore.Fact{ID: 10, Content: "loosely related"}
+	highScore := memstore.Fact{ID: 11, Content: "closely related"}
+
+	store := &linkingFakeStore{
+		neighborSets: [][]memstore.SearchResult{
+			{
+				{Fact: lowScore, VecScore: 0.55},  // below threshold -- skip
+				{Fact: highScore, VecScore: 0.70}, // above threshold -- link
+			},
+		},
+	}
+
+	linked, err := runLinkBlock(ctx, store, []memstore.Fact{fact}, "test")
+	if err != nil {
+		t.Fatalf("runLinkBlock: %v", err)
+	}
+	if linked != 1 {
+		t.Errorf("linked = %d, want 1 (only high-score neighbor)", linked)
+	}
+	if len(store.links) != 1 {
+		t.Fatalf("link records = %d, want 1", len(store.links))
+	}
+	if store.links[0][1] != highScore.ID {
+		t.Errorf("linked to %d, want %d", store.links[0][1], highScore.ID)
+	}
+}
+
+// TestAMEMLinking_CapThreeLinksPerFact verifies that a fact creates at most 3
+// links even when more than 3 qualifying neighbors are available.
+func TestAMEMLinking_CapThreeLinksPerFact(t *testing.T) {
+	ctx := context.Background()
+
+	fact := memstore.Fact{ID: 1, Content: "the fact"}
+	neighbors := []memstore.SearchResult{
+		{Fact: memstore.Fact{ID: 10}, VecScore: 0.9},
+		{Fact: memstore.Fact{ID: 11}, VecScore: 0.85},
+		{Fact: memstore.Fact{ID: 12}, VecScore: 0.80},
+		{Fact: memstore.Fact{ID: 13}, VecScore: 0.75}, // fourth -- should be skipped
+	}
+
+	store := &linkingFakeStore{
+		neighborSets: [][]memstore.SearchResult{neighbors},
+	}
+
+	linked, err := runLinkBlock(ctx, store, []memstore.Fact{fact}, "test")
+	if err != nil {
+		t.Fatalf("runLinkBlock: %v", err)
+	}
+	if linked != 3 {
+		t.Errorf("linked = %d, want 3 (cap at 3 per fact)", linked)
+	}
+	if len(store.links) != 3 {
+		t.Errorf("link records = %d, want 3", len(store.links))
+	}
+}

--- a/httpapi/extractqueue_test.go
+++ b/httpapi/extractqueue_test.go
@@ -1132,49 +1132,6 @@ func (s *linkingFakeStore) LinkFacts(_ context.Context, sourceID, targetID int64
 	return int64(len(s.links)), nil
 }
 
-// runLinkBlock reproduces the A-MEM linking block from processJob so tests
-// can exercise it without constructing a full ExtractQueue.
-func runLinkBlock(ctx context.Context, store *linkingFakeStore, inserted []memstore.Fact, projectName string) (linked int, err error) {
-	if len(inserted) == 0 {
-		return 0, nil
-	}
-	contents := make([]string, len(inserted))
-	for i, f := range inserted {
-		contents[i] = f.Content
-	}
-	neighborSets, searchErr := store.SearchBatch(ctx, contents, memstore.SearchOpts{
-		Subject:    projectName,
-		MaxResults: 4,
-		OnlyActive: true,
-	})
-	if searchErr != nil {
-		return 0, searchErr
-	}
-	for i, fact := range inserted {
-		if i >= len(neighborSets) {
-			break
-		}
-		count := 0
-		for _, r := range neighborSets[i] {
-			if r.Fact.ID == fact.ID {
-				continue
-			}
-			if r.VecScore < 0.6 {
-				continue
-			}
-			if _, linkErr := store.LinkFacts(ctx, fact.ID, r.Fact.ID, "related", true, "", nil); linkErr != nil {
-				continue
-			}
-			count++
-			if count >= 3 {
-				break
-			}
-		}
-		linked += count
-	}
-	return linked, nil
-}
-
 // TestAMEMLinking_LinksCreatedAfterBatch verifies that links are created for
 // all inserted facts using the batched SearchBatch path.
 func TestAMEMLinking_LinksCreatedAfterBatch(t *testing.T) {
@@ -1190,11 +1147,9 @@ func TestAMEMLinking_LinksCreatedAfterBatch(t *testing.T) {
 			{{Fact: neighbor, VecScore: 0.80}},
 		},
 	}
+	q := &ExtractQueue{store: store}
 
-	linked, err := runLinkBlock(ctx, store, []memstore.Fact{fact1, fact2}, "memstore")
-	if err != nil {
-		t.Fatalf("runLinkBlock: %v", err)
-	}
+	linked := q.linkInserted(ctx, "sess-link", "memstore", []memstore.Fact{fact1, fact2})
 	if linked != 2 {
 		t.Errorf("linked = %d, want 2", linked)
 	}
@@ -1217,11 +1172,9 @@ func TestAMEMLinking_SearchBatchFailSkipsLinking(t *testing.T) {
 	store := &linkingFakeStore{
 		searchBatchErr: fmt.Errorf("embedder offline"),
 	}
+	q := &ExtractQueue{store: store}
 
-	linked, err := runLinkBlock(ctx, store, []memstore.Fact{{ID: 1, Content: "some fact"}}, "memstore")
-	if err == nil {
-		t.Error("expected error from SearchBatch failure")
-	}
+	linked := q.linkInserted(ctx, "sess-fail", "memstore", []memstore.Fact{{ID: 1, Content: "some fact"}})
 	if linked != 0 {
 		t.Errorf("linked = %d, want 0 when SearchBatch fails", linked)
 	}
@@ -1247,11 +1200,9 @@ func TestAMEMLinking_VecScoreFilter(t *testing.T) {
 			},
 		},
 	}
+	q := &ExtractQueue{store: store}
 
-	linked, err := runLinkBlock(ctx, store, []memstore.Fact{fact}, "test")
-	if err != nil {
-		t.Fatalf("runLinkBlock: %v", err)
-	}
+	linked := q.linkInserted(ctx, "sess-vec", "test", []memstore.Fact{fact})
 	if linked != 1 {
 		t.Errorf("linked = %d, want 1 (only high-score neighbor)", linked)
 	}
@@ -1279,11 +1230,9 @@ func TestAMEMLinking_CapThreeLinksPerFact(t *testing.T) {
 	store := &linkingFakeStore{
 		neighborSets: [][]memstore.SearchResult{neighbors},
 	}
+	q := &ExtractQueue{store: store}
 
-	linked, err := runLinkBlock(ctx, store, []memstore.Fact{fact}, "test")
-	if err != nil {
-		t.Fatalf("runLinkBlock: %v", err)
-	}
+	linked := q.linkInserted(ctx, "sess-cap", "test", []memstore.Fact{fact})
 	if linked != 3 {
 		t.Errorf("linked = %d, want 3 (cap at 3 per fact)", linked)
 	}


### PR DESCRIPTION
Extracting N facts made ~3N serial embedding HTTP calls, all embedding strings the pipeline had already embedded: one embedding.Single per fact, a re-embed inside trySupersedeExisting's Search, and a third inside the A-MEM linking loop. A 40-fact session paid ~120 round-trips of queue latency before hints and next-session context were ready.

Extract now runs in four phases -- resolve/dedup, one batch embed, insert, then supersession via one SearchBatch per distinct subject -- and the A-MEM linking stage uses a single SearchBatch (factored into linkInserted so tests exercise the real method). Roughly 3 batched calls total instead of 3N.

Two semantics deliberately preserved from the old sequential loop: in-batch duplicates are still counted (a seen-set replaces what Exists used to catch after the first insert), and supersession candidates exclude later batch-mates plus anything already superseded in the run -- so two near-duplicate facts in one batch chain (A->B->C) instead of forming an A->B->A cycle. New tests pin the call count (2 embedder calls for a 3-fact extraction), in-batch dedup, the no-cycle chain, batch-embed failure, and all four linking behaviors.

Deferred follow-up (noted in the plan): a search-by-vector Store capability would eliminate the remaining re-embeds by reusing the phase-B vectors.

Plan: plans/007-batch-extraction-embedding.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)