### PR TITLE
Identity schema: memstore_users, fact/link/token ownership, backfill (v0.4.0 phase 1)

### DIFF
--- a/cmd/memstore/admin_cmd.go
+++ b/cmd/memstore/admin_cmd.go
@@ -15,7 +15,7 @@ import (
 )
 
 // runAdmin dispatches `memstore admin <subcommand>`. All admin commands
-// connect directly to PostgreSQL — they're intended to be run on the daemon
+// connect directly to PostgreSQL -- they're intended to be run on the daemon
 // host, not against the HTTP API.
 func runAdmin(args []string) {
 	if len(args) == 0 {
@@ -23,6 +23,8 @@ func runAdmin(args []string) {
 		os.Exit(1)
 	}
 	switch args[0] {
+	case "tier3-init":
+		runTier3Init(args[1:], os.Stdout)
 	case "issue-token":
 		runIssueToken(args[1:], os.Stdout)
 	case "list-tokens":
@@ -42,6 +44,7 @@ func printAdminUsage(w io.Writer) {
 	fmt.Fprintln(w, `Usage: memstore admin <subcommand> [flags]
 
 Subcommands:
+  tier3-init              Seed the identity schema for a namespace (creates default user, records meta).
   issue-token <name>      Mint a new bearer token. Prints the token ONCE; not retrievable later.
   list-tokens             List all active tokens (name, scopes, created, last used). Token values are not stored.
   revoke-token <name>     Revoke all active tokens with the given name.
@@ -50,7 +53,7 @@ Subcommands:
 All admin commands connect directly to PostgreSQL. Set --pg or MEMSTORE_PG.`)
 }
 
-func openTokenStore(pgFlag string) (*pgstore.TokenStore, func(), error) {
+func openPool(pgFlag string) (*pgxpool.Pool, func(), error) {
 	dsn := pgFlag
 	if dsn == "" {
 		dsn = cliConfig.PG
@@ -63,12 +66,47 @@ func openTokenStore(pgFlag string) (*pgstore.TokenStore, func(), error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("connect: %w", err)
 	}
-	ts, err := pgstore.NewTokenStore(ctx, pool)
+	return pool, func() { pool.Close() }, nil
+}
+
+func openTokenStore(pgFlag string) (*pgstore.TokenStore, func(), error) {
+	pool, closePool, err := openPool(pgFlag)
 	if err != nil {
-		pool.Close()
 		return nil, nil, err
 	}
-	return ts, func() { pool.Close() }, nil
+	ctx := context.Background()
+	ts, err := pgstore.NewTokenStore(ctx, pool)
+	if err != nil {
+		closePool()
+		return nil, nil, err
+	}
+	return ts, closePool, nil
+}
+
+// --- tier3-init ---
+
+func runTier3Init(args []string, out io.Writer) {
+	fs := flag.NewFlagSet("tier3-init", flag.ExitOnError)
+	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG / config)")
+	defaultUser := fs.String("default-user", "", "Name to seed as the default user (required)")
+	namespace := fs.String("namespace", "", "Namespace to initialize (default: empty string for single-tenant)")
+	fs.Parse(args)
+
+	if *defaultUser == "" {
+		fmt.Fprintln(os.Stderr, "tier3-init: --default-user is required")
+		os.Exit(1)
+	}
+
+	pool, closePool, err := openPool(*pgDSN)
+	if err != nil {
+		fail(err)
+	}
+	defer closePool()
+
+	if err := pgstore.InitIdentity(context.Background(), pool, *namespace, *defaultUser); err != nil {
+		fail(err)
+	}
+	fmt.Fprintf(out, "Identity initialized: namespace=%q default-user=%q\n", *namespace, *defaultUser)
 }
 
 // --- issue-token ---
@@ -78,13 +116,37 @@ func runIssueToken(args []string, out io.Writer) {
 	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG / config)")
 	scopes := fs.String("scopes", "", "comma-separated scopes (e.g. read,write,admin)")
 	expires := fs.Duration("expires", 0, "token lifetime, e.g. 90d, 720h. 0 = no expiry")
+	userName := fs.String("user", "", "user name to bind the token to (required; must exist in memstore_users)")
+	namespace := fs.String("namespace", "", "namespace to look up the user in (default: empty string for single-tenant)")
 	fs.Parse(args)
 
 	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "issue-token: expected exactly one positional argument <name>")
+		fmt.Fprintln(os.Stderr, "issue-token: expected exactly one positional argument <name> (format: <user>@<host>)")
 		os.Exit(1)
 	}
 	name := fs.Arg(0)
+
+	if *userName == "" {
+		fmt.Fprintln(os.Stderr, "issue-token: --user is required")
+		os.Exit(1)
+	}
+
+	pool, closePool, err := openPool(*pgDSN)
+	if err != nil {
+		fail(err)
+	}
+	defer closePool()
+
+	ctx := context.Background()
+
+	// Resolve user_id from memstore_users.
+	var userID int64
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM memstore_users WHERE namespace = $1 AND name = $2`,
+		*namespace, *userName,
+	).Scan(&userID); err != nil {
+		fail(fmt.Errorf("user %q not found in namespace %q: %w\nRun 'memstore admin tier3-init --default-user %s' to create it", *userName, *namespace, err, *userName))
+	}
 
 	ts, closeStore, err := openTokenStore(*pgDSN)
 	if err != nil {
@@ -92,7 +154,8 @@ func runIssueToken(args []string, out io.Writer) {
 	}
 	defer closeStore()
 
-	tok, err := ts.Issue(context.Background(), name, pgstore.IssueOpts{
+	tok, err := ts.Issue(ctx, name, pgstore.IssueOpts{
+		UserID:  userID,
 		Scopes:  splitCSV(*scopes),
 		Expires: *expires,
 	})
@@ -100,8 +163,9 @@ func runIssueToken(args []string, out io.Writer) {
 		fail(err)
 	}
 
-	fmt.Fprintln(out, "Token issued. Capture it now — it cannot be retrieved later.")
+	fmt.Fprintln(out, "Token issued. Capture it now -- it cannot be retrieved later.")
 	fmt.Fprintf(out, "  name:  %s\n", name)
+	fmt.Fprintf(out, "  user:  %s\n", *userName)
 	if *scopes != "" {
 		fmt.Fprintf(out, "  scopes: %s\n", *scopes)
 	}

--- a/cmd/memstored/main_test.go
+++ b/cmd/memstored/main_test.go
@@ -19,6 +19,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/matthewjhunter/memstore/pgstore"
 )
 
 // startDaemon launches run() in a goroutine and returns the bound address plus
@@ -183,6 +187,27 @@ func testDSN(t *testing.T) string {
 	return dsn
 }
 
+// seedIdentity prepares the database so the daemon can start: store
+// construction requires a recorded default user (see pgstore.InitIdentity).
+// The first pgstore.New on a virgin database migrates the schema and then
+// fails at user resolution; that failure is expected and the migration is
+// committed before it.
+func seedIdentity(t *testing.T, dsn, namespace string) {
+	t.Helper()
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	defer pool.Close()
+	if _, err := pgstore.New(ctx, pool, nil, namespace, 768, 512); err != nil && !strings.Contains(err.Error(), "tier3-init") {
+		t.Fatalf("pgstore.New (schema init): %v", err)
+	}
+	if err := pgstore.InitIdentity(ctx, pool, namespace, "testuser"); err != nil {
+		t.Fatalf("InitIdentity: %v", err)
+	}
+}
+
 // commonArgs returns the minimal flag set needed to boot the daemon against
 // the test PostgreSQL on an ephemeral port. Each test uses a unique namespace
 // so concurrent runs don't see each other's data.
@@ -190,10 +215,13 @@ func commonArgs(t *testing.T) []string {
 	t.Helper()
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // ignore any user config
 	t.Setenv("XDG_DATA_HOME", t.TempDir())   // isolate any defaults
+	dsn := testDSN(t)
+	ns := "test-" + t.Name()
+	seedIdentity(t, dsn, ns)
 	return []string{
 		"--addr", "127.0.0.1:0",
-		"--pg", testDSN(t),
-		"--namespace", "test-" + t.Name(),
+		"--pg", dsn,
+		"--namespace", ns,
 		"--vec-dim", "768",
 		"--ollama", "http://127.0.0.1:1", // never actually called in these tests
 	}

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -139,6 +139,31 @@ func testInsertGetRoundTrip(t *testing.T, s memstore.Store) {
 		t.Fatal("Metadata is nil")
 	}
 
+	// UserID must be non-zero: the store resolves an identity at construction.
+	if got.UserID == 0 {
+		t.Error("UserID is 0; store must assign a non-zero user identity on insert")
+	}
+
+	// A second fact inserted via the same store must share the same UserID.
+	id2, err := s.Insert(ctx, memstore.Fact{
+		Content:  "second conformance fact",
+		Subject:  "conformance",
+		Category: "test",
+	})
+	if err != nil {
+		t.Fatalf("Insert second fact: %v", err)
+	}
+	got2, err := s.Get(ctx, id2)
+	if err != nil {
+		t.Fatalf("Get second fact: %v", err)
+	}
+	if got2 == nil {
+		t.Fatal("Get second fact returned nil")
+	}
+	if got2.UserID != got.UserID {
+		t.Errorf("second fact UserID = %d, want same as first (%d)", got2.UserID, got.UserID)
+	}
+
 	// Compare metadata by value, not raw bytes -- SQLite stores TEXT, Postgres
 	// JSONB, so key order may differ.
 	var gotMeta, wantMeta map[string]any

--- a/pgstore/search.go
+++ b/pgstore/search.go
@@ -124,7 +124,7 @@ func (s *PostgresStore) searchFTS(ctx context.Context, query string, opts memsto
 	}
 
 	var b queryBuilder
-	b.write(`SELECT f.id, f.namespace, f.content, f.subject, f.category, f.kind, f.subsystem, f.metadata,
+	b.write(`SELECT f.id, f.namespace, f.user_id, f.content, f.subject, f.category, f.kind, f.subsystem, f.metadata,
 	                f.superseded_by, f.superseded_at, f.confirmed_count, f.last_confirmed_at,
 	                f.use_count, f.last_used_at, f.embedding, f.created_at,
 	                ts_rank(f.fts, plainto_tsquery('english', `, tsquery)
@@ -175,7 +175,7 @@ func (s *PostgresStore) searchFTS(ctx context.Context, query string, opts memsto
 		var rank float64
 
 		err := rows.Scan(
-			&f.ID, &f.Namespace, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
+			&f.ID, &f.Namespace, &f.UserID, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
 			&metadata, &supersededBy, &supersededAt,
 			&f.ConfirmedCount, &lastConfirmedAt,
 			&f.UseCount, &lastUsedAt,

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -16,20 +16,21 @@ import (
 	pgvector "github.com/pgvector/pgvector-go"
 )
 
-const schemaVersion = 3
+const schemaVersion = 4
 
 // factColumns is the canonical SELECT list for fact queries.
 // searchFTS has its own column list because it joins and adds ts_rank.
-const factColumns = `id, namespace, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, embedding, created_at`
+const factColumns = `id, namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, embedding, created_at`
 
 // PostgresStore implements memstore.Store backed by PostgreSQL.
 // It uses pgvector for vector similarity search and tsvector with GIN
-// indexing for full-text search. No mutex is needed — Postgres handles
+// indexing for full-text search. No mutex is needed -- Postgres handles
 // concurrency natively via MVCC.
 type PostgresStore struct {
 	pool       *pgxpool.Pool
 	embedder   embedding.Embedder
 	namespace  string
+	userID     int64                 // resolved owner for this store; set after migrateV4
 	vecDim     int                   // embedding dimension, set at construction or first embed
 	queryCache *embedding.QueryCache // caches query embeddings on the search path; nil if disabled
 	reranker   embedding.Reranker    // nil means no second-stage rerank; set via SetReranker
@@ -61,12 +62,80 @@ func New(ctx context.Context, pool *pgxpool.Pool, embedder embedding.Embedder, n
 	if err := s.migrate(ctx); err != nil {
 		return nil, fmt.Errorf("pgstore: migration: %w", err)
 	}
+	// Resolve the owning user from memstore_meta['default_user'].
+	// migrateV4 must have recorded it; if not, the operator needs to run
+	// 'memstore admin tier3-init --default-user <name>' first.
+	uid, err := s.resolveUser(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: resolving user: %w", err)
+	}
+	s.userID = uid
 	if embedder != nil {
 		if err := s.validateEmbedder(ctx); err != nil {
 			return nil, err
 		}
 	}
 	return s, nil
+}
+
+// resolveUser reads the default_user from memstore_meta and looks up its
+// user_id in memstore_users. Returns 0 without error if the schema is at V4
+// but memstore_users is empty (fresh DB with no facts; the next insert will
+// still fail without a user, but migration didn't create one for empty DBs).
+// Returns an error if default_user is recorded but has no matching row.
+func (s *PostgresStore) resolveUser(ctx context.Context) (int64, error) {
+	var name string
+	err := s.pool.QueryRow(ctx, `SELECT value FROM memstore_meta WHERE key = 'default_user'`).Scan(&name)
+	if err == pgx.ErrNoRows {
+		// Fresh DB: no default_user recorded. The schema has the users table but
+		// no rows yet. Return 0; caller must create a user before inserting.
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("reading default_user: %w", err)
+	}
+	if name == "" {
+		return 0, fmt.Errorf("default_user meta is empty -- run 'memstore admin tier3-init --default-user <name>' to repair")
+	}
+
+	var id int64
+	err = s.pool.QueryRow(ctx,
+		`SELECT id FROM memstore_users WHERE namespace = $1 AND name = $2`,
+		s.namespace, name,
+	).Scan(&id)
+	if err == pgx.ErrNoRows {
+		return 0, fmt.Errorf("user %q not found in memstore_users for namespace %q -- run 'memstore admin tier3-init --default-user %s'", name, s.namespace, name)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("looking up user %q: %w", name, err)
+	}
+	return id, nil
+}
+
+// InitIdentity seeds the identity schema for a namespace that has no default
+// user yet. It is idempotent: if the user row and meta entry already exist
+// they are not modified. This is the implementation behind
+// 'memstore admin tier3-init --default-user <name>'.
+func InitIdentity(ctx context.Context, pool *pgxpool.Pool, namespace, defaultUser string) error {
+	if defaultUser == "" {
+		return fmt.Errorf("pgstore: InitIdentity: default-user must not be empty")
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO memstore_users (namespace, name)
+		 VALUES ($1, $2)
+		 ON CONFLICT (namespace, name) DO NOTHING`,
+		namespace, defaultUser,
+	); err != nil {
+		return fmt.Errorf("pgstore: InitIdentity: creating user %q: %w", defaultUser, err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO memstore_meta (key, value) VALUES ('default_user', $1)
+		 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+		defaultUser,
+	); err != nil {
+		return fmt.Errorf("pgstore: InitIdentity: recording default_user: %w", err)
+	}
+	return nil
 }
 
 func (s *PostgresStore) migrate(ctx context.Context) error {
@@ -106,6 +175,12 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 
 	if version < 3 {
 		if err := s.migrateV3(ctx); err != nil {
+			return err
+		}
+	}
+
+	if version < 4 {
+		if err := s.migrateV4(ctx); err != nil {
 			return err
 		}
 	}
@@ -224,6 +299,184 @@ func (s *PostgresStore) migrateV3(ctx context.Context) error {
 	return nil
 }
 
+// migrateV4 introduces first-class user identity (Phase 0 of tier-3 permissions).
+// It creates memstore_users, adds user_id to facts and links, backfills, rewrites
+// subject for ownership-only usages, and enforces NOT NULL + FK after backfill.
+//
+// Default user inference (pgstore, multi-user capable):
+//   - Parse all non-legacy api_tokens names on the first hyphen.
+//   - Unanimous prefix (e.g. all "matthew-*") -> that user is the default.
+//   - No non-legacy tokens (only "legacy" or empty table) -> fresh-DB path:
+//     schema migrated with no user rows, no error. Operator must call
+//     InitIdentity before starting the daemon.
+//   - Ambiguous prefixes (multiple distinct users) -> hard error pointing
+//     at 'memstore admin tier3-init --default-user <name>'.
+func (s *PostgresStore) migrateV4(ctx context.Context) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("pgstore V4 migration: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// 1. Create users table.
+	if _, err := tx.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS memstore_users (
+			id         BIGSERIAL   PRIMARY KEY,
+			namespace  TEXT        NOT NULL,
+			name       TEXT        NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			UNIQUE (namespace, name)
+		)`); err != nil {
+		return fmt.Errorf("pgstore V4 migration: create memstore_users: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_memstore_users_namespace ON memstore_users (namespace)`); err != nil {
+		return fmt.Errorf("pgstore V4 migration: create users index: %w", err)
+	}
+
+	// 2. Infer default user from api_tokens (if table exists).
+	var tokensExist bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'api_tokens')`,
+	).Scan(&tokensExist); err != nil {
+		return fmt.Errorf("pgstore V4 migration: checking api_tokens: %w", err)
+	}
+
+	var factsExist bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM memstore_facts LIMIT 1)`,
+	).Scan(&factsExist); err != nil {
+		return fmt.Errorf("pgstore V4 migration: checking memstore_facts: %w", err)
+	}
+
+	defaultUser := ""
+	if tokensExist {
+		// Collect non-legacy token name prefixes (split on first hyphen).
+		rows, err := tx.Query(ctx, `SELECT name FROM api_tokens WHERE name <> 'legacy' AND revoked_at IS NULL`)
+		if err != nil {
+			return fmt.Errorf("pgstore V4 migration: querying tokens: %w", err)
+		}
+		prefixes := map[string]struct{}{}
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err != nil {
+				rows.Close()
+				return fmt.Errorf("pgstore V4 migration: scanning token: %w", err)
+			}
+			if idx := strings.IndexByte(name, '-'); idx > 0 {
+				prefixes[name[:idx]] = struct{}{}
+			}
+			// names without a hyphen: skip (operator will handle via tier3-init)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("pgstore V4 migration: iterating tokens: %w", err)
+		}
+
+		switch len(prefixes) {
+		case 0:
+			// Only legacy token or empty table: fresh/legacy-only DB.
+			// If facts also empty, proceed with no default user.
+			if factsExist {
+				return fmt.Errorf("pgstore V4 migration: cannot infer default user (no non-legacy tokens but facts exist). Run 'memstore admin tier3-init --default-user <name>' before starting memstored")
+			}
+			// Fresh DB: migrate schema with no user rows.
+		case 1:
+			for p := range prefixes {
+				defaultUser = p
+			}
+		default:
+			names := make([]string, 0, len(prefixes))
+			for p := range prefixes {
+				names = append(names, p)
+			}
+			return fmt.Errorf("pgstore V4 migration: ambiguous token prefixes %v -- run 'memstore admin tier3-init --default-user <name>' before starting memstored", names)
+		}
+	}
+
+	// 3. Add user_id columns (nullable first for backfill).
+	if _, err := tx.Exec(ctx, `ALTER TABLE memstore_facts ADD COLUMN IF NOT EXISTS user_id BIGINT`); err != nil {
+		return fmt.Errorf("pgstore V4 migration: add facts.user_id: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `ALTER TABLE memstore_links ADD COLUMN IF NOT EXISTS user_id BIGINT`); err != nil {
+		return fmt.Errorf("pgstore V4 migration: add links.user_id: %w", err)
+	}
+
+	if defaultUser != "" {
+		// 4. Seed user row.
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO memstore_users (namespace, name)
+			 VALUES ($1, $2)
+			 ON CONFLICT (namespace, name) DO NOTHING`,
+			s.namespace, defaultUser,
+		); err != nil {
+			return fmt.Errorf("pgstore V4 migration: insert user %q: %w", defaultUser, err)
+		}
+
+		var uid int64
+		if err := tx.QueryRow(ctx,
+			`SELECT id FROM memstore_users WHERE namespace = $1 AND name = $2`,
+			s.namespace, defaultUser,
+		).Scan(&uid); err != nil {
+			return fmt.Errorf("pgstore V4 migration: resolve user %q: %w", defaultUser, err)
+		}
+
+		// 5. Backfill facts and links.
+		if _, err := tx.Exec(ctx,
+			`UPDATE memstore_facts SET user_id = $1 WHERE namespace = $2 AND user_id IS NULL`,
+			uid, s.namespace,
+		); err != nil {
+			return fmt.Errorf("pgstore V4 migration: backfill facts: %w", err)
+		}
+		if _, err := tx.Exec(ctx,
+			`UPDATE memstore_links SET user_id = $1 WHERE namespace = $2 AND user_id IS NULL`,
+			uid, s.namespace,
+		); err != nil {
+			return fmt.Errorf("pgstore V4 migration: backfill links: %w", err)
+		}
+
+		// 6. Subject rewrite: free subject from ownership role for non-identity/preference facts.
+		if _, err := tx.Exec(ctx,
+			`UPDATE memstore_facts SET subject = NULL
+			 WHERE namespace = $1 AND subject = $2
+			   AND category NOT IN ('identity', 'preference')`,
+			s.namespace, defaultUser,
+		); err != nil {
+			return fmt.Errorf("pgstore V4 migration: subject rewrite: %w", err)
+		}
+
+		// 7. Enforce NOT NULL + FK on facts now that backfill is complete.
+		if _, err := tx.Exec(ctx, `
+			ALTER TABLE memstore_facts
+				ALTER COLUMN user_id SET NOT NULL,
+				ADD CONSTRAINT memstore_facts_user_id_fkey
+					FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT,
+				ALTER COLUMN subject DROP NOT NULL`); err != nil {
+			return fmt.Errorf("pgstore V4 migration: enforce facts constraints: %w", err)
+		}
+
+		// Indexes on facts for user-scoped queries.
+		for _, idx := range []string{
+			`CREATE INDEX IF NOT EXISTS idx_memstore_facts_user ON memstore_facts (namespace, user_id)`,
+			`CREATE INDEX IF NOT EXISTS idx_memstore_facts_user_subj ON memstore_facts (namespace, user_id, subject)`,
+		} {
+			if _, err := tx.Exec(ctx, idx); err != nil {
+				return fmt.Errorf("pgstore V4 migration: create facts user index: %w", err)
+			}
+		}
+
+		// 8. Record default_user for subsequent opens.
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO memstore_meta (key, value) VALUES ('default_user', $1)
+			 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+			defaultUser,
+		); err != nil {
+			return fmt.Errorf("pgstore V4 migration: record default_user: %w", err)
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
 func (s *PostgresStore) validateEmbedder(ctx context.Context) error {
 	var stored string
 	err := s.pool.QueryRow(ctx, `SELECT value FROM memstore_meta WHERE key = 'embedding_model'`).Scan(&stored)
@@ -280,12 +533,17 @@ func (s *PostgresStore) Insert(ctx context.Context, f memstore.Fact) (int64, err
 		emb = &v
 	}
 
+	userID := s.userID
+	if f.UserID != 0 {
+		userID = f.UserID
+	}
+
 	var id int64
 	err := s.pool.QueryRow(ctx,
-		`INSERT INTO memstore_facts (namespace, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		`INSERT INTO memstore_facts (namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		 RETURNING id`,
-		s.namespace, f.Content, f.Subject, f.Category, f.Kind, f.Subsystem,
+		s.namespace, userID, f.Content, f.Subject, f.Category, f.Kind, f.Subsystem,
 		nullableJSON(f.Metadata), f.SupersededBy, emb, f.CreatedAt,
 	).Scan(&id)
 	if err != nil {
@@ -314,11 +572,16 @@ func (s *PostgresStore) InsertBatch(ctx context.Context, facts []memstore.Fact) 
 			emb = &v
 		}
 
+		userID := s.userID
+		if facts[i].UserID != 0 {
+			userID = facts[i].UserID
+		}
+
 		err := tx.QueryRow(ctx,
-			`INSERT INTO memstore_facts (namespace, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			`INSERT INTO memstore_facts (namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 			 RETURNING id`,
-			s.namespace, facts[i].Content, facts[i].Subject, facts[i].Category, facts[i].Kind, facts[i].Subsystem,
+			s.namespace, userID, facts[i].Content, facts[i].Subject, facts[i].Category, facts[i].Kind, facts[i].Subsystem,
 			nullableJSON(facts[i].Metadata), facts[i].SupersededBy, emb, facts[i].CreatedAt,
 		).Scan(&facts[i].ID)
 		if err != nil {
@@ -877,10 +1140,10 @@ func (s *PostgresStore) LinkFacts(ctx context.Context, sourceID, targetID int64,
 
 	var id int64
 	err := s.pool.QueryRow(ctx,
-		`INSERT INTO memstore_links (namespace, source_id, target_id, link_type, bidirectional, label, metadata, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		`INSERT INTO memstore_links (namespace, user_id, source_id, target_id, link_type, bidirectional, label, metadata, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		 RETURNING id`,
-		s.namespace, sourceID, targetID, linkType, bidirectional, label, nullableBytes(metaJSON), time.Now().UTC(),
+		s.namespace, s.userID, sourceID, targetID, linkType, bidirectional, label, nullableBytes(metaJSON), time.Now().UTC(),
 	).Scan(&id)
 	if err != nil {
 		return 0, fmt.Errorf("pgstore: creating link %d->%d: %w", sourceID, targetID, err)
@@ -1025,7 +1288,7 @@ func scanFact(row scanner) (*memstore.Fact, error) {
 	var emb *pgvector.Vector
 
 	err := row.Scan(
-		&f.ID, &f.Namespace, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
+		&f.ID, &f.Namespace, &f.UserID, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
 		&metadata, &supersededBy, &supersededAt,
 		&f.ConfirmedCount, &lastConfirmedAt,
 		&f.UseCount, &lastUsedAt,

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -78,64 +78,132 @@ func New(ctx context.Context, pool *pgxpool.Pool, embedder embedding.Embedder, n
 	return s, nil
 }
 
-// resolveUser reads the default_user from memstore_meta and looks up its
-// user_id in memstore_users. Returns 0 without error if the schema is at V4
-// but memstore_users is empty (fresh DB with no facts; the next insert will
-// still fail without a user, but migration didn't create one for empty DBs).
-// Returns an error if default_user is recorded but has no matching row.
+// resolveUser reads the default_user from memstore_meta and resolves or
+// creates the user row for the store's namespace. A namespace seen for the
+// first time gets a fresh row for the default user (a user belongs to
+// exactly one namespace, so each namespace carries its own row). It errors
+// only when no default_user is recorded at all -- the operator must run
+// 'memstore admin tier3-init --default-user <name>' once.
 func (s *PostgresStore) resolveUser(ctx context.Context) (int64, error) {
 	var name string
 	err := s.pool.QueryRow(ctx, `SELECT value FROM memstore_meta WHERE key = 'default_user'`).Scan(&name)
-	if err == pgx.ErrNoRows {
-		// Fresh DB: no default_user recorded. The schema has the users table but
-		// no rows yet. Return 0; caller must create a user before inserting.
-		return 0, nil
+	if err == pgx.ErrNoRows || (err == nil && name == "") {
+		return 0, fmt.Errorf("no default user recorded -- run 'memstore admin tier3-init --default-user <name>' before starting memstored")
 	}
 	if err != nil {
 		return 0, fmt.Errorf("reading default_user: %w", err)
 	}
-	if name == "" {
-		return 0, fmt.Errorf("default_user meta is empty -- run 'memstore admin tier3-init --default-user <name>' to repair")
-	}
 
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO memstore_users (namespace, name)
+		 VALUES ($1, $2)
+		 ON CONFLICT (namespace, name) DO NOTHING`,
+		s.namespace, name,
+	); err != nil {
+		return 0, fmt.Errorf("creating user %q for namespace %q: %w", name, s.namespace, err)
+	}
 	var id int64
-	err = s.pool.QueryRow(ctx,
+	if err := s.pool.QueryRow(ctx,
 		`SELECT id FROM memstore_users WHERE namespace = $1 AND name = $2`,
 		s.namespace, name,
-	).Scan(&id)
-	if err == pgx.ErrNoRows {
-		return 0, fmt.Errorf("user %q not found in memstore_users for namespace %q -- run 'memstore admin tier3-init --default-user %s'", name, s.namespace, name)
-	}
-	if err != nil {
+	).Scan(&id); err != nil {
 		return 0, fmt.Errorf("looking up user %q: %w", name, err)
 	}
 	return id, nil
 }
 
-// InitIdentity seeds the identity schema for a namespace that has no default
-// user yet. It is idempotent: if the user row and meta entry already exist
-// they are not modified. This is the implementation behind
+// InitIdentity seeds the identity schema with an operator-supplied default
+// user. This is the implementation behind
 // 'memstore admin tier3-init --default-user <name>'.
+//
+// Two cases:
+//   - Schema already at V4 (fresh DB whose migration took the no-user path):
+//     ensure the user row and the default_user meta key exist. Idempotent.
+//   - Schema below V4 (typically because migrateV4's inference failed and the
+//     whole transaction rolled back): run the full V4 work -- shared with
+//     migrateV4 via migrateV4As so the two paths cannot drift -- with the
+//     explicit user, and record schema version 4.
 func InitIdentity(ctx context.Context, pool *pgxpool.Pool, namespace, defaultUser string) error {
 	if defaultUser == "" {
 		return fmt.Errorf("pgstore: InitIdentity: default-user must not be empty")
 	}
-	if _, err := pool.Exec(ctx,
-		`INSERT INTO memstore_users (namespace, name)
-		 VALUES ($1, $2)
-		 ON CONFLICT (namespace, name) DO NOTHING`,
-		namespace, defaultUser,
-	); err != nil {
-		return fmt.Errorf("pgstore: InitIdentity: creating user %q: %w", defaultUser, err)
+
+	var versionTableExists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'memstore_version')`,
+	).Scan(&versionTableExists); err != nil {
+		return fmt.Errorf("pgstore: InitIdentity: checking memstore_version: %w", err)
 	}
-	if _, err := pool.Exec(ctx,
-		`INSERT INTO memstore_meta (key, value) VALUES ('default_user', $1)
-		 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
-		defaultUser,
-	); err != nil {
-		return fmt.Errorf("pgstore: InitIdentity: recording default_user: %w", err)
+	version := 0
+	hasVersionRow := false
+	if versionTableExists {
+		err := pool.QueryRow(ctx, `SELECT version FROM memstore_version`).Scan(&version)
+		switch {
+		case err == pgx.ErrNoRows:
+			version = 0
+		case err != nil:
+			return fmt.Errorf("pgstore: InitIdentity: reading schema version: %w", err)
+		default:
+			hasVersionRow = true
+		}
 	}
-	return nil
+
+	if version >= 4 {
+		// Idempotent path: the V4 schema is in place; only make sure the user
+		// row and meta key exist.
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO memstore_users (namespace, name)
+			 VALUES ($1, $2)
+			 ON CONFLICT (namespace, name) DO NOTHING`,
+			namespace, defaultUser,
+		); err != nil {
+			return fmt.Errorf("pgstore: InitIdentity: creating user %q: %w", defaultUser, err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO memstore_meta (key, value) VALUES ('default_user', $1)
+			 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+			defaultUser,
+		); err != nil {
+			return fmt.Errorf("pgstore: InitIdentity: recording default_user: %w", err)
+		}
+		return nil
+	}
+
+	if hasVersionRow && version < 3 {
+		return fmt.Errorf("pgstore: InitIdentity: schema is at version %d; open the store once to migrate to V3 first, then re-run tier3-init", version)
+	}
+	var factsTableExists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'memstore_facts')`,
+	).Scan(&factsTableExists); err != nil {
+		return fmt.Errorf("pgstore: InitIdentity: checking memstore_facts: %w", err)
+	}
+	if !factsTableExists {
+		return fmt.Errorf("pgstore: InitIdentity: base schema missing (memstore_facts not found); open the store once to create it, then re-run tier3-init")
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("pgstore: InitIdentity: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if err := migrateV4As(ctx, tx, namespace, defaultUser); err != nil {
+		return fmt.Errorf("pgstore: InitIdentity: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `CREATE TABLE IF NOT EXISTS memstore_version (version INTEGER NOT NULL)`); err != nil {
+		return fmt.Errorf("pgstore: InitIdentity: creating version table: %w", err)
+	}
+	if hasVersionRow {
+		_, err = tx.Exec(ctx, `UPDATE memstore_version SET version = 4`)
+	} else {
+		_, err = tx.Exec(ctx, `INSERT INTO memstore_version (version) VALUES (4)`)
+	}
+	if err != nil {
+		return fmt.Errorf("pgstore: InitIdentity: recording schema version: %w", err)
+	}
+	return tx.Commit(ctx)
 }
 
 func (s *PostgresStore) migrate(ctx context.Context) error {
@@ -318,22 +386,7 @@ func (s *PostgresStore) migrateV4(ctx context.Context) error {
 	}
 	defer tx.Rollback(ctx)
 
-	// 1. Create users table.
-	if _, err := tx.Exec(ctx, `
-		CREATE TABLE IF NOT EXISTS memstore_users (
-			id         BIGSERIAL   PRIMARY KEY,
-			namespace  TEXT        NOT NULL,
-			name       TEXT        NOT NULL,
-			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-			UNIQUE (namespace, name)
-		)`); err != nil {
-		return fmt.Errorf("pgstore V4 migration: create memstore_users: %w", err)
-	}
-	if _, err := tx.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_memstore_users_namespace ON memstore_users (namespace)`); err != nil {
-		return fmt.Errorf("pgstore V4 migration: create users index: %w", err)
-	}
-
-	// 2. Infer default user from api_tokens (if table exists).
+	// Infer default user from api_tokens (if the table exists).
 	var tokensExist bool
 	if err := tx.QueryRow(ctx,
 		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'api_tokens')`,
@@ -373,17 +426,13 @@ func (s *PostgresStore) migrateV4(ctx context.Context) error {
 		}
 
 		switch len(prefixes) {
-		case 0:
-			// Only legacy token or empty table: fresh/legacy-only DB.
-			// If facts also empty, proceed with no default user.
-			if factsExist {
-				return fmt.Errorf("pgstore V4 migration: cannot infer default user (no non-legacy tokens but facts exist). Run 'memstore admin tier3-init --default-user <name>' before starting memstored")
-			}
-			// Fresh DB: migrate schema with no user rows.
 		case 1:
 			for p := range prefixes {
 				defaultUser = p
 			}
+		case 0:
+			// Only a legacy token or an empty table: fall through to the
+			// facts-exist guard below.
 		default:
 			names := make([]string, 0, len(prefixes))
 			for p := range prefixes {
@@ -393,88 +442,157 @@ func (s *PostgresStore) migrateV4(ctx context.Context) error {
 		}
 	}
 
-	// 3. Add user_id columns (nullable first for backfill).
+	// Facts with no inferable owner -- regardless of whether the tokens table
+	// exists -- cannot be backfilled silently. Only a truly fresh database
+	// (no facts) may migrate without a default user.
+	if defaultUser == "" && factsExist {
+		return fmt.Errorf("pgstore V4 migration: tier 3 migration cannot infer default user; run 'memstore admin tier3-init --default-user <name>' before starting memstored")
+	}
+
+	if err := migrateV4As(ctx, tx, s.namespace, defaultUser); err != nil {
+		return fmt.Errorf("pgstore V4 migration: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
+// migrateV4As performs the V4 identity work with an explicit default user.
+// It is shared by migrateV4 (user inferred from token names) and InitIdentity
+// (user supplied by the operator) so the two paths cannot drift.
+//
+// defaultUser may be "" only when the database holds no facts (fresh DB):
+// the schema is created with no user rows and nothing is backfilled. The
+// NOT NULL and FK constraints are applied either way -- on a fresh DB the
+// tables are empty, so the constraints succeed trivially.
+func migrateV4As(ctx context.Context, tx pgx.Tx, namespace, defaultUser string) error {
+	// 1. Create users table.
+	if _, err := tx.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS memstore_users (
+			id         BIGSERIAL   PRIMARY KEY,
+			namespace  TEXT        NOT NULL,
+			name       TEXT        NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			UNIQUE (namespace, name)
+		)`); err != nil {
+		return fmt.Errorf("create memstore_users: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_memstore_users_namespace ON memstore_users (namespace)`); err != nil {
+		return fmt.Errorf("create users index: %w", err)
+	}
+
+	// 2. Add user_id columns (nullable first for backfill).
 	if _, err := tx.Exec(ctx, `ALTER TABLE memstore_facts ADD COLUMN IF NOT EXISTS user_id BIGINT`); err != nil {
-		return fmt.Errorf("pgstore V4 migration: add facts.user_id: %w", err)
+		return fmt.Errorf("add facts.user_id: %w", err)
 	}
 	if _, err := tx.Exec(ctx, `ALTER TABLE memstore_links ADD COLUMN IF NOT EXISTS user_id BIGINT`); err != nil {
-		return fmt.Errorf("pgstore V4 migration: add links.user_id: %w", err)
+		return fmt.Errorf("add links.user_id: %w", err)
 	}
 
 	if defaultUser != "" {
-		// 4. Seed user row.
-		if _, err := tx.Exec(ctx,
-			`INSERT INTO memstore_users (namespace, name)
-			 VALUES ($1, $2)
-			 ON CONFLICT (namespace, name) DO NOTHING`,
-			s.namespace, defaultUser,
-		); err != nil {
-			return fmt.Errorf("pgstore V4 migration: insert user %q: %w", defaultUser, err)
+		// 3. One user row per distinct namespace present in facts or links
+		// (plus the store's own namespace), each backfilled to its own row.
+		// This keeps UNIQUE(namespace, name) meaningful: a user belongs to
+		// exactly one namespace.
+		nsSet := map[string]struct{}{namespace: {}}
+		rows, err := tx.Query(ctx,
+			`SELECT DISTINCT namespace FROM memstore_facts
+			 UNION SELECT DISTINCT namespace FROM memstore_links`)
+		if err != nil {
+			return fmt.Errorf("listing namespaces: %w", err)
+		}
+		for rows.Next() {
+			var ns string
+			if err := rows.Scan(&ns); err != nil {
+				rows.Close()
+				return fmt.Errorf("scanning namespace: %w", err)
+			}
+			nsSet[ns] = struct{}{}
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterating namespaces: %w", err)
 		}
 
-		var uid int64
-		if err := tx.QueryRow(ctx,
-			`SELECT id FROM memstore_users WHERE namespace = $1 AND name = $2`,
-			s.namespace, defaultUser,
-		).Scan(&uid); err != nil {
-			return fmt.Errorf("pgstore V4 migration: resolve user %q: %w", defaultUser, err)
-		}
-
-		// 5. Backfill facts and links.
-		if _, err := tx.Exec(ctx,
-			`UPDATE memstore_facts SET user_id = $1 WHERE namespace = $2 AND user_id IS NULL`,
-			uid, s.namespace,
-		); err != nil {
-			return fmt.Errorf("pgstore V4 migration: backfill facts: %w", err)
-		}
-		if _, err := tx.Exec(ctx,
-			`UPDATE memstore_links SET user_id = $1 WHERE namespace = $2 AND user_id IS NULL`,
-			uid, s.namespace,
-		); err != nil {
-			return fmt.Errorf("pgstore V4 migration: backfill links: %w", err)
-		}
-
-		// 6. Subject rewrite: free subject from ownership role for non-identity/preference facts.
-		if _, err := tx.Exec(ctx,
-			`UPDATE memstore_facts SET subject = NULL
-			 WHERE namespace = $1 AND subject = $2
-			   AND category NOT IN ('identity', 'preference')`,
-			s.namespace, defaultUser,
-		); err != nil {
-			return fmt.Errorf("pgstore V4 migration: subject rewrite: %w", err)
-		}
-
-		// 7. Enforce NOT NULL + FK on facts now that backfill is complete.
-		if _, err := tx.Exec(ctx, `
-			ALTER TABLE memstore_facts
-				ALTER COLUMN user_id SET NOT NULL,
-				ADD CONSTRAINT memstore_facts_user_id_fkey
-					FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT,
-				ALTER COLUMN subject DROP NOT NULL`); err != nil {
-			return fmt.Errorf("pgstore V4 migration: enforce facts constraints: %w", err)
-		}
-
-		// Indexes on facts for user-scoped queries.
-		for _, idx := range []string{
-			`CREATE INDEX IF NOT EXISTS idx_memstore_facts_user ON memstore_facts (namespace, user_id)`,
-			`CREATE INDEX IF NOT EXISTS idx_memstore_facts_user_subj ON memstore_facts (namespace, user_id, subject)`,
-		} {
-			if _, err := tx.Exec(ctx, idx); err != nil {
-				return fmt.Errorf("pgstore V4 migration: create facts user index: %w", err)
+		for ns := range nsSet {
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO memstore_users (namespace, name)
+				 VALUES ($1, $2)
+				 ON CONFLICT (namespace, name) DO NOTHING`,
+				ns, defaultUser,
+			); err != nil {
+				return fmt.Errorf("insert user %q ns %q: %w", defaultUser, ns, err)
+			}
+			var uid int64
+			if err := tx.QueryRow(ctx,
+				`SELECT id FROM memstore_users WHERE namespace = $1 AND name = $2`,
+				ns, defaultUser,
+			).Scan(&uid); err != nil {
+				return fmt.Errorf("resolve user %q ns %q: %w", defaultUser, ns, err)
+			}
+			if _, err := tx.Exec(ctx,
+				`UPDATE memstore_facts SET user_id = $1 WHERE namespace = $2 AND user_id IS NULL`,
+				uid, ns,
+			); err != nil {
+				return fmt.Errorf("backfill facts ns %q: %w", ns, err)
+			}
+			if _, err := tx.Exec(ctx,
+				`UPDATE memstore_links SET user_id = $1 WHERE namespace = $2 AND user_id IS NULL`,
+				uid, ns,
+			); err != nil {
+				return fmt.Errorf("backfill links ns %q: %w", ns, err)
 			}
 		}
 
-		// 8. Record default_user for subsequent opens.
+		// 4. Subject rewrite: user_id now carries ownership, so subjects that
+		// merely named the owner are freed to '' (empty string -- subject
+		// stays NOT NULL). Identity and preference facts keep the name as a
+		// genuine topic.
+		if _, err := tx.Exec(ctx,
+			`UPDATE memstore_facts SET subject = ''
+			 WHERE subject = $1 AND category NOT IN ('identity', 'preference')`,
+			defaultUser,
+		); err != nil {
+			return fmt.Errorf("subject rewrite: %w", err)
+		}
+
+		// 5. Record default_user for subsequent opens.
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO memstore_meta (key, value) VALUES ('default_user', $1)
 			 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
 			defaultUser,
 		); err != nil {
-			return fmt.Errorf("pgstore V4 migration: record default_user: %w", err)
+			return fmt.Errorf("record default_user: %w", err)
 		}
 	}
 
-	return tx.Commit(ctx)
+	// 6. Enforce NOT NULL + FK now that backfill is complete.
+	if _, err := tx.Exec(ctx, `
+		ALTER TABLE memstore_facts
+			ALTER COLUMN user_id SET NOT NULL,
+			ADD CONSTRAINT memstore_facts_user_id_fkey
+				FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT`); err != nil {
+		return fmt.Errorf("enforce facts constraints: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		ALTER TABLE memstore_links
+			ALTER COLUMN user_id SET NOT NULL,
+			ADD CONSTRAINT memstore_links_user_id_fkey
+				FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT`); err != nil {
+		return fmt.Errorf("enforce links constraints: %w", err)
+	}
+
+	// 7. Indexes for user-scoped queries.
+	for _, idx := range []string{
+		`CREATE INDEX IF NOT EXISTS idx_memstore_facts_user ON memstore_facts (namespace, user_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_memstore_facts_user_subj ON memstore_facts (namespace, user_id, subject)`,
+		`CREATE INDEX IF NOT EXISTS idx_memstore_links_user ON memstore_links (namespace, user_id)`,
+	} {
+		if _, err := tx.Exec(ctx, idx); err != nil {
+			return fmt.Errorf("create user index: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func (s *PostgresStore) validateEmbedder(ctx context.Context) error {

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -77,8 +77,10 @@ func newTestStoreNS(t *testing.T, ns string) *pgstore.PostgresStore {
 
 	embedder := &mockEmbedder{dim: 4}
 
-	// First pass: migrate creates the schema with userID=0 (fresh-DB path).
-	if _, err := pgstore.New(ctx, pool, embedder, ns, 4, 512); err != nil {
+	// First pass migrates the schema. On a fresh DB it fails at user
+	// resolution (no default user recorded yet); the migration itself is
+	// committed before that check, so the failure is expected and benign.
+	if _, err := pgstore.New(ctx, pool, embedder, ns, 4, 512); err != nil && !strings.Contains(err.Error(), "tier3-init") {
 		t.Fatalf("first pgstore.New (schema init): %v", err)
 	}
 	// Seed the identity so subsequent opens get a real userID.
@@ -125,8 +127,9 @@ func newTestStoreWithEmbedder(t *testing.T, embedder embedding.Embedder, dim, ca
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 
-	// Migrate first, seed identity, then open again with resolved userID.
-	if _, err := pgstore.New(ctx, pool, embedder, "test", dim, cacheSize); err != nil {
+	// Migrate first (expected to fail at user resolution on a fresh DB),
+	// seed identity, then open again with resolved userID.
+	if _, err := pgstore.New(ctx, pool, embedder, "test", dim, cacheSize); err != nil && !strings.Contains(err.Error(), "tier3-init") {
 		t.Fatalf("first pgstore.New (schema init): %v", err)
 	}
 	if err := pgstore.InitIdentity(ctx, pool, "test", "testuser"); err != nil {
@@ -870,11 +873,12 @@ func TestConformance(t *testing.T) {
 	var sharedNST *testing.T
 
 	// initStore migrates schema, seeds identity for ns, and returns a store
-	// with a non-zero userID. Requires two pgstore.New calls.
+	// with a non-zero userID. The first pgstore.New on a fresh pool fails at
+	// user resolution (no default user recorded yet); that is expected.
 	initStore := func(t *testing.T, pool *pgxpool.Pool, ns string) *pgstore.PostgresStore {
 		t.Helper()
 		emb := &mockEmbedder{dim: 4}
-		if _, err := pgstore.New(ctx, pool, emb, ns, 4, 512); err != nil {
+		if _, err := pgstore.New(ctx, pool, emb, ns, 4, 512); err != nil && !strings.Contains(err.Error(), "tier3-init") {
 			t.Fatalf("pgstore.New schema init ns=%q: %v", ns, err)
 		}
 		if err := pgstore.InitIdentity(ctx, pool, ns, "testuser"); err != nil {
@@ -1061,9 +1065,15 @@ func TestMigrateV4_Fresh(t *testing.T) {
 	t.Cleanup(pool.Close)
 	dropAll(ctx, pool)
 
-	// Fresh DB: no tokens, no facts. Migration should succeed with no user rows.
-	if _, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512); err != nil {
-		t.Fatalf("pgstore.New on fresh DB: %v", err)
+	// Fresh DB: no tokens, no facts. The migration succeeds with no user rows,
+	// but construction fails at user resolution with the tier3-init
+	// instruction -- new deployments run tier3-init once.
+	_, err = pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
+	if err == nil {
+		t.Fatal("expected pgstore.New on a fresh DB to fail with the tier3-init instruction, got nil")
+	}
+	if !strings.Contains(err.Error(), "tier3-init") {
+		t.Errorf("fresh-DB construction error should mention tier3-init: %v", err)
 	}
 
 	// memstore_users must exist.
@@ -1087,157 +1097,12 @@ func TestMigrateV4_Fresh(t *testing.T) {
 	}
 }
 
-// TestMigrateV4_InferUser verifies that V4 migration infers the default user
-// from a unanimous token name prefix.
-func TestMigrateV4_InferUser(t *testing.T) {
-	if os.Getenv("MEMSTORE_TEST_PG") == "" {
-		t.Skip("MEMSTORE_TEST_PG not set; skipping pg migration tests")
-	}
-	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, os.Getenv("MEMSTORE_TEST_PG"))
-	if err != nil {
-		t.Fatalf("pgxpool.New: %v", err)
-	}
-	t.Cleanup(pool.Close)
+// setupPreV4 builds a V3-shape schema by hand (version row = 3) with the
+// given api_tokens names, so that opening the store triggers the V4
+// migration against realistic pre-identity data. It returns the pool.
+func setupPreV4(t *testing.T, ctx context.Context, pool *pgxpool.Pool, tokenNames ...string) {
+	t.Helper()
 	dropAll(ctx, pool)
-
-	// Run V1-V3 migrations only (up to but not including V4) by creating a
-	// store at V3, then manually inserting a token with a "matthew-*" name,
-	// then letting V4 fire on next open.
-	//
-	// Strategy: migrate to V3 by calling pgstore.New (V4 is triggered because
-	// schemaVersion=4, and V4's fresh-DB branch fires since there are no facts).
-	// We then manually insert an api_tokens row and bump version back to 3 to
-	// force V4 to re-run.
-	//
-	// Simpler: build the pre-V4 state manually.
-	if _, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
-		t.Fatalf("create extension: %v", err)
-	}
-	preV4Stmts := []string{
-		`CREATE TABLE memstore_version (version INTEGER NOT NULL)`,
-		`INSERT INTO memstore_version VALUES (3)`,
-		`CREATE TABLE memstore_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
-		`CREATE TABLE memstore_facts (
-			id BIGSERIAL PRIMARY KEY,
-			namespace TEXT NOT NULL DEFAULT '',
-			content TEXT NOT NULL,
-			subject TEXT NOT NULL,
-			category TEXT NOT NULL,
-			kind TEXT NOT NULL DEFAULT '',
-			subsystem TEXT NOT NULL DEFAULT '',
-			metadata JSONB,
-			superseded_by BIGINT REFERENCES memstore_facts(id),
-			superseded_at TIMESTAMPTZ,
-			confirmed_count INTEGER NOT NULL DEFAULT 0,
-			last_confirmed_at TIMESTAMPTZ,
-			use_count INTEGER NOT NULL DEFAULT 0,
-			last_used_at TIMESTAMPTZ,
-			embedding vector(4),
-			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			fts TSVECTOR GENERATED ALWAYS AS (
-				setweight(to_tsvector('english', coalesce(subject, '')), 'A') ||
-				setweight(to_tsvector('english', coalesce(content, '')), 'B') ||
-				setweight(to_tsvector('english', coalesce(category, '')), 'C')
-			) STORED,
-			embed_failed_at TIMESTAMPTZ,
-			embed_error TEXT
-		)`,
-		`CREATE TABLE memstore_links (
-			id BIGSERIAL PRIMARY KEY,
-			namespace TEXT NOT NULL DEFAULT '',
-			source_id BIGINT NOT NULL REFERENCES memstore_facts(id) ON DELETE CASCADE,
-			target_id BIGINT NOT NULL REFERENCES memstore_facts(id) ON DELETE CASCADE,
-			link_type TEXT NOT NULL DEFAULT 'reference',
-			bidirectional BOOLEAN NOT NULL DEFAULT FALSE,
-			label TEXT NOT NULL DEFAULT '',
-			metadata JSONB,
-			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-		)`,
-		`CREATE TABLE api_tokens (
-			id BIGSERIAL PRIMARY KEY,
-			token_hash BYTEA NOT NULL UNIQUE,
-			name TEXT NOT NULL,
-			scopes TEXT[] NOT NULL DEFAULT '{}',
-			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-			last_used_at TIMESTAMPTZ,
-			expires_at TIMESTAMPTZ,
-			revoked_at TIMESTAMPTZ
-		)`,
-		// All tokens share the "matthew" prefix -- unambiguous.
-		`INSERT INTO api_tokens (token_hash, name, scopes) VALUES (E'\\x01', 'matthew-laptop', '{"admin"}')`,
-		`INSERT INTO api_tokens (token_hash, name, scopes) VALUES (E'\\x02', 'matthew-workstation', '{"read"}')`,
-	}
-	for _, s := range preV4Stmts {
-		if _, err := pool.Exec(ctx, s); err != nil {
-			t.Fatalf("pre-V4 setup: %v\nstmt: %s", err, s)
-		}
-	}
-
-	// Opening with pgstore.New triggers V4 (store migration).
-	// V4 infers "matthew" as the default user from the token prefix.
-	store, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
-	if err != nil {
-		t.Fatalf("pgstore.New (V4 migration): %v", err)
-	}
-	_ = store
-
-	// memstore_users should have one row for "matthew".
-	var count int
-	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM memstore_users`).Scan(&count); err != nil {
-		t.Fatalf("counting users: %v", err)
-	}
-	if count != 1 {
-		t.Errorf("expected 1 user row, got %d", count)
-	}
-
-	// Opening TokenStore triggers token migration, which rewrites token names.
-	if _, err := pgstore.NewTokenStore(ctx, pool); err != nil {
-		t.Fatalf("NewTokenStore (token migration): %v", err)
-	}
-
-	// Token names should have been rewritten to user@host shape.
-	rows, err := pool.Query(ctx, `SELECT name FROM api_tokens ORDER BY name`)
-	if err != nil {
-		t.Fatalf("listing tokens: %v", err)
-	}
-	defer rows.Close()
-	var names []string
-	for rows.Next() {
-		var n string
-		if err := rows.Scan(&n); err != nil {
-			t.Fatalf("scanning name: %v", err)
-		}
-		names = append(names, n)
-	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("iterating names: %v", err)
-	}
-	wantNames := []string{"matthew@laptop", "matthew@workstation"}
-	if len(names) != len(wantNames) {
-		t.Fatalf("token names = %v, want %v", names, wantNames)
-	}
-	for i, want := range wantNames {
-		if names[i] != want {
-			t.Errorf("token[%d] name = %q, want %q", i, names[i], want)
-		}
-	}
-}
-
-// TestMigrateV4_AmbiguousUser verifies that V4 migration fails when token
-// prefixes are ambiguous (multiple distinct user prefixes).
-func TestMigrateV4_AmbiguousUser(t *testing.T) {
-	if os.Getenv("MEMSTORE_TEST_PG") == "" {
-		t.Skip("MEMSTORE_TEST_PG not set; skipping pg migration tests")
-	}
-	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, os.Getenv("MEMSTORE_TEST_PG"))
-	if err != nil {
-		t.Fatalf("pgxpool.New: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	dropAll(ctx, pool)
-
 	if _, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
 		t.Fatalf("create extension: %v", err)
 	}
@@ -1291,15 +1156,171 @@ func TestMigrateV4_AmbiguousUser(t *testing.T) {
 			expires_at TIMESTAMPTZ,
 			revoked_at TIMESTAMPTZ
 		)`,
-		// Two different user prefixes: ambiguous.
-		`INSERT INTO api_tokens (token_hash, name, scopes) VALUES (E'\\x01', 'matthew-laptop', '{"admin"}')`,
-		`INSERT INTO api_tokens (token_hash, name, scopes) VALUES (E'\\x02', 'alice-desktop', '{"read"}')`,
 	}
 	for _, s := range preV4Stmts {
 		if _, err := pool.Exec(ctx, s); err != nil {
 			t.Fatalf("pre-V4 setup: %v\nstmt: %s", err, s)
 		}
 	}
+	for i, name := range tokenNames {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO api_tokens (token_hash, name, scopes) VALUES ($1, $2, '{"read"}')`,
+			[]byte{byte(i + 1)}, name,
+		); err != nil {
+			t.Fatalf("pre-V4 token %q: %v", name, err)
+		}
+	}
+}
+
+// insertPreV4Fact inserts a fact directly into a pre-V4 facts table and
+// returns its id.
+func insertPreV4Fact(t *testing.T, ctx context.Context, pool *pgxpool.Pool, ns, content, subject, category string) int64 {
+	t.Helper()
+	var id int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO memstore_facts (namespace, content, subject, category) VALUES ($1, $2, $3, $4) RETURNING id`,
+		ns, content, subject, category,
+	).Scan(&id); err != nil {
+		t.Fatalf("pre-V4 fact insert: %v", err)
+	}
+	return id
+}
+
+// TestMigrateV4_InferUser verifies that V4 migration infers the default user
+// from a unanimous token name prefix, backfills facts, and rewrites
+// ownership-only subjects to ” (empty string) -- subject stays NOT NULL.
+func TestMigrateV4_InferUser(t *testing.T) {
+	if os.Getenv("MEMSTORE_TEST_PG") == "" {
+		t.Skip("MEMSTORE_TEST_PG not set; skipping pg migration tests")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, os.Getenv("MEMSTORE_TEST_PG"))
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	// All tokens share the "matthew" prefix -- unambiguous.
+	setupPreV4(t, ctx, pool, "matthew-laptop", "matthew-workstation")
+	// Pre-identity facts: one with subject overloaded as ownership marker
+	// (rewritten to '') and one where the name is a genuine identity topic
+	// (kept).
+	projectID := insertPreV4Fact(t, ctx, pool, "test", "owned project fact", "matthew", "project")
+	identityID := insertPreV4Fact(t, ctx, pool, "test", "identity fact", "matthew", "identity")
+
+	// Opening with pgstore.New triggers V4 (store migration).
+	// V4 infers "matthew" as the default user from the token prefix.
+	store, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
+	if err != nil {
+		t.Fatalf("pgstore.New (V4 migration): %v", err)
+	}
+
+	// memstore_users should have one row for "matthew".
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM memstore_users`).Scan(&count); err != nil {
+		t.Fatalf("counting users: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 user row, got %d", count)
+	}
+
+	// All facts backfilled: no NULL user_id remains.
+	var nullCount int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM memstore_facts WHERE user_id IS NULL`).Scan(&nullCount); err != nil {
+		t.Fatalf("counting NULL user_id: %v", err)
+	}
+	if nullCount != 0 {
+		t.Errorf("%d facts have NULL user_id after backfill", nullCount)
+	}
+
+	// Subject rewrite: the project fact's subject becomes '' (NOT NULL kept);
+	// the identity fact keeps its subject.
+	var projSubject, identSubject string
+	if err := pool.QueryRow(ctx, `SELECT subject FROM memstore_facts WHERE id = $1`, projectID).Scan(&projSubject); err != nil {
+		t.Fatalf("reading project fact subject: %v", err)
+	}
+	if projSubject != "" {
+		t.Errorf("project fact subject = %q, want ''", projSubject)
+	}
+	if err := pool.QueryRow(ctx, `SELECT subject FROM memstore_facts WHERE id = $1`, identityID).Scan(&identSubject); err != nil {
+		t.Fatalf("reading identity fact subject: %v", err)
+	}
+	if identSubject != "matthew" {
+		t.Errorf("identity fact subject = %q, want \"matthew\"", identSubject)
+	}
+
+	// The subject column must remain NOT NULL.
+	var subjectNullable string
+	if err := pool.QueryRow(ctx,
+		`SELECT is_nullable FROM information_schema.columns WHERE table_name = 'memstore_facts' AND column_name = 'subject'`,
+	).Scan(&subjectNullable); err != nil {
+		t.Fatalf("checking subject nullability: %v", err)
+	}
+	if subjectNullable != "NO" {
+		t.Errorf("memstore_facts.subject is_nullable = %q, want NO", subjectNullable)
+	}
+
+	// Read the rewritten fact back through the store: the scan must handle
+	// the rewritten subject and the new user_id column.
+	got, err := store.Get(ctx, projectID)
+	if err != nil {
+		t.Fatalf("store.Get(rewritten fact): %v", err)
+	}
+	if got.Subject != "" {
+		t.Errorf("Get: subject = %q, want ''", got.Subject)
+	}
+	if got.UserID == 0 {
+		t.Error("Get: UserID = 0, want non-zero after backfill")
+	}
+
+	// Opening TokenStore triggers token migration, which rewrites token names.
+	if _, err := pgstore.NewTokenStore(ctx, pool); err != nil {
+		t.Fatalf("NewTokenStore (token migration): %v", err)
+	}
+
+	// Token names should have been rewritten to user@host shape.
+	rows, err := pool.Query(ctx, `SELECT name FROM api_tokens ORDER BY name`)
+	if err != nil {
+		t.Fatalf("listing tokens: %v", err)
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scanning name: %v", err)
+		}
+		names = append(names, n)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating names: %v", err)
+	}
+	wantNames := []string{"matthew@laptop", "matthew@workstation"}
+	if len(names) != len(wantNames) {
+		t.Fatalf("token names = %v, want %v", names, wantNames)
+	}
+	for i, want := range wantNames {
+		if names[i] != want {
+			t.Errorf("token[%d] name = %q, want %q", i, names[i], want)
+		}
+	}
+}
+
+// TestMigrateV4_AmbiguousUser verifies that V4 migration fails when token
+// prefixes are ambiguous (multiple distinct user prefixes).
+func TestMigrateV4_AmbiguousUser(t *testing.T) {
+	if os.Getenv("MEMSTORE_TEST_PG") == "" {
+		t.Skip("MEMSTORE_TEST_PG not set; skipping pg migration tests")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, os.Getenv("MEMSTORE_TEST_PG"))
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	// Two different user prefixes: ambiguous.
+	setupPreV4(t, ctx, pool, "matthew-laptop", "alice-desktop")
 
 	// V4 must fail with an ambiguous-prefix error.
 	_, err = pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
@@ -1311,8 +1332,11 @@ func TestMigrateV4_AmbiguousUser(t *testing.T) {
 	}
 }
 
-// TestInitIdentity verifies that after an ambiguous-migration failure,
-// InitIdentity succeeds and a subsequent pgstore.New resolves the user.
+// TestInitIdentity verifies the operator-recovery sequence end to end: an
+// ambiguous fixture makes pgstore.New fail (the whole V4 transaction rolls
+// back, including the memstore_users CREATE), then InitIdentity runs the
+// full V4 work with an explicit user, and a subsequent pgstore.New succeeds
+// with facts backfilled and constraints in place.
 func TestInitIdentity(t *testing.T) {
 	if os.Getenv("MEMSTORE_TEST_PG") == "" {
 		t.Skip("MEMSTORE_TEST_PG not set; skipping pg migration tests")
@@ -1323,22 +1347,80 @@ func TestInitIdentity(t *testing.T) {
 		t.Fatalf("pgxpool.New: %v", err)
 	}
 	t.Cleanup(pool.Close)
-	dropAll(ctx, pool)
 
-	// Migrate a fresh DB (no tokens, no facts -- succeeds trivially).
-	if _, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512); err != nil {
-		t.Fatalf("pgstore.New for fresh schema: %v", err)
+	// Ambiguous token prefixes plus a fact whose subject is the owner name.
+	setupPreV4(t, ctx, pool, "matthew-laptop", "alice-desktop")
+	factID := insertPreV4Fact(t, ctx, pool, "test", "owned project fact", "matthew", "project")
+
+	// V4 inference must fail and roll back everything, including memstore_users.
+	if _, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512); err == nil {
+		t.Fatal("expected pgstore.New to fail on ambiguous token prefixes, got nil")
+	}
+	var usersExist bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'memstore_users')`,
+	).Scan(&usersExist); err != nil {
+		t.Fatalf("checking memstore_users after rollback: %v", err)
+	}
+	if usersExist {
+		t.Error("memstore_users exists after failed V4 migration; expected full rollback")
 	}
 
-	// Call InitIdentity to seed the default user.
+	// InitIdentity performs the full V4 work with the explicit user.
 	if err := pgstore.InitIdentity(ctx, pool, "test", "matthew"); err != nil {
 		t.Fatalf("InitIdentity: %v", err)
 	}
 
-	// Subsequent open must resolve the user.
+	// Subsequent open must resolve the user without re-running V4.
 	store, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
 	if err != nil {
 		t.Fatalf("pgstore.New after InitIdentity: %v", err)
+	}
+
+	// The pre-existing fact is backfilled and its subject rewritten to ''.
+	got, err := store.Get(ctx, factID)
+	if err != nil {
+		t.Fatalf("Get(pre-V4 fact): %v", err)
+	}
+	if got.UserID == 0 {
+		t.Error("pre-V4 fact UserID is 0 after InitIdentity; expected backfill")
+	}
+	if got.Subject != "" {
+		t.Errorf("pre-V4 fact subject = %q, want '' after rewrite", got.Subject)
+	}
+
+	// Constraints are in place: user_id NOT NULL and the FK to memstore_users.
+	var userIDNullable string
+	if err := pool.QueryRow(ctx,
+		`SELECT is_nullable FROM information_schema.columns WHERE table_name = 'memstore_facts' AND column_name = 'user_id'`,
+	).Scan(&userIDNullable); err != nil {
+		t.Fatalf("checking user_id nullability: %v", err)
+	}
+	if userIDNullable != "NO" {
+		t.Errorf("memstore_facts.user_id is_nullable = %q, want NO", userIDNullable)
+	}
+	var fkExists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM information_schema.table_constraints
+			 WHERE table_name = 'memstore_facts'
+			   AND constraint_name = 'memstore_facts_user_id_fkey'
+			   AND constraint_type = 'FOREIGN KEY'
+		)`,
+	).Scan(&fkExists); err != nil {
+		t.Fatalf("checking facts FK: %v", err)
+	}
+	if !fkExists {
+		t.Error("memstore_facts_user_id_fkey not found after InitIdentity")
+	}
+
+	// The schema version was recorded as 4.
+	var version int
+	if err := pool.QueryRow(ctx, `SELECT version FROM memstore_version`).Scan(&version); err != nil {
+		t.Fatalf("reading schema version: %v", err)
+	}
+	if version != 4 {
+		t.Errorf("schema version = %d, want 4 after InitIdentity", version)
 	}
 
 	// Insert must succeed (non-zero userID bound to the store).

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -577,6 +577,14 @@ func TestHistory_CycleTerminates(t *testing.T) {
 	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
 	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 
+	// Fresh-DB construction fails at user resolution until an identity is
+	// seeded; the first New still commits the schema migration.
+	if _, err := pgstore.New(ctx, rawPool, &mockEmbedder{dim: 4}, "test", 4, 512); err != nil && !strings.Contains(err.Error(), "tier3-init") {
+		t.Fatalf("pgstore.New (schema init): %v", err)
+	}
+	if err := pgstore.InitIdentity(ctx, rawPool, "test", "testuser"); err != nil {
+		t.Fatalf("InitIdentity: %v", err)
+	}
 	store, err := pgstore.New(ctx, rawPool, &mockEmbedder{dim: 4}, "test", 4, 512)
 	if err != nil {
 		t.Fatalf("creating store: %v", err)

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -3,6 +3,7 @@ package pgstore_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -50,6 +51,14 @@ func testDSN(t *testing.T) string {
 
 func newTestStore(t *testing.T) *pgstore.PostgresStore {
 	t.Helper()
+	return newTestStoreNS(t, "test")
+}
+
+// newTestStoreNS creates a fresh store in the given namespace with a default
+// user seeded so that Insert works and UserID is non-zero. It drops all
+// memstore_* tables from previous runs before migrating.
+func newTestStoreNS(t *testing.T, ns string) *pgstore.PostgresStore {
+	t.Helper()
 	ctx := context.Background()
 	dsn := testDSN(t)
 
@@ -64,11 +73,22 @@ func newTestStore(t *testing.T) *pgstore.PostgresStore {
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 
 	embedder := &mockEmbedder{dim: 4}
-	store, err := pgstore.New(ctx, pool, embedder, "test", 4, 512)
+
+	// First pass: migrate creates the schema with userID=0 (fresh-DB path).
+	if _, err := pgstore.New(ctx, pool, embedder, ns, 4, 512); err != nil {
+		t.Fatalf("first pgstore.New (schema init): %v", err)
+	}
+	// Seed the identity so subsequent opens get a real userID.
+	if err := pgstore.InitIdentity(ctx, pool, ns, "testuser"); err != nil {
+		t.Fatalf("InitIdentity: %v", err)
+	}
+	// Second pass: resolveUser now finds the seeded row.
+	store, err := pgstore.New(ctx, pool, embedder, ns, 4, 512)
 	if err != nil {
-		t.Fatalf("creating store: %v", err)
+		t.Fatalf("second pgstore.New (with identity): %v", err)
 	}
 
 	return store
@@ -103,7 +123,15 @@ func newTestStoreWithEmbedder(t *testing.T, embedder embedding.Embedder, dim, ca
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 
+	// Migrate first, seed identity, then open again with resolved userID.
+	if _, err := pgstore.New(ctx, pool, embedder, "test", dim, cacheSize); err != nil {
+		t.Fatalf("first pgstore.New (schema init): %v", err)
+	}
+	if err := pgstore.InitIdentity(ctx, pool, "test", "testuser"); err != nil {
+		t.Fatalf("InitIdentity: %v", err)
+	}
 	store, err := pgstore.New(ctx, pool, embedder, "test", dim, cacheSize)
 	if err != nil {
 		t.Fatalf("creating store: %v", err)
@@ -544,6 +572,7 @@ func TestHistory_CycleTerminates(t *testing.T) {
 	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 
 	store, err := pgstore.New(ctx, rawPool, &mockEmbedder{dim: 4}, "test", 4, 512)
 	if err != nil {
@@ -826,6 +855,7 @@ func TestConformance(t *testing.T) {
 		pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 		pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 		pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+		pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 		return pool
 	}
 
@@ -839,15 +869,29 @@ func TestConformance(t *testing.T) {
 	var sharedNSPool *pgxpool.Pool
 	var sharedNST *testing.T
 
+	// initStore migrates schema, seeds identity for ns, and returns a store
+	// with a non-zero userID. Requires two pgstore.New calls.
+	initStore := func(t *testing.T, pool *pgxpool.Pool, ns string) *pgstore.PostgresStore {
+		t.Helper()
+		emb := &mockEmbedder{dim: 4}
+		if _, err := pgstore.New(ctx, pool, emb, ns, 4, 512); err != nil {
+			t.Fatalf("pgstore.New schema init ns=%q: %v", ns, err)
+		}
+		if err := pgstore.InitIdentity(ctx, pool, ns, "testuser"); err != nil {
+			t.Fatalf("InitIdentity ns=%q: %v", ns, err)
+		}
+		store, err := pgstore.New(ctx, pool, emb, ns, 4, 512)
+		if err != nil {
+			t.Fatalf("pgstore.New ns=%q: %v", ns, err)
+		}
+		return store
+	}
+
 	conformance.Run(t, conformance.Options{
 		NewStore: func(t *testing.T) memstore.Store {
 			pool := newPool(t)
 			lastPool = pool
-			store, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
-			if err != nil {
-				t.Fatalf("pgstore.New: %v", err)
-			}
-			return store
+			return initStore(t, pool, "test")
 		},
 
 		// NewStoreNS creates stores on a shared pool so namespace isolation is
@@ -859,11 +903,7 @@ func TestConformance(t *testing.T) {
 				sharedNSPool = newPool(t)
 				sharedNST = t
 			}
-			store, err := pgstore.New(ctx, sharedNSPool, &mockEmbedder{dim: 4}, ns, 4, 512)
-			if err != nil {
-				t.Fatalf("pgstore.New ns=%q: %v", ns, err)
-			}
-			return store
+			return initStore(t, sharedNSPool, ns)
 		},
 
 		// SetSupersededBy writes directly to lastPool using Postgres $N
@@ -993,4 +1033,331 @@ func factContents(facts []memstore.Fact) []string {
 		out[i] = f.Content
 	}
 	return out
+}
+
+// --- V4 migration tests ---
+
+// dropAll cleans up all memstore_* tables on the given pool for a fresh slate.
+func dropAll(ctx context.Context, pool *pgxpool.Pool) {
+	pool.Exec(ctx, `DROP TABLE IF EXISTS api_tokens`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_links CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
+}
+
+// TestMigrateV4_Fresh verifies that V4 migration on a clean DB with no tokens
+// and no facts creates memstore_users but leaves it empty.
+func TestMigrateV4_Fresh(t *testing.T) {
+	if os.Getenv("MEMSTORE_TEST_PG") == "" {
+		t.Skip("MEMSTORE_TEST_PG not set; skipping pg migration tests")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, os.Getenv("MEMSTORE_TEST_PG"))
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	dropAll(ctx, pool)
+
+	// Fresh DB: no tokens, no facts. Migration should succeed with no user rows.
+	if _, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512); err != nil {
+		t.Fatalf("pgstore.New on fresh DB: %v", err)
+	}
+
+	// memstore_users must exist.
+	var exists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'memstore_users')`,
+	).Scan(&exists); err != nil {
+		t.Fatalf("checking memstore_users: %v", err)
+	}
+	if !exists {
+		t.Error("memstore_users table not found after V4 migration")
+	}
+
+	// No user rows expected on a fresh DB.
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM memstore_users`).Scan(&count); err != nil {
+		t.Fatalf("counting users: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("fresh DB: expected 0 user rows, got %d", count)
+	}
+}
+
+// TestMigrateV4_InferUser verifies that V4 migration infers the default user
+// from a unanimous token name prefix.
+func TestMigrateV4_InferUser(t *testing.T) {
+	if os.Getenv("MEMSTORE_TEST_PG") == "" {
+		t.Skip("MEMSTORE_TEST_PG not set; skipping pg migration tests")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, os.Getenv("MEMSTORE_TEST_PG"))
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	dropAll(ctx, pool)
+
+	// Run V1-V3 migrations only (up to but not including V4) by creating a
+	// store at V3, then manually inserting a token with a "matthew-*" name,
+	// then letting V4 fire on next open.
+	//
+	// Strategy: migrate to V3 by calling pgstore.New (V4 is triggered because
+	// schemaVersion=4, and V4's fresh-DB branch fires since there are no facts).
+	// We then manually insert an api_tokens row and bump version back to 3 to
+	// force V4 to re-run.
+	//
+	// Simpler: build the pre-V4 state manually.
+	if _, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
+		t.Fatalf("create extension: %v", err)
+	}
+	preV4Stmts := []string{
+		`CREATE TABLE memstore_version (version INTEGER NOT NULL)`,
+		`INSERT INTO memstore_version VALUES (3)`,
+		`CREATE TABLE memstore_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+		`CREATE TABLE memstore_facts (
+			id BIGSERIAL PRIMARY KEY,
+			namespace TEXT NOT NULL DEFAULT '',
+			content TEXT NOT NULL,
+			subject TEXT NOT NULL,
+			category TEXT NOT NULL,
+			kind TEXT NOT NULL DEFAULT '',
+			subsystem TEXT NOT NULL DEFAULT '',
+			metadata JSONB,
+			superseded_by BIGINT REFERENCES memstore_facts(id),
+			superseded_at TIMESTAMPTZ,
+			confirmed_count INTEGER NOT NULL DEFAULT 0,
+			last_confirmed_at TIMESTAMPTZ,
+			use_count INTEGER NOT NULL DEFAULT 0,
+			last_used_at TIMESTAMPTZ,
+			embedding vector(4),
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			fts TSVECTOR GENERATED ALWAYS AS (
+				setweight(to_tsvector('english', coalesce(subject, '')), 'A') ||
+				setweight(to_tsvector('english', coalesce(content, '')), 'B') ||
+				setweight(to_tsvector('english', coalesce(category, '')), 'C')
+			) STORED,
+			embed_failed_at TIMESTAMPTZ,
+			embed_error TEXT
+		)`,
+		`CREATE TABLE memstore_links (
+			id BIGSERIAL PRIMARY KEY,
+			namespace TEXT NOT NULL DEFAULT '',
+			source_id BIGINT NOT NULL REFERENCES memstore_facts(id) ON DELETE CASCADE,
+			target_id BIGINT NOT NULL REFERENCES memstore_facts(id) ON DELETE CASCADE,
+			link_type TEXT NOT NULL DEFAULT 'reference',
+			bidirectional BOOLEAN NOT NULL DEFAULT FALSE,
+			label TEXT NOT NULL DEFAULT '',
+			metadata JSONB,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE TABLE api_tokens (
+			id BIGSERIAL PRIMARY KEY,
+			token_hash BYTEA NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			scopes TEXT[] NOT NULL DEFAULT '{}',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			last_used_at TIMESTAMPTZ,
+			expires_at TIMESTAMPTZ,
+			revoked_at TIMESTAMPTZ
+		)`,
+		// All tokens share the "matthew" prefix -- unambiguous.
+		`INSERT INTO api_tokens (token_hash, name, scopes) VALUES (E'\\x01', 'matthew-laptop', '{"admin"}')`,
+		`INSERT INTO api_tokens (token_hash, name, scopes) VALUES (E'\\x02', 'matthew-workstation', '{"read"}')`,
+	}
+	for _, s := range preV4Stmts {
+		if _, err := pool.Exec(ctx, s); err != nil {
+			t.Fatalf("pre-V4 setup: %v\nstmt: %s", err, s)
+		}
+	}
+
+	// Opening with pgstore.New triggers V4 (store migration).
+	// V4 infers "matthew" as the default user from the token prefix.
+	store, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
+	if err != nil {
+		t.Fatalf("pgstore.New (V4 migration): %v", err)
+	}
+	_ = store
+
+	// memstore_users should have one row for "matthew".
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM memstore_users`).Scan(&count); err != nil {
+		t.Fatalf("counting users: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 user row, got %d", count)
+	}
+
+	// Opening TokenStore triggers token migration, which rewrites token names.
+	if _, err := pgstore.NewTokenStore(ctx, pool); err != nil {
+		t.Fatalf("NewTokenStore (token migration): %v", err)
+	}
+
+	// Token names should have been rewritten to user@host shape.
+	rows, err := pool.Query(ctx, `SELECT name FROM api_tokens ORDER BY name`)
+	if err != nil {
+		t.Fatalf("listing tokens: %v", err)
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scanning name: %v", err)
+		}
+		names = append(names, n)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating names: %v", err)
+	}
+	wantNames := []string{"matthew@laptop", "matthew@workstation"}
+	if len(names) != len(wantNames) {
+		t.Fatalf("token names = %v, want %v", names, wantNames)
+	}
+	for i, want := range wantNames {
+		if names[i] != want {
+			t.Errorf("token[%d] name = %q, want %q", i, names[i], want)
+		}
+	}
+}
+
+// TestMigrateV4_AmbiguousUser verifies that V4 migration fails when token
+// prefixes are ambiguous (multiple distinct user prefixes).
+func TestMigrateV4_AmbiguousUser(t *testing.T) {
+	if os.Getenv("MEMSTORE_TEST_PG") == "" {
+		t.Skip("MEMSTORE_TEST_PG not set; skipping pg migration tests")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, os.Getenv("MEMSTORE_TEST_PG"))
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	dropAll(ctx, pool)
+
+	if _, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
+		t.Fatalf("create extension: %v", err)
+	}
+	preV4Stmts := []string{
+		`CREATE TABLE memstore_version (version INTEGER NOT NULL)`,
+		`INSERT INTO memstore_version VALUES (3)`,
+		`CREATE TABLE memstore_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+		fmt.Sprintf(`CREATE TABLE memstore_facts (
+			id BIGSERIAL PRIMARY KEY,
+			namespace TEXT NOT NULL DEFAULT '',
+			content TEXT NOT NULL CHECK (length(content) <= %d),
+			subject TEXT NOT NULL,
+			category TEXT NOT NULL,
+			kind TEXT NOT NULL DEFAULT '',
+			subsystem TEXT NOT NULL DEFAULT '',
+			metadata JSONB,
+			superseded_by BIGINT REFERENCES memstore_facts(id),
+			superseded_at TIMESTAMPTZ,
+			confirmed_count INTEGER NOT NULL DEFAULT 0,
+			last_confirmed_at TIMESTAMPTZ,
+			use_count INTEGER NOT NULL DEFAULT 0,
+			last_used_at TIMESTAMPTZ,
+			embedding vector(4),
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			fts TSVECTOR GENERATED ALWAYS AS (
+				setweight(to_tsvector('english', coalesce(subject, '')), 'A') ||
+				setweight(to_tsvector('english', coalesce(content, '')), 'B') ||
+				setweight(to_tsvector('english', coalesce(category, '')), 'C')
+			) STORED,
+			embed_failed_at TIMESTAMPTZ,
+			embed_error TEXT
+		)`, memstore.MaxContentLength),
+		`CREATE TABLE memstore_links (
+			id BIGSERIAL PRIMARY KEY,
+			namespace TEXT NOT NULL DEFAULT '',
+			source_id BIGINT NOT NULL REFERENCES memstore_facts(id) ON DELETE CASCADE,
+			target_id BIGINT NOT NULL REFERENCES memstore_facts(id) ON DELETE CASCADE,
+			link_type TEXT NOT NULL DEFAULT 'reference',
+			bidirectional BOOLEAN NOT NULL DEFAULT FALSE,
+			label TEXT NOT NULL DEFAULT '',
+			metadata JSONB,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE TABLE api_tokens (
+			id BIGSERIAL PRIMARY KEY,
+			token_hash BYTEA NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			scopes TEXT[] NOT NULL DEFAULT '{}',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			last_used_at TIMESTAMPTZ,
+			expires_at TIMESTAMPTZ,
+			revoked_at TIMESTAMPTZ
+		)`,
+		// Two different user prefixes: ambiguous.
+		`INSERT INTO api_tokens (token_hash, name, scopes) VALUES (E'\\x01', 'matthew-laptop', '{"admin"}')`,
+		`INSERT INTO api_tokens (token_hash, name, scopes) VALUES (E'\\x02', 'alice-desktop', '{"read"}')`,
+	}
+	for _, s := range preV4Stmts {
+		if _, err := pool.Exec(ctx, s); err != nil {
+			t.Fatalf("pre-V4 setup: %v\nstmt: %s", err, s)
+		}
+	}
+
+	// V4 must fail with an ambiguous-prefix error.
+	_, err = pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
+	if err == nil {
+		t.Fatal("expected error for ambiguous token prefixes, got nil")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error should mention ambiguous prefixes: %v", err)
+	}
+}
+
+// TestInitIdentity verifies that after an ambiguous-migration failure,
+// InitIdentity succeeds and a subsequent pgstore.New resolves the user.
+func TestInitIdentity(t *testing.T) {
+	if os.Getenv("MEMSTORE_TEST_PG") == "" {
+		t.Skip("MEMSTORE_TEST_PG not set; skipping pg migration tests")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, os.Getenv("MEMSTORE_TEST_PG"))
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	dropAll(ctx, pool)
+
+	// Migrate a fresh DB (no tokens, no facts -- succeeds trivially).
+	if _, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512); err != nil {
+		t.Fatalf("pgstore.New for fresh schema: %v", err)
+	}
+
+	// Call InitIdentity to seed the default user.
+	if err := pgstore.InitIdentity(ctx, pool, "test", "matthew"); err != nil {
+		t.Fatalf("InitIdentity: %v", err)
+	}
+
+	// Subsequent open must resolve the user.
+	store, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
+	if err != nil {
+		t.Fatalf("pgstore.New after InitIdentity: %v", err)
+	}
+
+	// Insert must succeed (non-zero userID bound to the store).
+	id, err := store.Insert(ctx, memstore.Fact{
+		Content: "identity check fact", Subject: "test", Category: "note",
+	})
+	if err != nil {
+		t.Fatalf("Insert after InitIdentity: %v", err)
+	}
+	f, err := store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if f.UserID == 0 {
+		t.Error("fact UserID is 0 after InitIdentity; expected non-zero")
+	}
+
+	// InitIdentity is idempotent.
+	if err := pgstore.InitIdentity(ctx, pool, "test", "matthew"); err != nil {
+		t.Fatalf("InitIdentity idempotent call: %v", err)
+	}
 }

--- a/pgstore/tokens.go
+++ b/pgstore/tokens.go
@@ -182,7 +182,7 @@ func (s *TokenStore) migrate(ctx context.Context) error {
 		}
 
 		for _, tok := range tokens {
-			newName := tok.name
+			var newName string
 			if idx := strings.IndexByte(tok.name, '-'); idx > 0 {
 				// "user-host" -> "user@host"
 				newName = tok.name[:idx] + "@" + tok.name[idx+1:]
@@ -202,9 +202,17 @@ func (s *TokenStore) migrate(ctx context.Context) error {
 			}
 		}
 	}
-	// user_id remains nullable on fresh DBs -- Issue always requires UserID,
-	// so no new rows will have NULL. We skip SET NOT NULL to avoid a full
-	// table rewrite on large deployments and because fresh DBs have no rows.
+	// Enforce NOT NULL + FK now that backfill is complete. On a fresh DB the
+	// table is empty, so the constraints succeed trivially; adding NOT NULL
+	// is a table scan, not a rewrite. Issue also requires a non-zero UserID,
+	// so new rows can never be NULL.
+	if _, err := s.pool.Exec(ctx, `
+		ALTER TABLE api_tokens
+			ALTER COLUMN user_id SET NOT NULL,
+			ADD CONSTRAINT api_tokens_user_id_fkey
+				FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT`); err != nil {
+		return fmt.Errorf("token store migrate: enforce user_id constraints: %w", err)
+	}
 
 	// Add index for user-scoped token lookups.
 	if _, err := s.pool.Exec(ctx,
@@ -392,12 +400,24 @@ func (s *TokenStore) EnsureLegacyToken(ctx context.Context, key string) (bool, e
 	if key == "" {
 		return false, nil
 	}
+	// api_tokens.user_id is NOT NULL: bind the legacy row to the default user.
+	var uid int64
+	err := s.pool.QueryRow(ctx, `
+		SELECT u.id FROM memstore_users u
+		 JOIN memstore_meta m ON m.key = 'default_user' AND m.value = u.name
+		 LIMIT 1`).Scan(&uid)
+	if err == pgx.ErrNoRows {
+		return false, errors.New("token store: no default user recorded; run 'memstore admin tier3-init --default-user <name>' first")
+	}
+	if err != nil {
+		return false, fmt.Errorf("token store: resolving default user: %w", err)
+	}
 	hash := hashToken(key)
 	tag, err := s.pool.Exec(ctx, `
-		INSERT INTO api_tokens (token_hash, name, scopes)
-		VALUES ($1, 'legacy', '{"admin"}')
+		INSERT INTO api_tokens (token_hash, name, user_id, scopes)
+		VALUES ($1, 'legacy', $2, '{"admin"}')
 		ON CONFLICT (token_hash) DO NOTHING
-	`, hash)
+	`, hash, uid)
 	if err != nil {
 		return false, err
 	}

--- a/pgstore/tokens.go
+++ b/pgstore/tokens.go
@@ -341,10 +341,10 @@ func (s *TokenStore) Revoke(ctx context.Context, name string) (int, error) {
 	return int(tag.RowsAffected()), nil
 }
 
-// Rotate issues a new token with the same name and scopes as the existing
-// active token, then revokes the old one(s). Returns the new plaintext token.
-// If multiple active tokens share the name, all are revoked and one new token
-// is issued.
+// Rotate issues a new token with the same name, scopes, and owner as the
+// existing active token, then revokes the old one(s). Returns the new
+// plaintext token. If multiple active tokens share the name, all are revoked
+// and one new token is issued.
 func (s *TokenStore) Rotate(ctx context.Context, name string) (string, error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -353,12 +353,13 @@ func (s *TokenStore) Rotate(ctx context.Context, name string) (string, error) {
 	defer tx.Rollback(ctx)
 
 	var scopes []string
+	var userID int64
 	err = tx.QueryRow(ctx, `
-		SELECT scopes FROM api_tokens
+		SELECT scopes, user_id FROM api_tokens
 		 WHERE name = $1 AND revoked_at IS NULL
 		 ORDER BY created_at DESC
 		 LIMIT 1
-	`, name).Scan(&scopes)
+	`, name).Scan(&scopes, &userID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", fmt.Errorf("no active token named %q", name)
 	}
@@ -381,9 +382,9 @@ func (s *TokenStore) Rotate(ctx context.Context, name string) (string, error) {
 		scopes = []string{}
 	}
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO api_tokens (token_hash, name, scopes)
-		VALUES ($1, $2, $3)
-	`, hashToken(newToken), name, scopes); err != nil {
+		INSERT INTO api_tokens (token_hash, name, user_id, scopes)
+		VALUES ($1, $2, $3, $4)
+	`, hashToken(newToken), name, userID, scopes); err != nil {
 		return "", err
 	}
 	if err := tx.Commit(ctx); err != nil {

--- a/pgstore/tokens.go
+++ b/pgstore/tokens.go
@@ -7,6 +7,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -27,6 +29,7 @@ type TokenStore struct {
 type TokenInfo struct {
 	ID         int64
 	Name       string
+	UserID     int64
 	Scopes     []string
 	CreatedAt  time.Time
 	LastUsedAt *time.Time
@@ -36,6 +39,7 @@ type TokenInfo struct {
 
 // IssueOpts configures a new token.
 type IssueOpts struct {
+	UserID  int64         // required; Issue returns an error if zero
 	Scopes  []string      // optional, e.g. {"read","write","admin"}
 	Expires time.Duration // 0 = no expiry
 }
@@ -46,6 +50,7 @@ type IssueOpts struct {
 type VerifyResult struct {
 	Name   string
 	Scopes []string
+	UserID int64
 }
 
 // ErrTokenInvalid is returned by Verify for any reason a token doesn't
@@ -64,8 +69,19 @@ func NewTokenStore(ctx context.Context, pool *pgxpool.Pool) (*TokenStore, error)
 	return s, s.migrate(ctx)
 }
 
+// tokenNameRe validates the <user>@<host> token name shape enforced at issuance.
+var tokenNameRe = regexp.MustCompile(`^[a-z0-9_-]+@[a-z0-9_-]+$`)
+
+// sanitizeName converts a token name to a safe identifier: lowercase,
+// replace non-alphanumeric/underscore/hyphen with underscore.
+func sanitizeName(s string) string {
+	re := regexp.MustCompile(`[^a-z0-9_-]`)
+	return re.ReplaceAllString(strings.ToLower(s), "_")
+}
+
 func (s *TokenStore) migrate(ctx context.Context) error {
-	stmts := []string{
+	// Base schema (idempotent via IF NOT EXISTS).
+	baseStmts := []string{
 		`CREATE TABLE IF NOT EXISTS api_tokens (
 			id           BIGSERIAL PRIMARY KEY,
 			token_hash   BYTEA       NOT NULL UNIQUE,
@@ -81,20 +97,139 @@ func (s *TokenStore) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS idx_api_tokens_name
 		     ON api_tokens (name) WHERE revoked_at IS NULL`,
 	}
-	for _, stmt := range stmts {
+	for _, stmt := range baseStmts {
 		if _, err := s.pool.Exec(ctx, stmt); err != nil {
 			return fmt.Errorf("token store migrate: %w\nstatement: %s", err, stmt)
 		}
 	}
+
+	// Check whether memstore_users exists (store migration must precede token migration).
+	var usersExist bool
+	if err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'memstore_users')`,
+	).Scan(&usersExist); err != nil {
+		return fmt.Errorf("token store migrate: checking memstore_users: %w", err)
+	}
+	if !usersExist {
+		return fmt.Errorf("memstore_users table not found; run store migration before token migration")
+	}
+
+	// Check whether user_id column already exists on api_tokens.
+	var colExists bool
+	if err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			 WHERE table_name = 'api_tokens' AND column_name = 'user_id'
+		)`,
+	).Scan(&colExists); err != nil {
+		return fmt.Errorf("token store migrate: checking user_id column: %w", err)
+	}
+	if colExists {
+		return nil // already migrated
+	}
+
+	// Add user_id nullable first so we can backfill.
+	if _, err := s.pool.Exec(ctx, `ALTER TABLE api_tokens ADD COLUMN IF NOT EXISTS user_id BIGINT`); err != nil {
+		return fmt.Errorf("token store migrate: add user_id: %w", err)
+	}
+
+	// Check if there are any existing rows to backfill.
+	var rowCount int
+	if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM api_tokens`).Scan(&rowCount); err != nil {
+		return fmt.Errorf("token store migrate: counting tokens: %w", err)
+	}
+
+	if rowCount > 0 {
+		// Look up or resolve the default user from memstore_meta.
+		var defaultUser string
+		if err := s.pool.QueryRow(ctx, `SELECT value FROM memstore_meta WHERE key = 'default_user'`).Scan(&defaultUser); err != nil {
+			return fmt.Errorf("token store migrate: reading default_user from memstore_meta: %w. Run 'memstore admin tier3-init --default-user <name>' first", err)
+		}
+
+		// Resolve user_id from memstore_users.
+		var defaultUID int64
+		if err := s.pool.QueryRow(ctx,
+			`SELECT id FROM memstore_users WHERE name = $1 LIMIT 1`, defaultUser,
+		).Scan(&defaultUID); err != nil {
+			return fmt.Errorf("token store migrate: resolving user %q in memstore_users: %w", defaultUser, err)
+		}
+
+		// Rewrite token names and backfill user_id.
+		// Rules:
+		//   "matthew-laptop" -> "matthew@laptop"
+		//   "legacy"         -> "<defaultUser>@legacy"
+		//   other            -> "<defaultUser>@<sanitized>" (with a logged warning)
+		rows, err := s.pool.Query(ctx, `SELECT id, name FROM api_tokens`)
+		if err != nil {
+			return fmt.Errorf("token store migrate: reading token names: %w", err)
+		}
+		type tokenRow struct {
+			id   int64
+			name string
+		}
+		var tokens []tokenRow
+		for rows.Next() {
+			var r tokenRow
+			if err := rows.Scan(&r.id, &r.name); err != nil {
+				rows.Close()
+				return fmt.Errorf("token store migrate: scanning token: %w", err)
+			}
+			tokens = append(tokens, r)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("token store migrate: iterating tokens: %w", err)
+		}
+
+		for _, tok := range tokens {
+			newName := tok.name
+			if idx := strings.IndexByte(tok.name, '-'); idx > 0 {
+				// "user-host" -> "user@host"
+				newName = tok.name[:idx] + "@" + tok.name[idx+1:]
+			} else if tok.name == "legacy" {
+				newName = defaultUser + "@legacy"
+			} else {
+				safe := sanitizeName(tok.name)
+				newName = defaultUser + "@" + safe
+				log.Printf("token store migrate: renaming unrecognized token %q -> %q", tok.name, newName)
+			}
+
+			if _, err := s.pool.Exec(ctx,
+				`UPDATE api_tokens SET name = $1, user_id = $2 WHERE id = $3`,
+				newName, defaultUID, tok.id,
+			); err != nil {
+				return fmt.Errorf("token store migrate: updating token %d: %w", tok.id, err)
+			}
+		}
+	}
+	// user_id remains nullable on fresh DBs -- Issue always requires UserID,
+	// so no new rows will have NULL. We skip SET NOT NULL to avoid a full
+	// table rewrite on large deployments and because fresh DBs have no rows.
+
+	// Add index for user-scoped token lookups.
+	if _, err := s.pool.Exec(ctx,
+		`CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens (user_id) WHERE revoked_at IS NULL`,
+	); err != nil {
+		return fmt.Errorf("token store migrate: create user index: %w", err)
+	}
+
 	return nil
 }
 
 // Issue mints a new token, stores its hash, and returns the plaintext token.
-// The plaintext is returned exactly once — it cannot be retrieved later.
+// The plaintext is returned exactly once -- it cannot be retrieved later.
 // Callers must surface it to the operator immediately and refuse to log it.
+//
+// Token names must match the <user>@<host> shape. opts.UserID is required.
 func (s *TokenStore) Issue(ctx context.Context, name string, opts IssueOpts) (string, error) {
 	if name == "" {
 		return "", errors.New("token name is required")
+	}
+	if !tokenNameRe.MatchString(name) {
+		return "", fmt.Errorf("token name %q must match <user>@<host> (e.g. matthew@laptop)", name)
+	}
+	if opts.UserID == 0 {
+		return "", errors.New("token store issue: UserID is required")
 	}
 	token, err := generateToken()
 	if err != nil {
@@ -113,9 +248,9 @@ func (s *TokenStore) Issue(ctx context.Context, name string, opts IssueOpts) (st
 	}
 
 	_, err = s.pool.Exec(ctx, `
-		INSERT INTO api_tokens (token_hash, name, scopes, expires_at)
-		VALUES ($1, $2, $3, $4)
-	`, hash, name, scopes, expiresAt)
+		INSERT INTO api_tokens (token_hash, name, user_id, scopes, expires_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`, hash, name, opts.UserID, scopes, expiresAt)
 	if err != nil {
 		return "", fmt.Errorf("token store insert: %w", err)
 	}
@@ -137,14 +272,15 @@ func (s *TokenStore) Verify(ctx context.Context, token string) (VerifyResult, er
 		id     int64
 		name   string
 		scopes []string
+		userID int64
 	)
 	err := s.pool.QueryRow(ctx, `
-		SELECT id, name, scopes
+		SELECT id, name, scopes, COALESCE(user_id, 0)
 		  FROM api_tokens
 		 WHERE token_hash = $1
 		   AND revoked_at IS NULL
 		   AND (expires_at IS NULL OR expires_at > now())
-	`, hash).Scan(&id, &name, &scopes)
+	`, hash).Scan(&id, &name, &scopes, &userID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return VerifyResult{}, ErrTokenInvalid
 	}
@@ -155,14 +291,14 @@ func (s *TokenStore) Verify(ctx context.Context, token string) (VerifyResult, er
 	// Best-effort last_used_at update; failure here doesn't fail the request.
 	_, _ = s.pool.Exec(ctx, `UPDATE api_tokens SET last_used_at = now() WHERE id = $1`, id)
 
-	return VerifyResult{Name: name, Scopes: scopes}, nil
+	return VerifyResult{Name: name, Scopes: scopes, UserID: userID}, nil
 }
 
 // List returns metadata for all non-revoked tokens, ordered by creation time.
 // The plaintext token is never returned (it's not stored).
 func (s *TokenStore) List(ctx context.Context) ([]TokenInfo, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, name, scopes, created_at, last_used_at, expires_at, revoked_at
+		SELECT id, name, COALESCE(user_id, 0), scopes, created_at, last_used_at, expires_at, revoked_at
 		  FROM api_tokens
 		 WHERE revoked_at IS NULL
 		 ORDER BY created_at
@@ -175,7 +311,7 @@ func (s *TokenStore) List(ctx context.Context) ([]TokenInfo, error) {
 	var out []TokenInfo
 	for rows.Next() {
 		var t TokenInfo
-		if err := rows.Scan(&t.ID, &t.Name, &t.Scopes, &t.CreatedAt, &t.LastUsedAt, &t.ExpiresAt, &t.RevokedAt); err != nil {
+		if err := rows.Scan(&t.ID, &t.Name, &t.UserID, &t.Scopes, &t.CreatedAt, &t.LastUsedAt, &t.ExpiresAt, &t.RevokedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, t)

--- a/pgstore/tokens_test.go
+++ b/pgstore/tokens_test.go
@@ -10,9 +10,10 @@ import (
 	"github.com/matthewjhunter/memstore/pgstore"
 )
 
-// newTokenStore returns a fresh TokenStore with the api_tokens table cleaned.
+// newTokenStore returns a fresh TokenStore with a clean schema including the
+// memstore_users and memstore_meta tables that token migration requires.
 // Skips if MEMSTORE_TEST_PG is unset.
-func newTokenStore(t *testing.T) *pgstore.TokenStore {
+func newTokenStore(t *testing.T) (*pgstore.TokenStore, int64) {
 	t.Helper()
 	ctx := context.Background()
 	dsn := testDSN(t)
@@ -22,20 +23,54 @@ func newTokenStore(t *testing.T) *pgstore.TokenStore {
 		t.Fatalf("connecting to postgres: %v", err)
 	}
 	t.Cleanup(pool.Close)
+
+	// Drop in reverse dependency order.
 	pool.Exec(ctx, `DROP TABLE IF EXISTS api_tokens`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
+
+	// Seed the tables token migration depends on.
+	if _, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS memstore_users (
+		id         BIGSERIAL   PRIMARY KEY,
+		namespace  TEXT        NOT NULL,
+		name       TEXT        NOT NULL,
+		created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+		UNIQUE (namespace, name)
+	)`); err != nil {
+		t.Fatalf("create memstore_users: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS memstore_meta (
+		key   TEXT PRIMARY KEY,
+		value TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("create memstore_meta: %v", err)
+	}
+
+	// Insert a default user and record it in meta.
+	var defaultUID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO memstore_users (namespace, name) VALUES ('', 'testuser') RETURNING id`,
+	).Scan(&defaultUID); err != nil {
+		t.Fatalf("insert default user: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO memstore_meta (key, value) VALUES ('default_user', 'testuser')`,
+	); err != nil {
+		t.Fatalf("insert default_user meta: %v", err)
+	}
 
 	ts, err := pgstore.NewTokenStore(ctx, pool)
 	if err != nil {
 		t.Fatalf("NewTokenStore: %v", err)
 	}
-	return ts
+	return ts, defaultUID
 }
 
 func TestTokenStore_IssueAndVerify(t *testing.T) {
-	ts := newTokenStore(t)
+	ts, uid := newTokenStore(t)
 	ctx := context.Background()
 
-	tok, err := ts.Issue(ctx, "matthew-laptop", pgstore.IssueOpts{Scopes: []string{"read", "write"}})
+	tok, err := ts.Issue(ctx, "matthew@laptop", pgstore.IssueOpts{UserID: uid, Scopes: []string{"read", "write"}})
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
@@ -47,16 +82,19 @@ func TestTokenStore_IssueAndVerify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
-	if res.Name != "matthew-laptop" {
+	if res.Name != "matthew@laptop" {
 		t.Errorf("Name = %q", res.Name)
 	}
 	if len(res.Scopes) != 2 || res.Scopes[0] != "read" {
 		t.Errorf("Scopes = %v", res.Scopes)
 	}
+	if res.UserID != uid {
+		t.Errorf("UserID = %d, want %d", res.UserID, uid)
+	}
 }
 
 func TestTokenStore_Verify_Invalid(t *testing.T) {
-	ts := newTokenStore(t)
+	ts, _ := newTokenStore(t)
 	ctx := context.Background()
 
 	if _, err := ts.Verify(ctx, ""); !errors.Is(err, pgstore.ErrTokenInvalid) {
@@ -68,10 +106,10 @@ func TestTokenStore_Verify_Invalid(t *testing.T) {
 }
 
 func TestTokenStore_Revoke(t *testing.T) {
-	ts := newTokenStore(t)
+	ts, uid := newTokenStore(t)
 	ctx := context.Background()
 
-	tok, err := ts.Issue(ctx, "alice-laptop", pgstore.IssueOpts{})
+	tok, err := ts.Issue(ctx, "alice@laptop", pgstore.IssueOpts{UserID: uid})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +117,7 @@ func TestTokenStore_Revoke(t *testing.T) {
 		t.Fatalf("Verify before revoke: %v", err)
 	}
 
-	n, err := ts.Revoke(ctx, "alice-laptop")
+	n, err := ts.Revoke(ctx, "alice@laptop")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,14 +130,14 @@ func TestTokenStore_Revoke(t *testing.T) {
 }
 
 func TestTokenStore_Rotate(t *testing.T) {
-	ts := newTokenStore(t)
+	ts, uid := newTokenStore(t)
 	ctx := context.Background()
 
-	old, err := ts.Issue(ctx, "matthew-workstation", pgstore.IssueOpts{Scopes: []string{"read"}})
+	old, err := ts.Issue(ctx, "matthew@workstation", pgstore.IssueOpts{UserID: uid, Scopes: []string{"read"}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	newTok, err := ts.Rotate(ctx, "matthew-workstation")
+	newTok, err := ts.Rotate(ctx, "matthew@workstation")
 	if err != nil {
 		t.Fatalf("Rotate: %v", err)
 	}
@@ -122,10 +160,10 @@ func TestTokenStore_Rotate(t *testing.T) {
 }
 
 func TestTokenStore_Expiry(t *testing.T) {
-	ts := newTokenStore(t)
+	ts, uid := newTokenStore(t)
 	ctx := context.Background()
 
-	tok, err := ts.Issue(ctx, "ephemeral", pgstore.IssueOpts{Expires: 50 * time.Millisecond})
+	tok, err := ts.Issue(ctx, "ephemeral@test", pgstore.IssueOpts{UserID: uid, Expires: 50 * time.Millisecond})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +178,7 @@ func TestTokenStore_Expiry(t *testing.T) {
 }
 
 func TestTokenStore_EnsureLegacyToken(t *testing.T) {
-	ts := newTokenStore(t)
+	ts, _ := newTokenStore(t)
 	ctx := context.Background()
 
 	// First call inserts.
@@ -181,13 +219,13 @@ func TestTokenStore_EnsureLegacyToken(t *testing.T) {
 }
 
 func TestTokenStore_List(t *testing.T) {
-	ts := newTokenStore(t)
+	ts, uid := newTokenStore(t)
 	ctx := context.Background()
 
-	if _, err := ts.Issue(ctx, "a", pgstore.IssueOpts{}); err != nil {
+	if _, err := ts.Issue(ctx, "a@host", pgstore.IssueOpts{UserID: uid}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ts.Issue(ctx, "b", pgstore.IssueOpts{Scopes: []string{"read"}}); err != nil {
+	if _, err := ts.Issue(ctx, "b@host", pgstore.IssueOpts{UserID: uid, Scopes: []string{"read"}}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -198,19 +236,22 @@ func TestTokenStore_List(t *testing.T) {
 	if len(infos) != 2 {
 		t.Fatalf("List = %d items, want 2", len(infos))
 	}
-	if infos[0].Name != "a" || infos[1].Name != "b" {
-		t.Errorf("List order = [%s, %s], want [a, b]", infos[0].Name, infos[1].Name)
+	if infos[0].Name != "a@host" || infos[1].Name != "b@host" {
+		t.Errorf("List order = [%s, %s], want [a@host, b@host]", infos[0].Name, infos[1].Name)
+	}
+	if infos[0].UserID != uid {
+		t.Errorf("infos[0].UserID = %d, want %d", infos[0].UserID, uid)
 	}
 
 	// Revoked tokens drop out of List.
-	if _, err := ts.Revoke(ctx, "a"); err != nil {
+	if _, err := ts.Revoke(ctx, "a@host"); err != nil {
 		t.Fatal(err)
 	}
 	infos, err = ts.List(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(infos) != 1 || infos[0].Name != "b" {
+	if len(infos) != 1 || infos[0].Name != "b@host" {
 		t.Errorf("after revoke: %v", infos)
 	}
 }

--- a/pgstore/tokens_test.go
+++ b/pgstore/tokens_test.go
@@ -149,13 +149,29 @@ func TestTokenStore_Rotate(t *testing.T) {
 	if _, err := ts.Verify(ctx, old); !errors.Is(err, pgstore.ErrTokenInvalid) {
 		t.Errorf("old token after rotate: got %v", err)
 	}
-	// New token works and preserves scopes.
+	// New token works and preserves scopes and owner.
 	res, err := ts.Verify(ctx, newTok)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(res.Scopes) != 1 || res.Scopes[0] != "read" {
 		t.Errorf("Scopes after rotate = %v", res.Scopes)
+	}
+	if res.UserID != uid {
+		t.Errorf("UserID after rotate = %d, want %d", res.UserID, uid)
+	}
+
+	// The rotated row keeps the original user_id (assert via List too).
+	infos, err := ts.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, info := range infos {
+		if info.Name == "matthew@workstation" && info.RevokedAt == nil {
+			if info.UserID != uid {
+				t.Errorf("List: rotated token UserID = %d, want %d", info.UserID, uid)
+			}
+		}
 	}
 }
 

--- a/search.go
+++ b/search.go
@@ -82,7 +82,7 @@ func (s *SQLiteStore) searchFTS(ctx context.Context, query string, opts SearchOp
 		return nil, nil
 	}
 
-	q := `SELECT f.id, f.namespace, f.content, f.subject, f.category, f.kind, f.subsystem, f.metadata,
+	q := `SELECT f.id, f.namespace, f.user_id, f.content, f.subject, f.category, f.kind, f.subsystem, f.metadata,
 	             f.superseded_by, f.superseded_at, f.confirmed_count, f.last_confirmed_at,
 	             f.use_count, f.last_used_at, f.embedding, f.created_at, rank
 	      FROM memstore_facts_fts fts
@@ -128,6 +128,7 @@ func (s *SQLiteStore) searchFTS(ctx context.Context, query string, opts SearchOp
 	var results []SearchResult
 	for rows.Next() {
 		var f Fact
+		var userID sql.NullInt64
 		var metadata sql.NullString
 		var supersededBy *int64
 		var supersededAt sql.NullString
@@ -138,7 +139,7 @@ func (s *SQLiteStore) searchFTS(ctx context.Context, query string, opts SearchOp
 		var rank float64
 
 		err := rows.Scan(
-			&f.ID, &f.Namespace, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
+			&f.ID, &f.Namespace, &userID, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
 			&metadata, &supersededBy, &supersededAt,
 			&f.ConfirmedCount, &lastConfirmedAt,
 			&f.UseCount, &lastUsedAt,
@@ -148,6 +149,9 @@ func (s *SQLiteStore) searchFTS(ctx context.Context, query string, opts SearchOp
 			return nil, fmt.Errorf("memstore: scanning FTS result: %w", err)
 		}
 
+		if userID.Valid {
+			f.UserID = userID.Int64
+		}
 		if metadata.Valid && metadata.String != "" {
 			f.Metadata = json.RawMessage(metadata.String)
 		}

--- a/sqlite.go
+++ b/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os/user"
 	"strings"
 	"sync"
 	"time"
@@ -12,11 +13,11 @@ import (
 	"github.com/matthewjhunter/go-embedding"
 )
 
-const schemaVersion = 11
+const schemaVersion = 12
 
 // factColumns is the canonical SELECT list for fact queries.
 // searchFTS has its own column list because it joins and adds rank.
-const factColumns = `id, namespace, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, embedding, created_at`
+const factColumns = `id, namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, embedding, created_at`
 
 // SQLiteStore implements Store backed by a caller-provided SQLite database.
 // It creates memstore_* tables and uses its own version tracking table so it
@@ -26,6 +27,7 @@ type SQLiteStore struct {
 	db        *sql.DB
 	embedder  embedding.Embedder // nil means FTS-only; embedding operations will fail
 	namespace string             // partition key for multi-tenant isolation
+	userID    int64              // resolved owner for this store; set after migrateV12
 	reranker  embedding.Reranker // nil means no second-stage rerank; set via SetReranker
 }
 
@@ -61,12 +63,60 @@ func NewSQLiteStore(db *sql.DB, embedder embedding.Embedder, namespace string) (
 	if err := s.migrate(); err != nil {
 		return nil, fmt.Errorf("memstore: migration: %w", err)
 	}
+	// Resolve the store's owning user. migrateV12 created or backfilled the row;
+	// for subsequent opens we just look it up from memstore_meta.
+	if uid, err := s.resolveOrCreateUser(); err != nil {
+		return nil, fmt.Errorf("memstore: resolving user: %w", err)
+	} else {
+		s.userID = uid
+	}
 	if embedder != nil {
 		if err := s.validateEmbedder(); err != nil {
 			return nil, err
 		}
 	}
 	return s, nil
+}
+
+// resolveOrCreateUser returns the user_id for the store's default user,
+// reading the name from memstore_meta key 'default_user'. If no row
+// exists in memstore_users yet (fresh DB case), it creates one using
+// the current OS user name, lowercased.
+func (s *SQLiteStore) resolveOrCreateUser() (int64, error) {
+	var name string
+	err := s.db.QueryRow(`SELECT value FROM memstore_meta WHERE key = 'default_user'`).Scan(&name)
+	if err == sql.ErrNoRows || name == "" {
+		// Fresh DB or pre-V12 meta missing: derive from OS user.
+		u, oserr := user.Current()
+		if oserr != nil {
+			name = "default"
+		} else {
+			name = strings.ToLower(u.Username)
+		}
+	} else if err != nil {
+		return 0, fmt.Errorf("reading default_user meta: %w", err)
+	}
+	return s.ensureUser(name)
+}
+
+// ensureUser creates a user row for (namespace, name) if one doesn't
+// exist and returns its id.
+func (s *SQLiteStore) ensureUser(name string) (int64, error) {
+	_, err := s.db.Exec(
+		`INSERT OR IGNORE INTO memstore_users (namespace, name, created_at) VALUES (?, ?, datetime('now'))`,
+		s.namespace, name,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("upserting user %q: %w", name, err)
+	}
+	var id int64
+	if err := s.db.QueryRow(
+		`SELECT id FROM memstore_users WHERE namespace = ? AND name = ?`,
+		s.namespace, name,
+	).Scan(&id); err != nil {
+		return 0, fmt.Errorf("looking up user %q: %w", name, err)
+	}
+	return id, nil
 }
 
 func (s *SQLiteStore) migrate() error {
@@ -154,6 +204,12 @@ func (s *SQLiteStore) migrate() error {
 		}
 	}
 
+	if version < 12 {
+		if err := s.migrateV12(); err != nil {
+			return err
+		}
+	}
+
 	if version == 0 {
 		_, err = s.db.Exec("INSERT INTO memstore_version (version) VALUES (?)", schemaVersion)
 	} else {
@@ -203,6 +259,116 @@ func (s *SQLiteStore) migrateV11() error {
 			return fmt.Errorf("memstore V11 migration: %w", err)
 		}
 	}
+	return nil
+}
+
+// migrateV12 introduces first-class user identity. It creates the
+// memstore_users table, adds user_id to facts and links (nullable --
+// SQLite cannot add NOT NULL without a table rebuild), backfills every
+// existing fact and link to the default OS user, and rewrites subject
+// to ” for non-identity/preference facts whose subject was the user's name.
+func (s *SQLiteStore) migrateV12() error {
+	// Determine default user name from OS.
+	defaultUser := "default"
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		defaultUser = strings.ToLower(u.Username)
+	}
+
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS memstore_users (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			namespace  TEXT NOT NULL,
+			name       TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			UNIQUE(namespace, name)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_memstore_users_namespace ON memstore_users(namespace)`,
+		`ALTER TABLE memstore_facts ADD COLUMN user_id INTEGER`,
+		`ALTER TABLE memstore_links ADD COLUMN user_id INTEGER`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.Exec(stmt); err != nil {
+			return fmt.Errorf("memstore V12 migration: %w\nstatement: %s", err, stmt)
+		}
+	}
+
+	// Collect distinct namespaces that already have facts.
+	rows, err := s.db.Query(`SELECT DISTINCT namespace FROM memstore_facts`)
+	if err != nil {
+		return fmt.Errorf("memstore V12 migration: listing namespaces: %w", err)
+	}
+	var namespaces []string
+	for rows.Next() {
+		var ns string
+		if err := rows.Scan(&ns); err != nil {
+			rows.Close()
+			return fmt.Errorf("memstore V12 migration: scanning namespace: %w", err)
+		}
+		namespaces = append(namespaces, ns)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("memstore V12 migration: iterating namespaces: %w", err)
+	}
+
+	// Ensure the store's own namespace is included (may have no facts yet).
+	found := false
+	for _, ns := range namespaces {
+		if ns == s.namespace {
+			found = true
+			break
+		}
+	}
+	if !found {
+		namespaces = append(namespaces, s.namespace)
+	}
+
+	// For each namespace: create user row, backfill facts and links.
+	for _, ns := range namespaces {
+		if _, err := s.db.Exec(
+			`INSERT OR IGNORE INTO memstore_users (namespace, name, created_at) VALUES (?, ?, datetime('now'))`,
+			ns, defaultUser,
+		); err != nil {
+			return fmt.Errorf("memstore V12 migration: creating user for ns %q: %w", ns, err)
+		}
+		var uid int64
+		if err := s.db.QueryRow(
+			`SELECT id FROM memstore_users WHERE namespace = ? AND name = ?`,
+			ns, defaultUser,
+		).Scan(&uid); err != nil {
+			return fmt.Errorf("memstore V12 migration: resolving user for ns %q: %w", ns, err)
+		}
+		if _, err := s.db.Exec(
+			`UPDATE memstore_facts SET user_id = ? WHERE namespace = ? AND user_id IS NULL`,
+			uid, ns,
+		); err != nil {
+			return fmt.Errorf("memstore V12 migration: backfilling facts ns %q: %w", ns, err)
+		}
+		if _, err := s.db.Exec(
+			`UPDATE memstore_links SET user_id = ? WHERE namespace = ? AND user_id IS NULL`,
+			uid, ns,
+		); err != nil {
+			return fmt.Errorf("memstore V12 migration: backfilling links ns %q: %w", ns, err)
+		}
+		// Subject rewrite: facts where subject was the user's name but is not
+		// an identity or preference fact had subject overloaded as ownership marker.
+		// Now that user_id carries ownership, free subject to mean topic only.
+		if _, err := s.db.Exec(
+			`UPDATE memstore_facts SET subject = '' WHERE namespace = ? AND subject = ? AND category NOT IN ('identity', 'preference')`,
+			ns, defaultUser,
+		); err != nil {
+			return fmt.Errorf("memstore V12 migration: subject rewrite ns %q: %w", ns, err)
+		}
+	}
+
+	// Record the default_user name for subsequent opens.
+	if _, err := s.db.Exec(
+		`INSERT OR REPLACE INTO memstore_meta (key, value) VALUES ('default_user', ?)`,
+		defaultUser,
+	); err != nil {
+		return fmt.Errorf("memstore V12 migration: recording default_user: %w", err)
+	}
+
 	return nil
 }
 
@@ -489,10 +655,15 @@ func (s *SQLiteStore) Insert(ctx context.Context, f Fact) (int64, error) {
 		metadata = &ms
 	}
 
+	userID := s.userID
+	if f.UserID != 0 {
+		userID = f.UserID
+	}
+
 	result, err := s.db.ExecContext(ctx,
-		`INSERT INTO memstore_facts (namespace, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.namespace, f.Content, f.Subject, f.Category, f.Kind, f.Subsystem, metadata,
+		`INSERT INTO memstore_facts (namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.namespace, userID, f.Content, f.Subject, f.Category, f.Kind, f.Subsystem, metadata,
 		f.SupersededBy, embBlob, f.CreatedAt.Format(time.RFC3339),
 	)
 	if err != nil {
@@ -514,8 +685,8 @@ func (s *SQLiteStore) InsertBatch(ctx context.Context, facts []Fact) error {
 	defer tx.Rollback()
 
 	stmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO memstore_facts (namespace, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO memstore_facts (namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	)
 	if err != nil {
 		return fmt.Errorf("memstore: preparing insert: %w", err)
@@ -539,8 +710,13 @@ func (s *SQLiteStore) InsertBatch(ctx context.Context, facts []Fact) error {
 			metadata = &ms
 		}
 
+		userID := s.userID
+		if facts[i].UserID != 0 {
+			userID = facts[i].UserID
+		}
+
 		result, err := stmt.ExecContext(ctx,
-			s.namespace, facts[i].Content, facts[i].Subject, facts[i].Category, facts[i].Kind, facts[i].Subsystem, metadata,
+			s.namespace, userID, facts[i].Content, facts[i].Subject, facts[i].Category, facts[i].Kind, facts[i].Subsystem, metadata,
 			facts[i].SupersededBy, embBlob, facts[i].CreatedAt.Format(time.RFC3339),
 		)
 		if err != nil {
@@ -1302,9 +1478,9 @@ func (s *SQLiteStore) LinkFacts(ctx context.Context, sourceID, targetID int64, l
 	}
 
 	result, err := s.db.ExecContext(ctx,
-		`INSERT INTO memstore_links (namespace, source_id, target_id, link_type, bidirectional, label, metadata, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.namespace, sourceID, targetID, linkType, bidi, label, metaStr, time.Now().UTC().Format(time.RFC3339),
+		`INSERT INTO memstore_links (namespace, user_id, source_id, target_id, link_type, bidirectional, label, metadata, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.namespace, s.userID, sourceID, targetID, linkType, bidi, label, metaStr, time.Now().UTC().Format(time.RFC3339),
 	)
 	if err != nil {
 		return 0, fmt.Errorf("memstore: creating link %d->%d: %w", sourceID, targetID, err)
@@ -1460,6 +1636,7 @@ type scanner interface {
 
 func scanFact(row scanner) (*Fact, error) {
 	var f Fact
+	var userID sql.NullInt64
 	var metadata sql.NullString
 	var supersededBy *int64
 	var supersededAt sql.NullString
@@ -1469,7 +1646,7 @@ func scanFact(row scanner) (*Fact, error) {
 	var createdAt string
 
 	err := row.Scan(
-		&f.ID, &f.Namespace, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
+		&f.ID, &f.Namespace, &userID, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
 		&metadata, &supersededBy, &supersededAt,
 		&f.ConfirmedCount, &lastConfirmedAt,
 		&f.UseCount, &lastUsedAt,
@@ -1477,6 +1654,9 @@ func scanFact(row scanner) (*Fact, error) {
 	)
 	if err != nil {
 		return nil, err
+	}
+	if userID.Valid {
+		f.UserID = userID.Int64
 	}
 
 	if metadata.Valid && metadata.String != "" {

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os/user"
 	"strings"
 	"sync"
 	"testing"
@@ -2043,4 +2044,203 @@ func TestConformance(t *testing.T) {
 			}
 		},
 	})
+}
+
+// TestMigrateV12 verifies the V12 schema migration: memstore_users exists, user_id
+// columns appear on facts and links, existing facts are backfilled with a non-null
+// user_id, and subject rewrite fires only for non-identity/preference facts.
+func TestMigrateV12(t *testing.T) {
+	osUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("user.Current: %v", err)
+	}
+	defaultUser := strings.ToLower(osUser.Username)
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// NewSQLiteStore runs all migrations including V12.
+	store, err := memstore.NewSQLiteStore(db, nil, "test")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+
+	// 1. memstore_users table must exist.
+	var usersTable string
+	if err := db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='memstore_users'`,
+	).Scan(&usersTable); err != nil {
+		t.Errorf("memstore_users table not found: %v", err)
+	}
+
+	// 2. user_id column must exist on memstore_facts and memstore_links.
+	for _, tbl := range []string{"memstore_facts", "memstore_links"} {
+		rows, err := db.Query(`PRAGMA table_info(` + tbl + `)`)
+		if err != nil {
+			t.Fatalf("PRAGMA table_info(%s): %v", tbl, err)
+		}
+		var found bool
+		for rows.Next() {
+			var cid int
+			var cname, ctype string
+			var notnull, pk int
+			var dflt sql.NullString
+			if err := rows.Scan(&cid, &cname, &ctype, &notnull, &dflt, &pk); err != nil {
+				rows.Close()
+				t.Fatalf("scanning table_info(%s): %v", tbl, err)
+			}
+			if cname == "user_id" {
+				found = true
+			}
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			t.Fatalf("table_info(%s) rows: %v", tbl, err)
+		}
+		if !found {
+			t.Errorf("user_id column not found in %s", tbl)
+		}
+	}
+
+	ctx := context.Background()
+
+	// 3. Insert a fact whose subject is the OS username with category "project"
+	// (non-identity, non-preference) -- should have subject rewritten to ''.
+	idProject, err := store.Insert(ctx, memstore.Fact{
+		Content:  "project fact",
+		Subject:  defaultUser,
+		Category: "project",
+	})
+	if err != nil {
+		t.Fatalf("Insert project fact: %v", err)
+	}
+
+	// 4. Insert a fact with category "identity" -- subject should NOT be rewritten.
+	idIdentity, err := store.Insert(ctx, memstore.Fact{
+		Content:  "identity fact",
+		Subject:  defaultUser,
+		Category: "identity",
+	})
+	if err != nil {
+		t.Fatalf("Insert identity fact: %v", err)
+	}
+
+	// 5. user_id must be non-zero for both (backfill from migration or insert path).
+	for _, id := range []int64{idProject, idIdentity} {
+		f, err := store.Get(ctx, id)
+		if err != nil {
+			t.Fatalf("Get(id=%d): %v", id, err)
+		}
+		if f == nil {
+			t.Fatalf("Get(id=%d): nil", id)
+		}
+		if f.UserID == 0 {
+			t.Errorf("fact id=%d has UserID=0; expected non-zero after V12", id)
+		}
+	}
+
+	// 6. Simulate backfill: open a second store on the same DB with a pre-existing
+	// fact whose subject was the OS username in a non-identity category. We verify
+	// via raw SQL that after migration the subject was cleared.
+	// (Since we're on a fresh DB that ran V12 already, we just check the insert
+	// path sets user_id correctly. Actual subject rewrite is tested via migration
+	// on an existing DB below.)
+
+	// 7. Simulate a pre-V12 DB: create a raw DB, insert a fact with subject ==
+	// defaultUser in category "project", set version to 11, then open with
+	// NewSQLiteStore to trigger V12.
+	rawDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rawDB.Close()
+
+	if _, err := rawDB.Exec(`PRAGMA foreign_keys = ON`); err != nil {
+		t.Fatal(err)
+	}
+	// Build a V11 schema manually.
+	v11Stmts := []string{
+		`CREATE TABLE memstore_version (version INTEGER NOT NULL)`,
+		`INSERT INTO memstore_version VALUES (11)`,
+		`CREATE TABLE memstore_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+		`CREATE TABLE memstore_facts (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			namespace     TEXT NOT NULL DEFAULT '',
+			content       TEXT NOT NULL,
+			subject       TEXT NOT NULL,
+			category      TEXT NOT NULL,
+			kind          TEXT NOT NULL DEFAULT '',
+			subsystem     TEXT NOT NULL DEFAULT '',
+			metadata      TEXT,
+			superseded_by INTEGER REFERENCES memstore_facts(id),
+			superseded_at TEXT,
+			confirmed_count INTEGER NOT NULL DEFAULT 0,
+			last_confirmed_at TEXT,
+			use_count     INTEGER NOT NULL DEFAULT 0,
+			last_used_at  TEXT,
+			embedding     BLOB,
+			created_at    TEXT NOT NULL,
+			embed_failed_at INTEGER,
+			embed_error   TEXT
+		)`,
+		`CREATE TABLE memstore_links (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			namespace     TEXT NOT NULL DEFAULT '',
+			source_id     INTEGER NOT NULL REFERENCES memstore_facts(id) ON DELETE CASCADE,
+			target_id     INTEGER NOT NULL REFERENCES memstore_facts(id) ON DELETE CASCADE,
+			link_type     TEXT NOT NULL DEFAULT 'reference',
+			bidirectional INTEGER NOT NULL DEFAULT 0,
+			label         TEXT NOT NULL DEFAULT '',
+			metadata      TEXT,
+			created_at    TEXT NOT NULL
+		)`,
+		// Insert fixture facts: one "project" (subject should be rewritten), one "identity" (kept).
+		fmt.Sprintf(`INSERT INTO memstore_facts (namespace, content, subject, category, created_at)
+			VALUES ('test', 'project fact', '%s', 'project', datetime('now'))`, defaultUser),
+		fmt.Sprintf(`INSERT INTO memstore_facts (namespace, content, subject, category, created_at)
+			VALUES ('test', 'identity fact', '%s', 'identity', datetime('now'))`, defaultUser),
+	}
+	for _, s := range v11Stmts {
+		if _, err := rawDB.Exec(s); err != nil {
+			t.Fatalf("V11 fixture setup: %v\nstmt: %s", err, s)
+		}
+	}
+
+	// Open with NewSQLiteStore -- this triggers migrateV12.
+	if _, err := memstore.NewSQLiteStore(rawDB, nil, "test"); err != nil {
+		t.Fatalf("NewSQLiteStore on V11 fixture: %v", err)
+	}
+
+	// Verify subject rewrite: "project" fact's subject should now be ''.
+	rows, err := rawDB.Query(`SELECT subject, category, user_id FROM memstore_facts ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query facts after V12: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var subject, category string
+		var userID sql.NullInt64
+		if err := rows.Scan(&subject, &category, &userID); err != nil {
+			t.Fatalf("scanning fact: %v", err)
+		}
+		if !userID.Valid || userID.Int64 == 0 {
+			t.Errorf("category=%q: user_id is null/zero after V12 backfill", category)
+		}
+		switch category {
+		case "project":
+			if subject != "" {
+				t.Errorf("project fact: subject should be '' after subject rewrite, got %q", subject)
+			}
+		case "identity":
+			if subject != defaultUser {
+				t.Errorf("identity fact: subject should be %q (unchanged), got %q", defaultUser, subject)
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating facts: %v", err)
+	}
 }

--- a/store.go
+++ b/store.go
@@ -18,8 +18,9 @@ const MaxContentLength = 8000
 type Fact struct {
 	ID              int64
 	Namespace       string          // partition key; set automatically by the store on insert
+	UserID          int64           `json:"user_id,omitempty"` // owning user; set automatically from the store's resolved identity
 	Content         string          // the factual claim
-	Subject         string          // entity being described
+	Subject         string          // topic of the fact (not ownership -- see UserID)
 	Category        string          // freeform: "character", "preference", "identity", etc.
 	Kind            string          // structural type: convention | failure_mode | invariant | pattern | decision | trigger | task | ""
 	Subsystem       string          // optional project subsystem (e.g. "feeds", "auth"); scopes facts within a subject

--- a/transfer.go
+++ b/transfer.go
@@ -19,11 +19,12 @@ type ExportData struct {
 }
 
 // ExportedFact represents a single fact in an export. Embeddings are
-// deliberately excluded — they're model-specific binary blobs that don't
+// deliberately excluded -- they're model-specific binary blobs that don't
 // transfer portably. Re-embed after import via EmbedFacts().
 type ExportedFact struct {
 	ID              int64           `json:"id"`
 	Namespace       string          `json:"namespace"`
+	User            string          `json:"user,omitempty"` // owner name from memstore_users; empty means import uses target default
 	Content         string          `json:"content"`
 	Subject         string          `json:"subject"`
 	Category        string          `json:"category"`
@@ -62,10 +63,12 @@ func Export(ctx context.Context, db *sql.DB) (*ExportData, error) {
 	}
 
 	rows, err := db.QueryContext(ctx,
-		`SELECT id, namespace, content, subject, category, kind, subsystem, metadata,
-		        superseded_by, superseded_at, confirmed_count, last_confirmed_at,
-		        use_count, last_used_at, created_at
-		 FROM memstore_facts ORDER BY id`)
+		`SELECT f.id, f.namespace, COALESCE(u.name, ''), f.content, f.subject, f.category, f.kind, f.subsystem, f.metadata,
+		        f.superseded_by, f.superseded_at, f.confirmed_count, f.last_confirmed_at,
+		        f.use_count, f.last_used_at, f.created_at
+		 FROM memstore_facts f
+		 LEFT JOIN memstore_users u ON u.id = f.user_id
+		 ORDER BY f.id`)
 	if err != nil {
 		return nil, fmt.Errorf("memstore export: querying facts: %w", err)
 	}
@@ -80,7 +83,7 @@ func Export(ctx context.Context, db *sql.DB) (*ExportData, error) {
 		var lastUsedAt sql.NullString
 		var createdAt string
 
-		if err := rows.Scan(&ef.ID, &ef.Namespace, &ef.Content, &ef.Subject, &ef.Category,
+		if err := rows.Scan(&ef.ID, &ef.Namespace, &ef.User, &ef.Content, &ef.Subject, &ef.Category,
 			&ef.Kind, &ef.Subsystem, &metadata, &supersededBy, &supersededAt,
 			&ef.ConfirmedCount, &lastConfirmedAt,
 			&ef.UseCount, &lastUsedAt, &createdAt); err != nil {

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -306,3 +306,123 @@ func TestExportIncludesSuperseded(t *testing.T) {
 		t.Error("superseded fact should have SupersededAt set")
 	}
 }
+
+// TestExportRoundTrip_UserPreserved verifies that the User field in ExportedFact
+// is populated on export and that a re-imported fact has a non-zero UserID.
+func TestExportRoundTrip_UserPreserved(t *testing.T) {
+	srcDB := openTestDB(t)
+	store, err := memstore.NewSQLiteStore(srcDB, nil, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	id, err := store.Insert(ctx, memstore.Fact{
+		Content: "user ownership fact", Subject: "test-subject", Category: "project",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the inserted fact has a non-zero UserID.
+	inserted, err := store.Get(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inserted.UserID == 0 {
+		t.Fatal("inserted fact has UserID=0; store should set it from resolved identity")
+	}
+
+	// Export: the ExportedFact.User field should be the user's name.
+	data, err := memstore.Export(ctx, srcDB)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if len(data.Facts) != 1 {
+		t.Fatalf("exported %d facts, want 1", len(data.Facts))
+	}
+	if data.Facts[0].User == "" {
+		t.Error("ExportedFact.User is empty; expected the owning user name")
+	}
+
+	// Import into a fresh DB and verify UserID is populated.
+	dstDB := openTestDB(t)
+	if _, err := memstore.NewSQLiteStore(dstDB, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	result, err := memstore.Import(ctx, dstDB, data, memstore.ImportOpts{})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if result.Imported != 1 {
+		t.Fatalf("imported = %d, want 1", result.Imported)
+	}
+
+	dstStore, err := memstore.NewSQLiteStore(dstDB, nil, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	facts, err := dstStore.List(ctx, memstore.QueryOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("dst facts = %d, want 1", len(facts))
+	}
+	if facts[0].UserID == 0 {
+		t.Error("imported fact has UserID=0; should have been assigned from default user")
+	}
+}
+
+// TestImport_LegacyExportNoUser verifies that a legacy export record with an
+// empty User field still imports successfully and gets the destination store's
+// default user assigned as UserID.
+func TestImport_LegacyExportNoUser(t *testing.T) {
+	// Build a synthetic export with no User field (simulates a pre-V12 export).
+	data := &memstore.ExportData{
+		Version:    1,
+		ExportedAt: time.Now().UTC(),
+		Facts: []memstore.ExportedFact{
+			{
+				ID:        1,
+				Namespace: "test",
+				User:      "", // empty = legacy, no user recorded
+				Content:   "legacy fact",
+				Subject:   "legacy-subject",
+				Category:  "project",
+				CreatedAt: time.Now().UTC(),
+			},
+		},
+	}
+
+	ctx := context.Background()
+	dstDB := openTestDB(t)
+	if _, err := memstore.NewSQLiteStore(dstDB, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := memstore.Import(ctx, dstDB, data, memstore.ImportOpts{})
+	if err != nil {
+		t.Fatalf("Import legacy export: %v", err)
+	}
+	if result.Imported != 1 {
+		t.Fatalf("imported = %d, want 1", result.Imported)
+	}
+
+	dstStore, err := memstore.NewSQLiteStore(dstDB, nil, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	facts, err := dstStore.List(ctx, memstore.QueryOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("dst facts = %d, want 1", len(facts))
+	}
+	// With a legacy export (User == ""), the importer falls back to the store's
+	// default user, so UserID must be non-zero.
+	if facts[0].UserID == 0 {
+		t.Error("legacy-imported fact has UserID=0; should have been assigned from default user")
+	}
+}


### PR DESCRIPTION
Phase 1 of 4 for v0.4.0 multi-user isolation (spec: plans/009; design: docs/tier3-permissions.md Phase 0 with three documented deltas). Deliberately inert for reads: users become first-class rows, every fact and link records its owner, tokens bind to users, and all new writes are stamped -- but no read path filters by user yet (phase 2) and the daemon still serves a single identity (phase 3). Every pre-existing test passes unchanged except the sanctioned cases (grown token API, fresh-DB construction semantics).

What lands:
- memstore_users table on both backends; sqlite V12 / pgstore V4 migrations with per-namespace backfill, the Phase 0 subject rewrite (ownership-marking subjects freed to '', identity/preference facts keep theirs), and token-name rewrite to the <user>@<host> convention.
- Default-user resolution per Phase 0: sqlite uses the OS user; pg infers from token-name prefixes, and fails into 'memstore admin tier3-init --default-user <name>' when inference is empty-with-data or ambiguous. InitIdentity shares the full migration body with migrateV4 so the two paths cannot drift.
- api_tokens.user_id NOT NULL + FK; Issue requires an owner; Rotate preserves it; VerifyResult carries it (phase 3 consumes this).
- All four scan-site groups updated for user_id; transfer exports ownership by user NAME so dumps stay portable across databases; legacy exports import as the target's default user.
- Conformance InsertGetRoundTrip now pins UserID round-tripping.

Operational note: a FRESH pg deployment now requires 'memstore admin tier3-init --default-user <name>' once before memstored starts -- no implicit user is ever invented. Existing single-user deployments migrate automatically via inference.

Review history: three rounds against a real pgvector container. Round 1 caught a NULL-vs-'' subject deviation that would have broken reads of rewritten rows, an InitIdentity that could not run after the rollback that necessitates it, a silent no-backfill path, and a missing NOT NULL. Rounds 2-3 were pg-only test fixtures for the new fresh-DB semantics plus the Rotate ownership bug. Final state: lint clean, full race suite green on a fresh Postgres including all migration fixtures.

Plan: plans/010-identity-schema-migration.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)