### PR TITLE
pgstore: owner-only enforcement -- user predicates, ForUser, UserIsolation battery (v0.4.0 phase 2)

### DIFF
--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -17,6 +17,7 @@ package conformance
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/matthewjhunter/memstore"
@@ -40,6 +41,11 @@ type Options struct {
 	// (? placeholders for SQLite, $N for Postgres). Required for
 	// HistoryCycleTerminates; if nil that subtest is skipped.
 	SetSupersededBy func(t *testing.T, supersededByID, targetID int64)
+
+	// NewTwoUserStores returns two stores over the SAME underlying database
+	// and namespace, scoped to two DIFFERENT users. nil skips the
+	// UserIsolation family (backends without per-user scoping).
+	NewTwoUserStores func(t *testing.T) (memstore.Store, memstore.Store)
 }
 
 // Run executes the shared Store contract tests using the factories in opts.
@@ -85,6 +91,45 @@ func Run(t *testing.T, opts Options) {
 			t.Skip("NewStoreNS not provided; skipping namespace isolation test")
 		}
 		testNamespaceIsolation(t, opts.NewStoreNS)
+	})
+	t.Run("UserIsolation", func(t *testing.T) {
+		// Each subtest skips individually (rather than skipping the parent)
+		// so backends without per-user scoping show the family as SKIPPED,
+		// not absent.
+		newTwo := func(t *testing.T) (memstore.Store, memstore.Store) {
+			t.Helper()
+			if opts.NewTwoUserStores == nil {
+				t.Skip("NewTwoUserStores not provided; skipping user isolation test")
+			}
+			return opts.NewTwoUserStores(t)
+		}
+		t.Run("GetCrossUserNotFound", func(t *testing.T) {
+			a, b := newTwo(t)
+			testGetCrossUserNotFound(t, a, b)
+		})
+		t.Run("ListAndSearchIsolated", func(t *testing.T) {
+			a, b := newTwo(t)
+			testListAndSearchIsolated(t, a, b)
+		})
+		t.Run("MutationsIsolated", func(t *testing.T) {
+			a, b := newTwo(t)
+			testMutationsIsolated(t, a, b)
+		})
+		t.Run("LinksIsolated", func(t *testing.T) {
+			a, b := newTwo(t)
+			testLinksIsolated(t, a, b)
+		})
+		t.Run("HistoryCannotCrossUsers", func(t *testing.T) {
+			a, b := newTwo(t)
+			if opts.SetSupersededBy == nil {
+				t.Skip("SetSupersededBy not provided; skipping cross-user history test")
+			}
+			testHistoryCannotCrossUsers(t, a, b, opts.SetSupersededBy)
+		})
+		t.Run("EmbedPipelineIsolated", func(t *testing.T) {
+			a, b := newTwo(t)
+			testEmbedPipelineIsolated(t, a, b)
+		})
 	})
 }
 
@@ -634,5 +679,371 @@ func testNamespaceIsolation(t *testing.T, newStoreNS func(*testing.T, string) me
 	}
 	if exists {
 		t.Error("sB.Exists should not find alpha's fact")
+	}
+}
+
+// --- UserIsolation subtests ---
+//
+// Each subtest receives two stores over the same database and namespace,
+// scoped to different users (A seeds, B probes). The contract under test is
+// plan 009 D2: owner-only access on every read and write path, with
+// cross-user access indistinguishable from nonexistent data.
+
+// missingFactID is an id far beyond anything a fresh test database assigns,
+// used to compare cross-user outcomes against the nonexistent-id outcome.
+const missingFactID = int64(1) << 60
+
+func testGetCrossUserNotFound(t *testing.T, a, b memstore.Store) {
+	t.Helper()
+	ctx := context.Background()
+
+	id, err := a.Insert(ctx, memstore.Fact{Content: "user A private fact", Subject: "iso", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert A: %v", err)
+	}
+
+	crossFact, crossErr := b.Get(ctx, id)
+	missingFact, missingErr := b.Get(ctx, missingFactID)
+
+	if crossFact != nil {
+		t.Fatalf("B.Get(A's id) returned a fact: %+v", crossFact)
+	}
+	if missingFact != nil {
+		t.Fatalf("B.Get(nonexistent id) returned a fact: %+v", missingFact)
+	}
+	// Existence must not leak: the cross-user outcome must be identical to
+	// the nonexistent-id outcome.
+	if fmt.Sprint(crossErr) != fmt.Sprint(missingErr) {
+		t.Errorf("B.Get(A's id) err = %v; B.Get(nonexistent) err = %v; outcomes must be identical", crossErr, missingErr)
+	}
+
+	// A still sees its own fact.
+	own, err := a.Get(ctx, id)
+	if err != nil || own == nil {
+		t.Fatalf("A.Get(own id) = (%v, %v), want fact", own, err)
+	}
+}
+
+func testListAndSearchIsolated(t *testing.T, a, b memstore.Store) {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, err := a.Insert(ctx, memstore.Fact{
+		Content: "zebra quantum heliotrope fact", Subject: "iso-subject",
+		Category: "test", Subsystem: "isosub",
+	}); err != nil {
+		t.Fatalf("Insert A: %v", err)
+	}
+
+	facts, err := b.List(ctx, memstore.QueryOpts{})
+	if err != nil {
+		t.Fatalf("B.List: %v", err)
+	}
+	if len(facts) != 0 {
+		t.Errorf("B.List sees %d of A's facts, want 0", len(facts))
+	}
+
+	bySub, err := b.BySubject(ctx, "iso-subject", false)
+	if err != nil {
+		t.Fatalf("B.BySubject: %v", err)
+	}
+	if len(bySub) != 0 {
+		t.Errorf("B.BySubject sees %d of A's facts, want 0", len(bySub))
+	}
+
+	exists, err := b.Exists(ctx, "zebra quantum heliotrope fact", "iso-subject")
+	if err != nil {
+		t.Fatalf("B.Exists: %v", err)
+	}
+	if exists {
+		t.Error("B.Exists found A's fact")
+	}
+
+	count, err := b.ActiveCount(ctx)
+	if err != nil {
+		t.Fatalf("B.ActiveCount: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("B.ActiveCount = %d, want 0", count)
+	}
+
+	fts, err := b.SearchFTS(ctx, "zebra quantum", memstore.SearchOpts{})
+	if err != nil {
+		t.Fatalf("B.SearchFTS: %v", err)
+	}
+	if len(fts) != 0 {
+		t.Errorf("B.SearchFTS returned %d of A's facts, want 0", len(fts))
+	}
+
+	hybrid, err := b.Search(ctx, "zebra quantum", memstore.SearchOpts{})
+	if err != nil {
+		t.Fatalf("B.Search: %v", err)
+	}
+	if len(hybrid) != 0 {
+		t.Errorf("B.Search returned %d of A's facts, want 0", len(hybrid))
+	}
+
+	batch, err := b.SearchBatch(ctx, []string{"zebra quantum"}, memstore.SearchOpts{})
+	if err != nil {
+		t.Fatalf("B.SearchBatch: %v", err)
+	}
+	for i, res := range batch {
+		if len(res) != 0 {
+			t.Errorf("B.SearchBatch[%d] returned %d of A's facts, want 0", i, len(res))
+		}
+	}
+
+	subs, err := b.ListSubsystems(ctx, "")
+	if err != nil {
+		t.Fatalf("B.ListSubsystems: %v", err)
+	}
+	if len(subs) != 0 {
+		t.Errorf("B.ListSubsystems sees A's subsystems: %v", subs)
+	}
+
+	// Swap roles: B seeds, A probes.
+	if _, err := b.Insert(ctx, memstore.Fact{
+		Content: "yonder gizmo flotsam fact", Subject: "iso-b", Category: "test",
+	}); err != nil {
+		t.Fatalf("Insert B: %v", err)
+	}
+	aFacts, err := a.List(ctx, memstore.QueryOpts{Subject: "iso-b"})
+	if err != nil {
+		t.Fatalf("A.List: %v", err)
+	}
+	if len(aFacts) != 0 {
+		t.Errorf("A.List sees %d of B's facts, want 0", len(aFacts))
+	}
+	aFTS, err := a.SearchFTS(ctx, "yonder gizmo", memstore.SearchOpts{})
+	if err != nil {
+		t.Fatalf("A.SearchFTS: %v", err)
+	}
+	if len(aFTS) != 0 {
+		t.Errorf("A.SearchFTS returned %d of B's facts, want 0", len(aFTS))
+	}
+}
+
+func testMutationsIsolated(t *testing.T, a, b memstore.Store) {
+	t.Helper()
+	ctx := context.Background()
+
+	id, err := a.Insert(ctx, memstore.Fact{
+		Content: "mutation target", Subject: "iso-mut", Category: "test",
+		Metadata: json.RawMessage(`{"k":"v"}`),
+	})
+	if err != nil {
+		t.Fatalf("Insert A: %v", err)
+	}
+	orig, err := a.Get(ctx, id)
+	if err != nil || orig == nil {
+		t.Fatalf("A.Get(own id) = (%v, %v), want fact", orig, err)
+	}
+
+	// Each mutation must produce the same outcome for A's id as for a
+	// nonexistent id (no existence leak), and leave A's data unchanged.
+	check := func(name string, fn func(id int64) error) {
+		t.Helper()
+		crossErr := fn(id)
+		missErr := fn(missingFactID)
+		if (crossErr == nil) != (missErr == nil) {
+			t.Errorf("B.%s: cross-user err = %v, nonexistent err = %v; outcomes must match", name, crossErr, missErr)
+		}
+	}
+
+	check("Confirm", func(x int64) error { return b.Confirm(ctx, x) })
+	check("Touch", func(x int64) error { return b.Touch(ctx, []int64{x}) })
+	check("UpdateMetadata", func(x int64) error { return b.UpdateMetadata(ctx, x, map[string]any{"k": "hacked"}) })
+	check("Supersede", func(x int64) error { return b.Supersede(ctx, x, x) })
+	check("SetEmbedding", func(x int64) error { return b.SetEmbedding(ctx, x, []float32{0.1, 0.2, 0.3, 0.4}) })
+	check("MarkEmbedFailed", func(x int64) error { return b.MarkEmbedFailed(ctx, x, "isolation probe") })
+	check("Delete", func(x int64) error { return b.Delete(ctx, x) })
+
+	after, err := a.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("A.Get after probes: %v", err)
+	}
+	if after == nil {
+		t.Fatal("A's fact was deleted by B")
+	}
+	if after.Content != orig.Content {
+		t.Errorf("Content changed: %q -> %q", orig.Content, after.Content)
+	}
+	if after.ConfirmedCount != orig.ConfirmedCount {
+		t.Errorf("ConfirmedCount changed: %d -> %d", orig.ConfirmedCount, after.ConfirmedCount)
+	}
+	if after.UseCount != orig.UseCount {
+		t.Errorf("UseCount changed: %d -> %d", orig.UseCount, after.UseCount)
+	}
+	if after.SupersededBy != nil {
+		t.Errorf("SupersededBy set by B: %v", *after.SupersededBy)
+	}
+	if string(after.Metadata) != string(orig.Metadata) {
+		t.Errorf("Metadata changed: %s -> %s", orig.Metadata, after.Metadata)
+	}
+
+	// The fact has no embedding, so it must still be in A's embed queue:
+	// B's SetEmbedding must not have landed, and B's MarkEmbedFailed must
+	// not have quarantined it.
+	pending, err := a.NeedingEmbedding(ctx, 100)
+	if err != nil {
+		t.Fatalf("A.NeedingEmbedding: %v", err)
+	}
+	found := false
+	for _, f := range pending {
+		if f.ID == id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("A's fact left the embed queue: B's SetEmbedding or MarkEmbedFailed landed")
+	}
+}
+
+func testLinksIsolated(t *testing.T, a, b memstore.Store) {
+	t.Helper()
+	ctx := context.Background()
+
+	src, err := a.Insert(ctx, memstore.Fact{Content: "link source", Subject: "iso-link", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert A src: %v", err)
+	}
+	tgt, err := a.Insert(ctx, memstore.Fact{Content: "link target", Subject: "iso-link", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert A tgt: %v", err)
+	}
+	linkID, err := a.LinkFacts(ctx, src, tgt, "ref", false, "a-link", nil)
+	if err != nil {
+		t.Fatalf("A.LinkFacts: %v", err)
+	}
+
+	// B cannot link A's facts, in any combination with its own.
+	bFact, err := b.Insert(ctx, memstore.Fact{Content: "b fact", Subject: "iso-link", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert B: %v", err)
+	}
+	if _, err := b.LinkFacts(ctx, src, tgt, "ref", false, "b-link", nil); err == nil {
+		t.Error("B.LinkFacts(A's src, A's tgt) succeeded")
+	}
+	if _, err := b.LinkFacts(ctx, bFact, tgt, "ref", false, "", nil); err == nil {
+		t.Error("B.LinkFacts(B's fact, A's tgt) succeeded")
+	}
+	if _, err := b.LinkFacts(ctx, src, bFact, "ref", false, "", nil); err == nil {
+		t.Error("B.LinkFacts(A's src, B's fact) succeeded")
+	}
+
+	// B cannot see or affect A's link.
+	if l, err := b.GetLink(ctx, linkID); err == nil {
+		t.Errorf("B.GetLink sees A's link: %+v", l)
+	}
+	links, err := b.GetLinks(ctx, src, memstore.LinkBoth)
+	if err != nil {
+		t.Fatalf("B.GetLinks: %v", err)
+	}
+	if len(links) != 0 {
+		t.Errorf("B.GetLinks sees %d of A's links, want 0", len(links))
+	}
+	if err := b.UpdateLink(ctx, linkID, "hacked", nil); err == nil {
+		t.Error("B.UpdateLink on A's link succeeded")
+	}
+	if err := b.DeleteLink(ctx, linkID); err == nil {
+		t.Error("B.DeleteLink on A's link succeeded")
+	}
+
+	// A's link is intact and unchanged.
+	l, err := a.GetLink(ctx, linkID)
+	if err != nil {
+		t.Fatalf("A.GetLink after probes: %v", err)
+	}
+	if l.Label != "a-link" {
+		t.Errorf("A's link label = %q, want %q", l.Label, "a-link")
+	}
+}
+
+func testHistoryCannotCrossUsers(t *testing.T, a, b memstore.Store, setSupersededBy func(t *testing.T, supersededByID, targetID int64)) {
+	t.Helper()
+	ctx := context.Background()
+
+	aID, err := a.Insert(ctx, memstore.Fact{Content: "user A chain head", Subject: "iso-hist", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert A: %v", err)
+	}
+	bID, err := b.Insert(ctx, memstore.Fact{Content: "user B secret", Subject: "iso-hist", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert B: %v", err)
+	}
+
+	// Forge A's fact's superseded_by to point at B's fact via a raw write.
+	setSupersededBy(t, bID, aID)
+
+	// A's history must terminate without ever returning B's fact, exactly
+	// as if superseded_by were dangling.
+	entries, err := a.History(ctx, aID, "")
+	if err != nil {
+		t.Fatalf("A.History: %v", err)
+	}
+	for _, e := range entries {
+		if e.Fact.ID == bID {
+			t.Errorf("A.History crossed into B's fact %d", bID)
+		}
+	}
+
+	// B's history of its own fact must not include A's.
+	bEntries, err := b.History(ctx, bID, "")
+	if err != nil {
+		t.Fatalf("B.History: %v", err)
+	}
+	for _, e := range bEntries {
+		if e.Fact.ID == aID {
+			t.Errorf("B.History crossed into A's fact %d", aID)
+		}
+	}
+
+	// Subject-based history is scoped too.
+	bSubj, err := b.History(ctx, 0, "iso-hist")
+	if err != nil {
+		t.Fatalf("B.History(subject): %v", err)
+	}
+	for _, e := range bSubj {
+		if e.Fact.ID == aID {
+			t.Errorf("B.History(subject) returned A's fact %d", aID)
+		}
+	}
+}
+
+func testEmbedPipelineIsolated(t *testing.T, a, b memstore.Store) {
+	t.Helper()
+	ctx := context.Background()
+
+	aID, err := a.Insert(ctx, memstore.Fact{Content: "unembedded fact of A", Subject: "iso-embed", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert A: %v", err)
+	}
+
+	// Sanity: the factory must produce an un-embedded fact for this test to
+	// mean anything. If the backend embeds at insert time, skip.
+	aPending, err := a.NeedingEmbedding(ctx, 100)
+	if err != nil {
+		t.Fatalf("A.NeedingEmbedding: %v", err)
+	}
+	found := false
+	for _, f := range aPending {
+		if f.ID == aID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Skip("factory embeds facts at insert; cannot produce an un-embedded fact to isolate")
+	}
+
+	bPending, err := b.NeedingEmbedding(ctx, 100)
+	if err != nil {
+		t.Fatalf("B.NeedingEmbedding: %v", err)
+	}
+	for _, f := range bPending {
+		if f.ID == aID {
+			t.Errorf("B.NeedingEmbedding returned A's fact %d", aID)
+		}
 	}
 }

--- a/pgstore/search.go
+++ b/pgstore/search.go
@@ -135,6 +135,7 @@ func (s *PostgresStore) searchFTS(ctx context.Context, query string, opts memsto
 	b.q += `)`
 
 	s.appendNamespaceFilter(&b, "f.namespace", opts.AllNamespaces, opts.Namespaces)
+	s.appendUserFilter(&b, "f.user_id")
 	if opts.OnlyActive {
 		b.q += ` AND f.superseded_by IS NULL`
 	}
@@ -217,6 +218,7 @@ func (s *PostgresStore) searchVector(ctx context.Context, queryEmb []float32, op
 	         WHERE embedding IS NOT NULL`
 
 	s.appendNamespaceFilter(&b, "namespace", opts.AllNamespaces, opts.Namespaces)
+	s.appendUserFilter(&b, "user_id")
 	if opts.OnlyActive {
 		b.q += ` AND superseded_by IS NULL`
 	}
@@ -258,7 +260,7 @@ func (s *PostgresStore) searchVector(ctx context.Context, queryEmb []float32, op
 		var similarity float64
 
 		err := rows.Scan(
-			&f.ID, &f.Namespace, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
+			&f.ID, &f.Namespace, &f.UserID, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
 			&metadata, &supersededBy, &supersededAt,
 			&f.ConfirmedCount, &lastConfirmedAt,
 			&f.UseCount, &lastUsedAt,

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -112,6 +112,59 @@ func (s *PostgresStore) resolveUser(ctx context.Context) (int64, error) {
 	return id, nil
 }
 
+// PostgresStore supports per-user scoping.
+var _ memstore.UserScoper = (*PostgresStore)(nil)
+
+// ForUser returns a cheap clone of the store scoped to the given user: every
+// read and write the clone performs carries the owner predicate for userID.
+// The clone shares the pool, embedder, query cache, and reranker with the
+// receiver and runs no migrations. userID must be positive.
+func (s *PostgresStore) ForUser(userID int64) (memstore.Store, error) {
+	if userID <= 0 {
+		return nil, fmt.Errorf("pgstore: ForUser: invalid user id %d", userID)
+	}
+	c := *s
+	c.userID = userID
+	return &c, nil
+}
+
+// ServiceScope returns a clone of the store with NO user predicate: it sees
+// and can touch every user's facts and links in the namespace.
+//
+// This scope is PRIVILEGED. It exists only for daemon-internal workers
+// (embedding backfill, curation) that must operate across users; never hand
+// it to anything serving an end-user request.
+func (s *PostgresStore) ServiceScope() *PostgresStore {
+	c := *s
+	c.userID = 0
+	return &c
+}
+
+// EnsureUser resolves or creates the user row for name in namespace and
+// returns its id. Idempotent. Intended for admin tooling (user provisioning)
+// and tests; it does not touch memstore_meta['default_user'].
+func EnsureUser(ctx context.Context, pool *pgxpool.Pool, namespace, name string) (int64, error) {
+	if name == "" {
+		return 0, fmt.Errorf("pgstore: EnsureUser: name must not be empty")
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO memstore_users (namespace, name)
+		 VALUES ($1, $2)
+		 ON CONFLICT (namespace, name) DO NOTHING`,
+		namespace, name,
+	); err != nil {
+		return 0, fmt.Errorf("pgstore: EnsureUser: creating user %q: %w", name, err)
+	}
+	var id int64
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM memstore_users WHERE namespace = $1 AND name = $2`,
+		namespace, name,
+	).Scan(&id); err != nil {
+		return 0, fmt.Errorf("pgstore: EnsureUser: looking up user %q: %w", name, err)
+	}
+	return id, nil
+}
+
 // InitIdentity seeds the identity schema with an operator-supplied default
 // user. This is the implementation behind
 // 'memstore admin tier3-init --default-user <name>'.
@@ -713,11 +766,18 @@ func (s *PostgresStore) InsertBatch(ctx context.Context, facts []memstore.Fact) 
 // Supersede marks an old fact as superseded by a new fact.
 func (s *PostgresStore) Supersede(ctx context.Context, oldID, newID int64) error {
 	now := time.Now().UTC()
-	ct, err := s.pool.Exec(ctx,
-		`UPDATE memstore_facts SET superseded_by = $1, superseded_at = $2
-		 WHERE id = $3 AND namespace = $4 AND superseded_by IS NULL`,
-		newID, now, oldID, s.namespace,
-	)
+	q := `UPDATE memstore_facts SET superseded_by = $1, superseded_at = $2
+		 WHERE id = $3 AND namespace = $4 AND superseded_by IS NULL`
+	args := []any{newID, now, oldID, s.namespace}
+	if s.userID != 0 {
+		// Both ends of the supersession must belong to the store's user. A
+		// foreign or missing newID fails exactly like a missing oldID (0 rows),
+		// so existence of other users' facts does not leak.
+		args = append(args, s.userID)
+		q += ` AND user_id = $5 AND EXISTS (
+			SELECT 1 FROM memstore_facts WHERE id = $1 AND namespace = $4 AND user_id = $5)`
+	}
+	ct, err := s.pool.Exec(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("pgstore: superseding fact %d: %w", oldID, err)
 	}
@@ -730,11 +790,11 @@ func (s *PostgresStore) Supersede(ctx context.Context, oldID, newID int64) error
 // Confirm increments a fact's confirmed_count and updates last_confirmed_at.
 func (s *PostgresStore) Confirm(ctx context.Context, id int64) error {
 	now := time.Now().UTC()
-	ct, err := s.pool.Exec(ctx,
+	q, args := s.userPredicate(
 		`UPDATE memstore_facts SET confirmed_count = confirmed_count + 1, last_confirmed_at = $1
 		 WHERE id = $2 AND namespace = $3`,
-		now, id, s.namespace,
-	)
+		[]any{now, id, s.namespace})
+	ct, err := s.pool.Exec(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("pgstore: confirming fact %d: %w", id, err)
 	}
@@ -752,11 +812,11 @@ func (s *PostgresStore) Touch(ctx context.Context, ids []int64) error {
 
 	now := time.Now().UTC()
 	// pgx supports ANY($1::bigint[]) for IN-list queries.
-	_, err := s.pool.Exec(ctx,
+	q, args := s.userPredicate(
 		`UPDATE memstore_facts SET use_count = use_count + 1, last_used_at = $1
 		 WHERE namespace = $2 AND id = ANY($3::bigint[])`,
-		now, s.namespace, ids,
-	)
+		[]any{now, s.namespace, ids})
+	_, err := s.pool.Exec(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("pgstore: touching facts: %w", err)
 	}
@@ -767,10 +827,10 @@ func (s *PostgresStore) Touch(ctx context.Context, ids []int64) error {
 func (s *PostgresStore) UpdateMetadata(ctx context.Context, id int64, patch map[string]any) error {
 	// Read current metadata.
 	var raw []byte
-	err := s.pool.QueryRow(ctx,
+	readQ, readArgs := s.userPredicate(
 		`SELECT metadata FROM memstore_facts WHERE id = $1 AND namespace = $2`,
-		id, s.namespace,
-	).Scan(&raw)
+		[]any{id, s.namespace})
+	err := s.pool.QueryRow(ctx, readQ, readArgs...).Scan(&raw)
 	if err == pgx.ErrNoRows {
 		return fmt.Errorf("pgstore: fact %d not found", id)
 	}
@@ -798,10 +858,10 @@ func (s *PostgresStore) UpdateMetadata(ctx context.Context, id int64, patch map[
 		return fmt.Errorf("pgstore: marshaling metadata for fact %d: %w", id, err)
 	}
 
-	_, err = s.pool.Exec(ctx,
+	updQ, updArgs := s.userPredicate(
 		`UPDATE memstore_facts SET metadata = $1 WHERE id = $2 AND namespace = $3`,
-		merged, id, s.namespace,
-	)
+		[]any{merged, id, s.namespace})
+	_, err = s.pool.Exec(ctx, updQ, updArgs...)
 	if err != nil {
 		return fmt.Errorf("pgstore: updating metadata for fact %d: %w", id, err)
 	}
@@ -810,9 +870,10 @@ func (s *PostgresStore) UpdateMetadata(ctx context.Context, id int64, patch map[
 
 // Delete removes a fact by ID.
 func (s *PostgresStore) Delete(ctx context.Context, id int64) error {
-	ct, err := s.pool.Exec(ctx,
-		`DELETE FROM memstore_facts WHERE id = $1 AND namespace = $2`, id, s.namespace,
-	)
+	q, args := s.userPredicate(
+		`DELETE FROM memstore_facts WHERE id = $1 AND namespace = $2`,
+		[]any{id, s.namespace})
+	ct, err := s.pool.Exec(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("pgstore: deleting fact %d: %w", id, err)
 	}
@@ -824,9 +885,10 @@ func (s *PostgresStore) Delete(ctx context.Context, id int64) error {
 
 // Get retrieves a single fact by ID. Returns nil if not found.
 func (s *PostgresStore) Get(ctx context.Context, id int64) (*memstore.Fact, error) {
-	row := s.pool.QueryRow(ctx,
-		`SELECT `+factColumns+` FROM memstore_facts WHERE id = $1 AND namespace = $2`, id, s.namespace,
-	)
+	q, args := s.userPredicate(
+		`SELECT `+factColumns+` FROM memstore_facts WHERE id = $1 AND namespace = $2`,
+		[]any{id, s.namespace})
+	row := s.pool.QueryRow(ctx, q, args...)
 	f, err := scanFact(row)
 	if err == pgx.ErrNoRows {
 		return nil, nil
@@ -842,6 +904,7 @@ func (s *PostgresStore) List(ctx context.Context, opts memstore.QueryOpts) ([]me
 	var b queryBuilder
 	b.write(`SELECT ` + factColumns + ` FROM memstore_facts WHERE 1=1`)
 	s.appendNamespaceFilter(&b, "namespace", false, opts.Namespaces)
+	s.appendUserFilter(&b, "user_id")
 
 	if opts.Subject != "" {
 		b.write(` AND subject = `, opts.Subject)
@@ -887,6 +950,7 @@ func (s *PostgresStore) BySubject(ctx context.Context, subject string, onlyActiv
 	var b queryBuilder
 	b.write(`SELECT `+factColumns+` FROM memstore_facts WHERE subject = `, subject)
 	b.write(` AND namespace = `, s.namespace)
+	s.appendUserFilter(&b, "user_id")
 	if onlyActive {
 		b.q += ` AND superseded_by IS NULL`
 	}
@@ -904,10 +968,10 @@ func (s *PostgresStore) BySubject(ctx context.Context, subject string, onlyActiv
 // Exists checks whether a fact with the same content and subject exists.
 func (s *PostgresStore) Exists(ctx context.Context, content, subject string) (bool, error) {
 	var count int
-	err := s.pool.QueryRow(ctx,
+	q, args := s.userPredicate(
 		`SELECT COUNT(*) FROM memstore_facts WHERE content = $1 AND subject = $2 AND namespace = $3`,
-		content, subject, s.namespace,
-	).Scan(&count)
+		[]any{content, subject, s.namespace})
+	err := s.pool.QueryRow(ctx, q, args...).Scan(&count)
 	if err != nil {
 		return false, fmt.Errorf("pgstore: checking existence: %w", err)
 	}
@@ -917,10 +981,10 @@ func (s *PostgresStore) Exists(ctx context.Context, content, subject string) (bo
 // ActiveCount returns the number of non-superseded facts.
 func (s *PostgresStore) ActiveCount(ctx context.Context) (int64, error) {
 	var count int64
-	err := s.pool.QueryRow(ctx,
+	q, args := s.userPredicate(
 		`SELECT COUNT(*) FROM memstore_facts WHERE superseded_by IS NULL AND namespace = $1`,
-		s.namespace,
-	).Scan(&count)
+		[]any{s.namespace})
+	err := s.pool.QueryRow(ctx, q, args...).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("pgstore: counting active facts: %w", err)
 	}
@@ -933,13 +997,14 @@ func (s *PostgresStore) NeedingEmbedding(ctx context.Context, limit int) ([]mems
 		limit = 100
 	}
 
-	rows, err := s.pool.Query(ctx,
+	q, args := s.userPredicate(
 		`SELECT `+factColumns+`
 		 FROM memstore_facts
-		 WHERE embedding IS NULL AND embed_failed_at IS NULL AND namespace = $1
-		 ORDER BY id LIMIT $2`,
-		s.namespace, limit,
-	)
+		 WHERE embedding IS NULL AND embed_failed_at IS NULL AND namespace = $1`,
+		[]any{s.namespace})
+	args = append(args, limit)
+	q += fmt.Sprintf(` ORDER BY id LIMIT $%d`, len(args))
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("pgstore: querying unembedded facts: %w", err)
 	}
@@ -954,12 +1019,12 @@ func (s *PostgresStore) NeedingEmbedding(ctx context.Context, limit int) ([]mems
 // the caller also resets embed_failed_at; superseding replaces the fact with a
 // fresh row that starts unquarantined.
 func (s *PostgresStore) MarkEmbedFailed(ctx context.Context, id int64, reason string) error {
-	_, err := s.pool.Exec(ctx,
+	q, args := s.userPredicate(
 		`UPDATE memstore_facts
 		 SET embed_failed_at = now(), embed_error = $1
 		 WHERE id = $2 AND namespace = $3`,
-		reason, id, s.namespace,
-	)
+		[]any{reason, id, s.namespace})
+	_, err := s.pool.Exec(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("pgstore: marking embed failed for fact %d: %w", id, err)
 	}
@@ -969,10 +1034,10 @@ func (s *PostgresStore) MarkEmbedFailed(ctx context.Context, id int64, reason st
 // SetEmbedding stores a computed embedding for a fact.
 func (s *PostgresStore) SetEmbedding(ctx context.Context, id int64, emb []float32) error {
 	v := pgvector.NewVector(emb)
-	_, err := s.pool.Exec(ctx,
+	q, args := s.userPredicate(
 		`UPDATE memstore_facts SET embedding = $1 WHERE id = $2 AND namespace = $3`,
-		v, id, s.namespace,
-	)
+		[]any{v, id, s.namespace})
+	_, err := s.pool.Exec(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("pgstore: setting embedding for fact %d: %w", id, err)
 	}
@@ -988,9 +1053,11 @@ func (s *PostgresStore) EmbedFacts(ctx context.Context, batchSize int) (int, err
 		batchSize = 50
 	}
 
-	rows, err := s.pool.Query(ctx,
-		`SELECT id, content FROM memstore_facts WHERE embedding IS NULL AND namespace = $1 ORDER BY id`,
-		s.namespace)
+	q, args := s.userPredicate(
+		`SELECT id, content FROM memstore_facts WHERE embedding IS NULL AND namespace = $1`,
+		[]any{s.namespace})
+	q += ` ORDER BY id`
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return 0, fmt.Errorf("pgstore: querying unembedded facts: %w", err)
 	}
@@ -1050,10 +1117,12 @@ func (s *PostgresStore) EmbedFacts(ctx context.Context, batchSize int) (int, err
 
 		for j, emb := range embeddings {
 			v := pgvector.NewVector(emb)
-			if _, err := tx.Exec(ctx,
+			// The ids come from the user-scoped select above; the predicate
+			// here is defense in depth.
+			updQ, updArgs := s.userPredicate(
 				`UPDATE memstore_facts SET embedding = $1 WHERE id = $2`,
-				v, batch[j].id,
-			); err != nil {
+				[]any{v, batch[j].id})
+			if _, err := tx.Exec(ctx, updQ, updArgs...); err != nil {
 				tx.Rollback(ctx)
 				return total, fmt.Errorf("pgstore: updating fact %d: %w", batch[j].id, err)
 			}
@@ -1081,8 +1150,10 @@ func (s *PostgresStore) History(ctx context.Context, id int64, subject string) (
 }
 
 func (s *PostgresStore) historyByID(ctx context.Context, id int64) ([]memstore.HistoryEntry, error) {
-	row := s.pool.QueryRow(ctx,
-		`SELECT `+factColumns+` FROM memstore_facts WHERE id = $1 AND namespace = $2`, id, s.namespace)
+	anchorQ, anchorArgs := s.userPredicate(
+		`SELECT `+factColumns+` FROM memstore_facts WHERE id = $1 AND namespace = $2`,
+		[]any{id, s.namespace})
+	row := s.pool.QueryRow(ctx, anchorQ, anchorArgs...)
 	anchor, err := scanFact(row)
 	if err != nil {
 		return nil, fmt.Errorf("pgstore: fact %d not found: %w", id, err)
@@ -1093,9 +1164,12 @@ func (s *PostgresStore) historyByID(ctx context.Context, id int64) ([]memstore.H
 	var backward []memstore.Fact
 	current := anchor.ID
 	for {
-		row := s.pool.QueryRow(ctx,
+		// The user predicate makes a forged superseded_by pointing into
+		// another user's chain terminate like a dangling pointer.
+		backQ, backArgs := s.userPredicate(
 			`SELECT `+factColumns+` FROM memstore_facts WHERE superseded_by = $1 AND namespace = $2`,
-			current, s.namespace)
+			[]any{current, s.namespace})
+		row := s.pool.QueryRow(ctx, backQ, backArgs...)
 		pred, err := scanFact(row)
 		if err != nil {
 			break
@@ -1119,9 +1193,10 @@ func (s *PostgresStore) historyByID(ctx context.Context, id int64) ([]memstore.H
 		next := *anchor.SupersededBy
 		// Walk until the chain ends or repeats.
 		for !visited[next] {
-			row := s.pool.QueryRow(ctx,
+			fwdQ, fwdArgs := s.userPredicate(
 				`SELECT `+factColumns+` FROM memstore_facts WHERE id = $1 AND namespace = $2`,
-				next, s.namespace)
+				[]any{next, s.namespace})
+			row := s.pool.QueryRow(ctx, fwdQ, fwdArgs...)
 			succ, err := scanFact(row)
 			if err != nil {
 				break
@@ -1143,9 +1218,11 @@ func (s *PostgresStore) historyByID(ctx context.Context, id int64) ([]memstore.H
 }
 
 func (s *PostgresStore) historyBySubject(ctx context.Context, subject string) ([]memstore.HistoryEntry, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT `+factColumns+` FROM memstore_facts WHERE subject = $1 AND namespace = $2 ORDER BY created_at, id`,
-		subject, s.namespace)
+	q, args := s.userPredicate(
+		`SELECT `+factColumns+` FROM memstore_facts WHERE subject = $1 AND namespace = $2`,
+		[]any{subject, s.namespace})
+	q += ` ORDER BY created_at, id`
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("pgstore: history by subject: %w", err)
 	}
@@ -1167,6 +1244,7 @@ func (s *PostgresStore) historyBySubject(ctx context.Context, subject string) ([
 func (s *PostgresStore) ListSubsystems(ctx context.Context, subject string) ([]string, error) {
 	var b queryBuilder
 	b.write(`SELECT DISTINCT subsystem FROM memstore_facts WHERE namespace = `, s.namespace)
+	s.appendUserFilter(&b, "user_id")
 	b.q += ` AND superseded_by IS NULL AND subsystem != ''`
 	if subject != "" {
 		b.write(` AND subject = `, subject)
@@ -1199,17 +1277,23 @@ func (s *PostgresStore) TermDocCounts(ctx context.Context, terms []string) (map[
 
 	// Get total active document count.
 	var totalDocs int
-	err := s.pool.QueryRow(ctx,
+	countQ, countArgs := s.userPredicate(
 		`SELECT COUNT(*) FROM memstore_facts WHERE namespace = $1 AND superseded_by IS NULL`,
-		s.namespace).Scan(&totalDocs)
+		[]any{s.namespace})
+	err := s.pool.QueryRow(ctx, countQ, countArgs...).Scan(&totalDocs)
 	if err != nil {
 		return nil, 0, fmt.Errorf("pgstore: counting docs: %w", err)
 	}
 
 	// Use ts_stat to get document frequencies for the requested terms.
+	// ts_stat takes the inner query as a string literal, so the user
+	// predicate is inlined; userID is an int64, not attacker-controlled text.
 	statsQuery := fmt.Sprintf(
 		`SELECT fts FROM memstore_facts WHERE namespace = %s AND superseded_by IS NULL`,
 		quoteLiteral(s.namespace))
+	if s.userID != 0 {
+		statsQuery += fmt.Sprintf(` AND user_id = %d`, s.userID)
+	}
 
 	rows, err := s.pool.Query(ctx,
 		`SELECT word, ndoc FROM ts_stat($1) WHERE word = ANY($2)`,
@@ -1257,12 +1341,34 @@ func (s *PostgresStore) LinkFacts(ctx context.Context, sourceID, targetID int64,
 	}
 
 	var id int64
-	err := s.pool.QueryRow(ctx,
-		`INSERT INTO memstore_links (namespace, user_id, source_id, target_id, link_type, bidirectional, label, metadata, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		 RETURNING id`,
-		s.namespace, s.userID, sourceID, targetID, linkType, bidirectional, label, nullableBytes(metaJSON), time.Now().UTC(),
-	).Scan(&id)
+	var err error
+	if s.userID == 0 {
+		// Service scope: no ownership guard.
+		err = s.pool.QueryRow(ctx,
+			`INSERT INTO memstore_links (namespace, user_id, source_id, target_id, link_type, bidirectional, label, metadata, created_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			 RETURNING id`,
+			s.namespace, s.userID, sourceID, targetID, linkType, bidirectional, label, nullableBytes(metaJSON), time.Now().UTC(),
+		).Scan(&id)
+	} else {
+		// Guarded insert: both endpoints must exist in the store's namespace
+		// and belong to the store's user. A foreign fact fails exactly like a
+		// missing one (no rows inserted), so existence does not leak.
+		// COUNT(DISTINCT id) with the CASE keeps self-links (source == target)
+		// behaving as before.
+		err = s.pool.QueryRow(ctx,
+			`INSERT INTO memstore_links (namespace, user_id, source_id, target_id, link_type, bidirectional, label, metadata, created_at)
+			 SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
+			 WHERE (SELECT COUNT(DISTINCT id) FROM memstore_facts
+			        WHERE id IN ($3, $4) AND namespace = $1 AND user_id = $2)
+			       = (CASE WHEN $3 = $4 THEN 1 ELSE 2 END)
+			 RETURNING id`,
+			s.namespace, s.userID, sourceID, targetID, linkType, bidirectional, label, nullableBytes(metaJSON), time.Now().UTC(),
+		).Scan(&id)
+		if err == pgx.ErrNoRows {
+			return 0, fmt.Errorf("pgstore: creating link %d->%d: fact not found", sourceID, targetID)
+		}
+	}
 	if err != nil {
 		return 0, fmt.Errorf("pgstore: creating link %d->%d: %w", sourceID, targetID, err)
 	}
@@ -1271,10 +1377,10 @@ func (s *PostgresStore) LinkFacts(ctx context.Context, sourceID, targetID int64,
 
 // GetLink retrieves a single link by ID.
 func (s *PostgresStore) GetLink(ctx context.Context, linkID int64) (*memstore.Link, error) {
-	row := s.pool.QueryRow(ctx,
+	q, args := s.userPredicate(
 		`SELECT `+linkColumns+` FROM memstore_links WHERE id = $1 AND namespace = $2`,
-		linkID, s.namespace,
-	)
+		[]any{linkID, s.namespace})
+	row := s.pool.QueryRow(ctx, q, args...)
 	l, err := scanLink(row)
 	if err == pgx.ErrNoRows {
 		return nil, fmt.Errorf("pgstore: link %d not found", linkID)
@@ -1307,6 +1413,8 @@ func (s *PostgresStore) GetLinks(ctx context.Context, factID int64, direction me
 		b.q += `)`
 	}
 
+	s.appendUserFilter(&b, "user_id")
+
 	if len(linkTypes) > 0 {
 		b.write(` AND link_type = ANY(`, linkTypes)
 		b.q += `::text[])`
@@ -1327,10 +1435,10 @@ func (s *PostgresStore) GetLinks(ctx context.Context, factID int64, direction me
 func (s *PostgresStore) UpdateLink(ctx context.Context, linkID int64, label string, metadata map[string]any) error {
 	var currentLabel string
 	var metaRaw []byte
-	err := s.pool.QueryRow(ctx,
+	readQ, readArgs := s.userPredicate(
 		`SELECT label, metadata FROM memstore_links WHERE id = $1 AND namespace = $2`,
-		linkID, s.namespace,
-	).Scan(&currentLabel, &metaRaw)
+		[]any{linkID, s.namespace})
+	err := s.pool.QueryRow(ctx, readQ, readArgs...).Scan(&currentLabel, &metaRaw)
 	if err == pgx.ErrNoRows {
 		return fmt.Errorf("pgstore: link %d not found", linkID)
 	}
@@ -1365,10 +1473,10 @@ func (s *PostgresStore) UpdateLink(ctx context.Context, linkID int64, label stri
 		}
 	}
 
-	_, err = s.pool.Exec(ctx,
+	updQ, updArgs := s.userPredicate(
 		`UPDATE memstore_links SET label = $1, metadata = $2 WHERE id = $3 AND namespace = $4`,
-		newLabel, nullableBytes(metaJSON), linkID, s.namespace,
-	)
+		[]any{newLabel, nullableBytes(metaJSON), linkID, s.namespace})
+	_, err = s.pool.Exec(ctx, updQ, updArgs...)
 	if err != nil {
 		return fmt.Errorf("pgstore: updating link %d: %w", linkID, err)
 	}
@@ -1377,9 +1485,10 @@ func (s *PostgresStore) UpdateLink(ctx context.Context, linkID int64, label stri
 
 // DeleteLink removes a link by ID.
 func (s *PostgresStore) DeleteLink(ctx context.Context, linkID int64) error {
-	ct, err := s.pool.Exec(ctx,
-		`DELETE FROM memstore_links WHERE id = $1 AND namespace = $2`, linkID, s.namespace,
-	)
+	q, args := s.userPredicate(
+		`DELETE FROM memstore_links WHERE id = $1 AND namespace = $2`,
+		[]any{linkID, s.namespace})
+	ct, err := s.pool.Exec(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("pgstore: deleting link %d: %w", linkID, err)
 	}
@@ -1509,6 +1618,26 @@ func (s *PostgresStore) appendNamespaceFilter(b *queryBuilder, nsCol string, all
 	} else {
 		b.write(` AND `+nsCol+` = `, s.namespace)
 	}
+}
+
+// appendUserFilter adds the owner predicate for scoped stores. Service-scope
+// stores (userID == 0) carry no user predicate and see all users' rows.
+func (s *PostgresStore) appendUserFilter(b *queryBuilder, col string) {
+	if s.userID == 0 {
+		return
+	}
+	b.write(` AND `+col+` = `, s.userID)
+}
+
+// userPredicate appends " AND user_id = $N" to an inline query for scoped
+// stores and returns the (possibly extended) query and args. Service-scope
+// stores (userID == 0) get the query back unchanged.
+func (s *PostgresStore) userPredicate(q string, args []any) (string, []any) {
+	if s.userID == 0 {
+		return q, args
+	}
+	args = append(args, s.userID)
+	return q + fmt.Sprintf(" AND user_id = $%d", len(args)), args
 }
 
 // validMetadataKey checks that a metadata key contains only safe characters.

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -918,6 +918,31 @@ func TestConformance(t *testing.T) {
 			return initStore(t, sharedNSPool, ns)
 		},
 
+		// NewTwoUserStores derives two user-scoped stores from one base store
+		// on a fresh pool, exercising the owner predicates at the SQL level.
+		NewTwoUserStores: func(t *testing.T) (memstore.Store, memstore.Store) {
+			pool := newPool(t)
+			lastPool = pool
+			base := initStore(t, pool, "test")
+			uidA, err := pgstore.EnsureUser(ctx, pool, "test", "iso-user-a")
+			if err != nil {
+				t.Fatalf("EnsureUser iso-user-a: %v", err)
+			}
+			uidB, err := pgstore.EnsureUser(ctx, pool, "test", "iso-user-b")
+			if err != nil {
+				t.Fatalf("EnsureUser iso-user-b: %v", err)
+			}
+			a, err := base.ForUser(uidA)
+			if err != nil {
+				t.Fatalf("ForUser(%d): %v", uidA, err)
+			}
+			b, err := base.ForUser(uidB)
+			if err != nil {
+				t.Fatalf("ForUser(%d): %v", uidB, err)
+			}
+			return a, b
+		},
+
 		// SetSupersededBy writes directly to lastPool using Postgres $N
 		// placeholder syntax, bypassing Store validation to force a cycle.
 		SetSupersededBy: func(t *testing.T, supersededByID, targetID int64) {
@@ -932,6 +957,110 @@ func TestConformance(t *testing.T) {
 			}
 		},
 	})
+}
+
+func TestForUser_InvalidID(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.ForUser(0); err == nil {
+		t.Error("ForUser(0) succeeded, want error")
+	}
+	if _, err := store.ForUser(-5); err == nil {
+		t.Error("ForUser(-5) succeeded, want error")
+	}
+}
+
+// secondUserStore provisions an extra user in the "test" namespace and
+// returns a store scoped to it. Must be called after newTestStore so the
+// schema and identity exist.
+func secondUserStore(t *testing.T, base *pgstore.PostgresStore, name string) memstore.Store {
+	t.Helper()
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, testDSN(t))
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	uid, err := pgstore.EnsureUser(ctx, pool, "test", name)
+	if err != nil {
+		t.Fatalf("EnsureUser(%q): %v", name, err)
+	}
+	scoped, err := base.ForUser(uid)
+	if err != nil {
+		t.Fatalf("ForUser(%d): %v", uid, err)
+	}
+	return scoped
+}
+
+func TestServiceScope_SeesAllUsers(t *testing.T) {
+	store := newTestStore(t) // scoped to the default user "testuser"
+	ctx := context.Background()
+	other := secondUserStore(t, store, "seconduser")
+
+	if _, err := store.Insert(ctx, memstore.Fact{Content: "default user fact", Subject: "svc", Category: "test"}); err != nil {
+		t.Fatalf("Insert default: %v", err)
+	}
+	if _, err := other.Insert(ctx, memstore.Fact{Content: "second user fact", Subject: "svc", Category: "test"}); err != nil {
+		t.Fatalf("Insert second: %v", err)
+	}
+
+	// Scoped stores each see only their own fact.
+	defFacts, err := store.List(ctx, memstore.QueryOpts{Subject: "svc"})
+	if err != nil {
+		t.Fatalf("default List: %v", err)
+	}
+	if len(defFacts) != 1 {
+		t.Errorf("default-scoped store sees %d facts, want 1", len(defFacts))
+	}
+	otherFacts, err := other.List(ctx, memstore.QueryOpts{Subject: "svc"})
+	if err != nil {
+		t.Fatalf("second List: %v", err)
+	}
+	if len(otherFacts) != 1 {
+		t.Errorf("second-scoped store sees %d facts, want 1", len(otherFacts))
+	}
+
+	// The service scope is the one place cross-user visibility is correct.
+	svc := store.ServiceScope()
+	all, err := svc.List(ctx, memstore.QueryOpts{Subject: "svc"})
+	if err != nil {
+		t.Fatalf("service List: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("service scope sees %d facts, want 2", len(all))
+	}
+}
+
+func TestLinkFacts_CrossUserRejected(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	other := secondUserStore(t, store, "seconduser")
+
+	src, err := store.Insert(ctx, memstore.Fact{Content: "owner src", Subject: "links", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert src: %v", err)
+	}
+	tgt, err := store.Insert(ctx, memstore.Fact{Content: "owner tgt", Subject: "links", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert tgt: %v", err)
+	}
+
+	// Another user linking the owner's facts must fail with a
+	// not-found-shaped error: existence must not leak.
+	_, err = other.LinkFacts(ctx, src, tgt, "ref", false, "", nil)
+	if err == nil {
+		t.Fatal("cross-user LinkFacts succeeded")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("cross-user LinkFacts error %q is not not-found-shaped", err)
+	}
+
+	// The owner can still link, including self-links (preserved semantics).
+	if _, err := store.LinkFacts(ctx, src, tgt, "ref", false, "ok", nil); err != nil {
+		t.Errorf("owner LinkFacts failed: %v", err)
+	}
+	if _, err := store.LinkFacts(ctx, src, src, "self", false, "", nil); err != nil {
+		t.Errorf("owner self-link failed: %v", err)
+	}
 }
 
 // TestList_NumericMetadataFilter verifies that pgstore compares numeric

--- a/store.go
+++ b/store.go
@@ -266,6 +266,14 @@ type Store interface {
 	Close() error
 }
 
+// UserScoper is implemented by backends that support per-user scoping.
+// ForUser returns a store whose every read and write is scoped to the
+// given user. Backends without multi-user support (SQLite) do not
+// implement it.
+type UserScoper interface {
+	ForUser(userID int64) (Store, error)
+}
+
 // TermCounter is optionally implemented by stores that support IDF-based
 // keyword extraction. TermDocCounts returns the document frequency for each
 // term and the total number of active documents in the store's namespace.


### PR DESCRIPTION
Phase 2 of 4 for v0.4.0 multi-user isolation (spec: plans/009 D2/D3/D5/D8; depends on #86). This is the phase that closes the authn-without-authz gap at the storage layer: every pgstore read, mutation, and embedding-pipeline query now carries the owner predicate, and a conformance battery proves two users sharing one database cannot see or touch each other's data on any Store method.

What lands:
- `UserScoper` capability interface (root store.go): `ForUser(userID) (Store, error)`. pgstore implements it; SQLite deliberately does not (local file = OS-user isolation, spec D8).
- `PostgresStore.ForUser` (cheap clone sharing pool/embedder/cache, swaps userID) and `ServiceScope()` (userID 0 = NO predicate, privileged, for daemon workers only -- phase 3 consumes it). `EnsureUser` for provisioning.
- Owner predicate on EVERY fact/link query: Get, List, BySubject, Exists, ActiveCount, History (anchor + both walks + by-subject), ListSubsystems, searchFTS, searchVector, SearchBatch, Supersede (both ends must be the user's), Confirm, Touch, Delete, UpdateMetadata, the full embed pipeline, and all link ops. Helpers `appendUserFilter`/`userPredicate` no-op at service scope so the predicate form is uniform and greppable.
- Cross-user access is indistinguishable from nonexistent: Get returns identical not-found; mutations affect 0 rows; LinkFacts to/from a foreign fact fails exactly like a missing one (self-links preserved via a COUNT(DISTINCT) CASE guard); a forged superseded_by pointing at another user's fact terminates History like a dangling pointer.
- `UserIsolation` conformance family (6 subtests: Get, List/Search, Mutations, Links, History-cannot-cross, Embed-pipeline) gated on a NewTwoUserStores option -- runs on pg, SKIPS on SQLite. Plus TestForUser_InvalidID, TestServiceScope_SeesAllUsers (the one correct cross-user path), TestLinkFacts_CrossUserRejected.

INCLUDES A BUG FIX FOR A #86 REGRESSION ON MAIN: #86 added user_id to factColumns and updated searchFTS's scan but NOT searchVector's -- 18 columns vs 17 destinations, so any pg vector search returning rows fails at Scan. Fixed here (the isolation battery exercises vector search, which is how it surfaced). pg vector search is currently broken on main; this is the fix.

Review: enumeration of all 76 fact/link query sites verified independently; full race suite + the isolation battery run twice against a fresh pgvector container (fresh DB, then re-run for state dependence); lint clean.

Plan: plans/011-pgstore-owner-enforcement.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)