### PR TITLE
Session-layer isolation: user_id on session tables, scoped SessionStore (v0.4.0 phase 3a)

### DIFF
--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -46,6 +46,11 @@ type Options struct {
 	// and namespace, scoped to two DIFFERENT users. nil skips the
 	// UserIsolation family (backends without per-user scoping).
 	NewTwoUserStores func(t *testing.T) (memstore.Store, memstore.Store)
+
+	// NewTwoUserSessionStores returns two SessionStores over the SAME
+	// database, scoped to two DIFFERENT users. nil skips the
+	// SessionIsolation family.
+	NewTwoUserSessionStores func(t *testing.T) (memstore.SessionStore, memstore.SessionStore)
 }
 
 // Run executes the shared Store contract tests using the factories in opts.
@@ -129,6 +134,31 @@ func Run(t *testing.T, opts Options) {
 		t.Run("EmbedPipelineIsolated", func(t *testing.T) {
 			a, b := newTwo(t)
 			testEmbedPipelineIsolated(t, a, b)
+		})
+	})
+	t.Run("SessionIsolation", func(t *testing.T) {
+		newTwoSession := func(t *testing.T) (memstore.SessionStore, memstore.SessionStore) {
+			t.Helper()
+			if opts.NewTwoUserSessionStores == nil {
+				t.Skip("NewTwoUserSessionStores not provided; skipping session isolation test")
+			}
+			return opts.NewTwoUserSessionStores(t)
+		}
+		t.Run("TurnsIsolated", func(t *testing.T) {
+			a, b := newTwoSession(t)
+			testSessionTurnsIsolated(t, a, b)
+		})
+		t.Run("HintsIsolated", func(t *testing.T) {
+			a, b := newTwoSession(t)
+			testSessionHintsIsolated(t, a, b)
+		})
+		t.Run("InjectionsIsolated", func(t *testing.T) {
+			a, b := newTwoSession(t)
+			testSessionInjectionsIsolated(t, a, b)
+		})
+		t.Run("FeedbackIsolated", func(t *testing.T) {
+			a, b := newTwoSession(t)
+			testSessionFeedbackIsolated(t, a, b)
 		})
 	})
 }
@@ -1045,5 +1075,195 @@ func testEmbedPipelineIsolated(t *testing.T, a, b memstore.Store) {
 		if f.ID == aID {
 			t.Errorf("B.NeedingEmbedding returned A's fact %d", aID)
 		}
+	}
+}
+
+// --- session isolation subtests ---
+
+// sessionTurnReader is the extended capability for reading back session turns.
+// Not part of the core SessionStore interface; capability-asserted in the test.
+type sessionTurnReader interface {
+	GetSessionTurns(ctx context.Context, sessionID string) ([]memstore.SessionTurn, error)
+}
+
+// sessionInjectionReader is the extended capability for reading injected fact IDs.
+type sessionInjectionReader interface {
+	GetInjectedFactIDs(ctx context.Context, sessionID string) ([]int64, error)
+}
+
+// testSessionTurnsIsolated verifies that two users' turns for the same
+// session_id are stored and retrieved independently.
+func testSessionTurnsIsolated(t *testing.T, a, b memstore.SessionStore) {
+	t.Helper()
+	ctx := context.Background()
+	sid := "session-turns-isolation"
+
+	ar, ok := a.(sessionTurnReader)
+	if !ok {
+		t.Skip("store does not implement GetSessionTurns; skipping turns isolation check")
+	}
+	br, ok := b.(sessionTurnReader)
+	if !ok {
+		t.Skip("store does not implement GetSessionTurns; skipping turns isolation check")
+	}
+
+	turnsA := []memstore.SessionTurn{
+		{SessionID: sid, UUID: "uuid-a-1", TurnIndex: 0, Role: "user", Content: "hello from A"},
+	}
+	turnsB := []memstore.SessionTurn{
+		{SessionID: sid, UUID: "uuid-b-1", TurnIndex: 0, Role: "user", Content: "hello from B"},
+	}
+
+	if err := a.SaveTurns(ctx, sid, turnsA); err != nil {
+		t.Fatalf("A.SaveTurns: %v", err)
+	}
+	if err := b.SaveTurns(ctx, sid, turnsB); err != nil {
+		t.Fatalf("B.SaveTurns: %v", err)
+	}
+
+	gotA, err := ar.GetSessionTurns(ctx, sid)
+	if err != nil {
+		t.Fatalf("A.GetSessionTurns: %v", err)
+	}
+	if len(gotA) != 1 || gotA[0].Content != "hello from A" {
+		t.Errorf("A sees wrong turns: %v", gotA)
+	}
+	for _, tr := range gotA {
+		if tr.Content == "hello from B" {
+			t.Errorf("A.GetSessionTurns leaked B's turn")
+		}
+	}
+
+	gotB, err := br.GetSessionTurns(ctx, sid)
+	if err != nil {
+		t.Fatalf("B.GetSessionTurns: %v", err)
+	}
+	if len(gotB) != 1 || gotB[0].Content != "hello from B" {
+		t.Errorf("B sees wrong turns: %v", gotB)
+	}
+	for _, tr := range gotB {
+		if tr.Content == "hello from A" {
+			t.Errorf("B.GetSessionTurns leaked A's turn")
+		}
+	}
+}
+
+// testSessionHintsIsolated verifies that hints stored by A are not visible to
+// B, and that B cannot consume A's hint.
+func testSessionHintsIsolated(t *testing.T, a, b memstore.SessionStore) {
+	t.Helper()
+	ctx := context.Background()
+	sid := "session-hints-isolation"
+	cwd := "/proj/hints-isolation"
+
+	hint := memstore.ContextHint{
+		SessionID:    sid,
+		CWD:          cwd,
+		TurnIndex:    1,
+		HintText:     "hint from A",
+		Relevance:    0.9,
+		Desirability: 0.8,
+	}
+	hintID, err := a.StoreHint(ctx, hint)
+	if err != nil {
+		t.Fatalf("A.StoreHint: %v", err)
+	}
+
+	// B queries same session/cwd -- should see nothing.
+	bHints, err := b.GetPendingHints(ctx, sid, cwd)
+	if err != nil {
+		t.Fatalf("B.GetPendingHints: %v", err)
+	}
+	if len(bHints) != 0 {
+		t.Errorf("B.GetPendingHints returned %d hints from A (expected 0)", len(bHints))
+	}
+
+	// B attempts to consume A's hint by ID -- should be a no-op (A still sees it).
+	if err := b.MarkHintConsumed(ctx, hintID); err != nil {
+		t.Fatalf("B.MarkHintConsumed: %v", err)
+	}
+	aHints, err := a.GetPendingHints(ctx, sid, cwd)
+	if err != nil {
+		t.Fatalf("A.GetPendingHints after B.MarkHintConsumed: %v", err)
+	}
+	if len(aHints) != 1 {
+		t.Errorf("A's hint was consumed by B: GetPendingHints returned %d (expected 1)", len(aHints))
+	}
+}
+
+// testSessionInjectionsIsolated verifies that A's injection is invisible to B.
+func testSessionInjectionsIsolated(t *testing.T, a, b memstore.SessionStore) {
+	t.Helper()
+	ctx := context.Background()
+	sid := "session-inj-isolation"
+	refID := "42"
+	refType := memstore.RefTypeFact
+
+	if err := a.RecordInjection(ctx, sid, refID, refType, 0); err != nil {
+		t.Fatalf("A.RecordInjection: %v", err)
+	}
+
+	// B checks same session -- should not see A's injection via WasInjected.
+	injected, err := b.WasInjected(ctx, sid, refID, refType)
+	if err != nil {
+		t.Fatalf("B.WasInjected: %v", err)
+	}
+	if injected {
+		t.Error("B.WasInjected returned true for A's injection")
+	}
+
+	// B checks GetInjectedFactIDs if the capability is present.
+	if br, ok := b.(sessionInjectionReader); ok {
+		ids, err := br.GetInjectedFactIDs(ctx, sid)
+		if err != nil {
+			t.Fatalf("B.GetInjectedFactIDs: %v", err)
+		}
+		for _, id := range ids {
+			if fmt.Sprintf("%d", id) == refID {
+				t.Errorf("B.GetInjectedFactIDs returned A's refID")
+			}
+		}
+	}
+
+	// A should still see its own injection.
+	injectedA, err := a.WasInjected(ctx, sid, refID, refType)
+	if err != nil {
+		t.Fatalf("A.WasInjected: %v", err)
+	}
+	if !injectedA {
+		t.Error("A.WasInjected returned false for its own injection")
+	}
+}
+
+// testSessionFeedbackIsolated verifies that A's feedback is not visible to B.
+func testSessionFeedbackIsolated(t *testing.T, a, b memstore.SessionStore) {
+	t.Helper()
+	ctx := context.Background()
+	sid := "session-fb-isolation"
+	refID := "99"
+	refType := memstore.RefTypeFact
+
+	fb := memstore.ContextFeedback{
+		RefID:     refID,
+		RefType:   refType,
+		SessionID: sid,
+		Score:     1,
+		Reason:    "useful",
+	}
+	if err := a.RecordFeedback(ctx, fb); err != nil {
+		t.Fatalf("A.RecordFeedback: %v", err)
+	}
+
+	// B queries FeedbackScores for the same refID -- should see nothing.
+	scorer, ok := b.(memstore.FeedbackScorer)
+	if !ok {
+		t.Skip("B does not implement FeedbackScorer; skipping feedback isolation check")
+	}
+	stats, err := scorer.FeedbackScores(ctx, []string{refID}, refType)
+	if err != nil {
+		t.Fatalf("B.FeedbackScores: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Errorf("B.FeedbackScores returned %d entries from A (expected 0): %v", len(stats), stats)
 	}
 }

--- a/pgstore/session_store.go
+++ b/pgstore/session_store.go
@@ -12,15 +12,117 @@ import (
 )
 
 // SessionStore persists Claude Code session events to PostgreSQL.
-// It is independent of PostgresStore — it manages its own tables.
+// It is independent of PostgresStore -- it manages its own tables.
+//
+// Every instance carries a userID resolved at construction from
+// memstore_meta['default_user']. ForUser returns a cheap clone scoped
+// to a different user; ServiceScope returns a clone with userID 0 that
+// omits the user predicate on reads and is intended for cross-user
+// maintenance operations only (writes would violate NOT NULL on user_id).
 type SessionStore struct {
-	pool *pgxpool.Pool
+	pool   *pgxpool.Pool
+	userID int64
 }
 
-// NewSessionStore creates a SessionStore and runs its migrations.
+// NewSessionStore creates a SessionStore, runs its migrations, and resolves
+// the default user from memstore_meta. The default user must already exist
+// (recorded by the facts-layer migration or 'memstore admin tier3-init')
+// unless all session tables are empty, in which case userID stays 0 until
+// ForUser is called.
 func NewSessionStore(ctx context.Context, pool *pgxpool.Pool) (*SessionStore, error) {
 	s := &SessionStore{pool: pool}
-	return s, s.migrate(ctx)
+	if err := s.migrate(ctx); err != nil {
+		return nil, err
+	}
+	uid, err := resolveSessionUser(ctx, pool)
+	if err != nil {
+		return nil, fmt.Errorf("session store: resolving user: %w", err)
+	}
+	s.userID = uid
+	return s, nil
+}
+
+// resolveSessionUser reads the default_user from memstore_meta and returns
+// the user's id from memstore_users. Returns 0 (no-op predicate) if
+// memstore_meta has no default_user entry AND all session tables are empty --
+// this handles the case where the session store is initialized before the
+// facts layer has seeded identity (e.g. in tests). If there is no default
+// user but session data exists, it returns the same tier3-init error the
+// facts layer uses.
+func resolveSessionUser(ctx context.Context, pool *pgxpool.Pool) (int64, error) {
+	var name string
+	err := pool.QueryRow(ctx, `SELECT value FROM memstore_meta WHERE key = 'default_user'`).Scan(&name)
+	if err == pgx.ErrNoRows || (err == nil && name == "") {
+		// No default user recorded. Safe to proceed as userID=0 only if
+		// all session tables are empty.
+		var hasData bool
+		checkQ := `
+			SELECT EXISTS(
+				SELECT 1 FROM session_turns    LIMIT 1 UNION ALL
+				SELECT 1 FROM session_hooks    LIMIT 1 UNION ALL
+				SELECT 1 FROM context_hints    LIMIT 1 UNION ALL
+				SELECT 1 FROM context_injections LIMIT 1 UNION ALL
+				SELECT 1 FROM context_feedback LIMIT 1
+			)`
+		if qerr := pool.QueryRow(ctx, checkQ).Scan(&hasData); qerr != nil {
+			// Tables may not yet exist (first migration call); treat as empty.
+			return 0, nil
+		}
+		if hasData {
+			return 0, fmt.Errorf("no default user recorded -- run 'memstore admin tier3-init --default-user <name>' before starting memstored")
+		}
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("reading default_user: %w", err)
+	}
+
+	var id int64
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM memstore_users WHERE name = $1 LIMIT 1`,
+		name,
+	).Scan(&id); err != nil {
+		return 0, fmt.Errorf("looking up user %q: %w", name, err)
+	}
+	return id, nil
+}
+
+// SessionStore supports per-user scoping.
+var _ memstore.SessionUserScoper = (*SessionStore)(nil)
+
+// ForUser returns a cheap clone of the session store scoped to the given
+// user. Every read and write the clone performs carries the owner predicate
+// for userID. userID must be positive.
+func (s *SessionStore) ForUser(userID int64) (memstore.SessionStore, error) {
+	if userID <= 0 {
+		return nil, fmt.Errorf("pgstore: SessionStore.ForUser: invalid user id %d", userID)
+	}
+	c := *s
+	c.userID = userID
+	return &c, nil
+}
+
+// ServiceScope returns a clone of the session store with NO user predicate.
+// Reads span all users; writes are invalid (user_id NOT NULL would fire).
+// Intended for cross-user maintenance (BackfillFeedback, UnratedFactSessions).
+func (s *SessionStore) ServiceScope() *SessionStore {
+	c := *s
+	c.userID = 0
+	return &c
+}
+
+// userClause returns an SQL fragment and appended args for the user predicate.
+// When userID is 0 (service scope) it returns an empty string and the args
+// unchanged so callers can unconditionally append the result.
+//
+//	where, args := s.userClause("AND", args)
+//	query += where
+func (s *SessionStore) userClause(conjunction string, args []any) (string, []any) {
+	if s.userID == 0 {
+		return "", args
+	}
+	args = append(args, s.userID)
+	return fmt.Sprintf(" %s user_id = $%d", conjunction, len(args)), args
 }
 
 func (s *SessionStore) migrate(ctx context.Context) error {
@@ -99,13 +201,138 @@ func (s *SessionStore) migrate(ctx context.Context) error {
 		)`,
 		// Backward compatibility: add constraint to tables that predate this migration.
 		// PostgreSQL raises 42710 (duplicate_object) for a pre-existing constraint name,
-		// but may also raise 42P07 (duplicate_table) in some versions — catch both.
+		// but may also raise 42P07 (duplicate_table) in some versions -- catch both.
 		`DO $$ BEGIN
 			ALTER TABLE context_feedback ADD CONSTRAINT uq_context_feedback_ref_session UNIQUE (ref_id, ref_type, session_id);
 		EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 		END $$`,
 		`CREATE INDEX IF NOT EXISTS idx_context_feedback_ref ON context_feedback(ref_id, ref_type)`,
 		`CREATE INDEX IF NOT EXISTS idx_context_feedback_session ON context_feedback(session_id)`,
+
+		// --- 012a: add user_id to all five session tables ---
+
+		// 1. Add the column with a default of 0 so backfill can run before NOT NULL.
+		`ALTER TABLE session_turns      ADD COLUMN IF NOT EXISTS user_id BIGINT`,
+		`ALTER TABLE session_hooks      ADD COLUMN IF NOT EXISTS user_id BIGINT`,
+		`ALTER TABLE context_hints      ADD COLUMN IF NOT EXISTS user_id BIGINT`,
+		`ALTER TABLE context_injections ADD COLUMN IF NOT EXISTS user_id BIGINT`,
+		`ALTER TABLE context_feedback   ADD COLUMN IF NOT EXISTS user_id BIGINT`,
+
+		// 2. Backfill existing rows to the default user. Resolves via the
+		//    memstore_users table using the default_user meta key. No-op on a
+		//    fresh DB (no rows to backfill) and no-op on re-run (already NOT NULL).
+		`DO $$ DECLARE def_uid BIGINT;
+		BEGIN
+			SELECT id INTO def_uid
+			FROM memstore_users
+			WHERE name = (SELECT value FROM memstore_meta WHERE key = 'default_user')
+			LIMIT 1;
+			IF def_uid IS NOT NULL THEN
+				UPDATE session_turns      SET user_id = def_uid WHERE user_id IS NULL;
+				UPDATE session_hooks      SET user_id = def_uid WHERE user_id IS NULL;
+				UPDATE context_hints      SET user_id = def_uid WHERE user_id IS NULL;
+				UPDATE context_injections SET user_id = def_uid WHERE user_id IS NULL;
+				UPDATE context_feedback   SET user_id = def_uid WHERE user_id IS NULL;
+			END IF;
+		END $$`,
+
+		// 3. Apply NOT NULL + FK constraints (idempotent: IF NOT EXISTS for FK,
+		//    exception-guarded for NOT NULL since Postgres has no IF NOT EXISTS).
+		`DO $$ BEGIN
+			ALTER TABLE session_turns ALTER COLUMN user_id SET NOT NULL;
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE session_hooks ALTER COLUMN user_id SET NOT NULL;
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE context_hints ALTER COLUMN user_id SET NOT NULL;
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE context_injections ALTER COLUMN user_id SET NOT NULL;
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE context_feedback ALTER COLUMN user_id SET NOT NULL;
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
+
+		// 4. FK constraints.
+		`DO $$ BEGIN
+			ALTER TABLE session_turns ADD CONSTRAINT fk_session_turns_user
+				FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT;
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE session_hooks ADD CONSTRAINT fk_session_hooks_user
+				FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT;
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE context_hints ADD CONSTRAINT fk_context_hints_user
+				FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT;
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE context_injections ADD CONSTRAINT fk_context_injections_user
+				FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT;
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE context_feedback ADD CONSTRAINT fk_context_feedback_user
+				FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT;
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$`,
+
+		// 5. Indexes on user_id.
+		`CREATE INDEX IF NOT EXISTS idx_session_turns_user      ON session_turns(user_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_session_hooks_user      ON session_hooks(user_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_context_hints_user      ON context_hints(user_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_context_injections_user ON context_injections(user_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_context_feedback_user   ON context_feedback(user_id)`,
+
+		// 6. Widen unique constraints to include user_id. Drop the old narrow
+		//    constraints first (idempotent: exception on missing), then add the
+		//    wide ones (idempotent: exception on duplicate_object).
+		//
+		//    session_turns: was UNIQUE(session_id, uuid)
+		`DO $$ BEGIN
+			ALTER TABLE session_turns DROP CONSTRAINT IF EXISTS session_turns_session_id_uuid_key;
+		EXCEPTION WHEN undefined_object THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE session_turns ADD CONSTRAINT uq_session_turns_user_session_uuid
+				UNIQUE (user_id, session_id, uuid);
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$`,
+
+		//    context_injections: was UNIQUE(session_id, ref_id, ref_type)
+		`DO $$ BEGIN
+			ALTER TABLE context_injections DROP CONSTRAINT IF EXISTS context_injections_session_id_ref_id_ref_type_key;
+		EXCEPTION WHEN undefined_object THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE context_injections ADD CONSTRAINT uq_context_injections_user_session_ref
+				UNIQUE (user_id, session_id, ref_id, ref_type);
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$`,
+
+		//    context_feedback: was UNIQUE(ref_id, ref_type, session_id) via named constraint
+		`DO $$ BEGIN
+			ALTER TABLE context_feedback DROP CONSTRAINT uq_context_feedback_ref_session;
+		EXCEPTION WHEN undefined_object THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE context_feedback DROP CONSTRAINT IF EXISTS context_feedback_ref_id_ref_type_session_id_key;
+		EXCEPTION WHEN undefined_object THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE context_feedback ADD CONSTRAINT uq_context_feedback_user_ref_session
+				UNIQUE (user_id, ref_id, ref_type, session_id);
+		EXCEPTION WHEN duplicate_object THEN NULL;
+		END $$`,
 	}
 	for _, stmt := range stmts {
 		if _, err := s.pool.Exec(ctx, stmt); err != nil {
@@ -116,6 +343,7 @@ func (s *SessionStore) migrate(ctx context.Context) error {
 }
 
 // SaveTurns upserts session turns using a single batched round-trip.
+// Stamped-write: stamps user_id = s.userID.
 func (s *SessionStore) SaveTurns(ctx context.Context, sessionID string, turns []memstore.SessionTurn) error {
 	if len(turns) == 0 {
 		return nil
@@ -123,10 +351,10 @@ func (s *SessionStore) SaveTurns(ctx context.Context, sessionID string, turns []
 	batch := &pgx.Batch{}
 	for _, t := range turns {
 		batch.Queue(`
-			INSERT INTO session_turns(session_id, uuid, turn_index, role, content, cwd, created_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)
-			ON CONFLICT (session_id, uuid) DO NOTHING
-		`, sessionID, t.UUID, t.TurnIndex, t.Role, t.Content, t.CWD, t.CreatedAt)
+			INSERT INTO session_turns(session_id, uuid, turn_index, role, content, cwd, created_at, user_id)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			ON CONFLICT (user_id, session_id, uuid) DO NOTHING
+		`, sessionID, t.UUID, t.TurnIndex, t.Role, t.Content, t.CWD, t.CreatedAt, s.userID)
 	}
 	br := s.pool.SendBatch(ctx, batch)
 	defer br.Close()
@@ -139,6 +367,10 @@ func (s *SessionStore) SaveTurns(ctx context.Context, sessionID string, turns []
 }
 
 // SaveHook appends a raw Stop hook payload.
+// Stamped-write: stamps user_id = s.userID.
+// session_id is extracted from the JSON payload (best-effort); user_id is
+// stamped from the store's scope, not the payload, since hooks do not carry
+// an owner identity.
 func (s *SessionStore) SaveHook(ctx context.Context, payload []byte) error {
 	var hook struct {
 		SessionID string `json:"session_id"`
@@ -146,9 +378,9 @@ func (s *SessionStore) SaveHook(ctx context.Context, payload []byte) error {
 	}
 	json.Unmarshal(payload, &hook) // best-effort
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO session_hooks(session_id, cwd, payload)
-		VALUES ($1, $2, $3)
-	`, hook.SessionID, hook.CWD, payload)
+		INSERT INTO session_hooks(session_id, cwd, payload, user_id)
+		VALUES ($1, $2, $3, $4)
+	`, hook.SessionID, hook.CWD, payload, s.userID)
 	return err
 }
 
@@ -163,6 +395,7 @@ func normalizeCWD(cwd string) string {
 }
 
 // StoreHint stores a context hint produced by the Ollama pipeline.
+// Stamped-write: stamps user_id = s.userID.
 func (s *SessionStore) StoreHint(ctx context.Context, hint memstore.ContextHint) (int64, error) {
 	refIDs, _ := json.Marshal(hint.RefIDs)
 	retrievedIDs, _ := json.Marshal(hint.RetrievedIDs)
@@ -173,13 +406,13 @@ func (s *SessionStore) StoreHint(ctx context.Context, hint memstore.ContextHint)
 			session_id, cwd, turn_index, hint_text,
 			ref_ids, retrieved_ids, candidate_scores,
 			search_query, ranker_version,
-			relevance, desirability
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			relevance, desirability, user_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		RETURNING id
 	`, hint.SessionID, normalizeCWD(hint.CWD), hint.TurnIndex, hint.HintText,
 		refIDs, retrievedIDs, candidateScores,
 		hint.SearchQuery, hint.RankerVersion,
-		hint.Relevance, hint.Desirability).Scan(&id)
+		hint.Relevance, hint.Desirability, s.userID).Scan(&id)
 	return id, err
 }
 
@@ -211,8 +444,11 @@ func scanHints(rows interface {
 }
 
 // GetPendingHints returns unconsumed hints matching sessionID or cwd (OR semantics),
-// ordered by relevance×desirability desc. Either parameter may be empty.
+// ordered by relevance*desirability desc. Either parameter may be empty.
+// Scoped-read: filters AND user_id = s.userID when userID != 0.
 func (s *SessionStore) GetPendingHints(ctx context.Context, sessionID, cwd string) ([]memstore.ContextHint, error) {
+	args := []any{sessionID, normalizeCWD(cwd)}
+	userWhere, args := s.userClause("AND", args)
 	rows, err := s.pool.Query(ctx, `
 		SELECT id, session_id, cwd, turn_index, hint_text,
 		       ref_ids, retrieved_ids, candidate_scores,
@@ -220,9 +456,10 @@ func (s *SessionStore) GetPendingHints(ctx context.Context, sessionID, cwd strin
 		       relevance, desirability, created_at
 		FROM context_hints
 		WHERE consumed_at IS NULL
-		  AND (($1 != '' AND session_id = $1) OR ($2 != '' AND cwd = $2))
+		  AND (($1 != '' AND session_id = $1) OR ($2 != '' AND cwd = $2))`+
+		userWhere+`
 		ORDER BY (relevance * desirability) DESC
-	`, sessionID, normalizeCWD(cwd))
+	`, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -230,57 +467,70 @@ func (s *SessionStore) GetPendingHints(ctx context.Context, sessionID, cwd strin
 }
 
 // MarkHintConsumed marks a hint as consumed.
+// Scoped-read/mutation: filters AND user_id = s.userID so a user cannot
+// consume another user's hint.
 func (s *SessionStore) MarkHintConsumed(ctx context.Context, hintID int64) error {
-	_, err := s.pool.Exec(ctx, `
-		UPDATE context_hints SET consumed_at = NOW() WHERE id = $1
-	`, hintID)
+	args := []any{hintID}
+	userWhere, args := s.userClause("AND", args)
+	_, err := s.pool.Exec(ctx,
+		`UPDATE context_hints SET consumed_at = NOW() WHERE id = $1`+userWhere,
+		args...,
+	)
 	return err
 }
 
 // RecordInjection records that a ref was injected into a session.
 // rank is the 0-based position of the item in the candidate list; -1 if unknown.
-// Ignores conflicts (idempotent).
+// Stamped-write: stamps user_id = s.userID. Ignores conflicts (idempotent).
 func (s *SessionStore) RecordInjection(ctx context.Context, sessionID, refID, refType string, rank int) error {
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO context_injections(session_id, ref_id, ref_type, rank)
-		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (session_id, ref_id, ref_type) DO NOTHING
-	`, sessionID, refID, refType, rank)
+		INSERT INTO context_injections(session_id, ref_id, ref_type, rank, user_id)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (user_id, session_id, ref_id, ref_type) DO NOTHING
+	`, sessionID, refID, refType, rank, s.userID)
 	return err
 }
 
 // WasInjected returns true if refID+refType was already injected this session.
+// Scoped-read: filters AND user_id = s.userID when userID != 0.
 func (s *SessionStore) WasInjected(ctx context.Context, sessionID, refID, refType string) (bool, error) {
+	args := []any{sessionID, refID, refType}
+	userWhere, args := s.userClause("AND", args)
 	var exists bool
-	err := s.pool.QueryRow(ctx, `
-		SELECT EXISTS(
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(
 			SELECT 1 FROM context_injections
-			WHERE session_id=$1 AND ref_id=$2 AND ref_type=$3
-		)
-	`, sessionID, refID, refType).Scan(&exists)
+			WHERE session_id=$1 AND ref_id=$2 AND ref_type=$3`+
+			userWhere+`
+		)`, args...).Scan(&exists)
 	return exists, err
 }
 
 // RecordFeedback stores Claude's rating of an injected context item.
-// One rating per (ref_id, ref_type, session_id) — silently ignores duplicates.
+// Stamped-write: stamps user_id = s.userID. One rating per (user_id, ref_id,
+// ref_type, session_id) -- silently ignores duplicates.
 func (s *SessionStore) RecordFeedback(ctx context.Context, fb memstore.ContextFeedback) error {
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO context_feedback(ref_id, ref_type, session_id, score, reason)
-		VALUES ($1, $2, $3, $4, $5)
-		ON CONFLICT (ref_id, ref_type, session_id) DO NOTHING
-	`, fb.RefID, fb.RefType, fb.SessionID, fb.Score, fb.Reason)
+		INSERT INTO context_feedback(ref_id, ref_type, session_id, score, reason, user_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (user_id, ref_id, ref_type, session_id) DO NOTHING
+	`, fb.RefID, fb.RefType, fb.SessionID, fb.Score, fb.Reason, s.userID)
 	return err
 }
 
-// GetInjectedFactIDs returns the IDs of facts that were injected into the given
-// session via recall, identified via the context_injections dedup log.
-// Used for auto-rating at session end.
+// GetInjectedFactIDs returns the IDs of facts injected into the given session
+// via recall. Used for auto-rating at session end.
+// Scoped-read: filters AND user_id = s.userID when userID != 0.
 func (s *SessionStore) GetInjectedFactIDs(ctx context.Context, sessionID string) ([]int64, error) {
-	rows, err := s.pool.Query(ctx, `
-		SELECT ref_id::bigint FROM context_injections
-		WHERE session_id = $1 AND ref_type = 'fact'
-		ORDER BY rank ASC
-	`, sessionID)
+	args := []any{sessionID}
+	userWhere, args := s.userClause("AND", args)
+	rows, err := s.pool.Query(ctx,
+		`SELECT ref_id::bigint FROM context_injections
+		WHERE session_id = $1 AND ref_type = 'fact'`+
+			userWhere+`
+		ORDER BY rank ASC`,
+		args...,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -296,20 +546,29 @@ func (s *SessionStore) GetInjectedFactIDs(ctx context.Context, sessionID string)
 	return ids, rows.Err()
 }
 
-// GetInjectedHints returns hints that were injected into the given session,
-// identified via the context_injections dedup log. Used for auto-rating at session end.
+// GetInjectedHints returns hints injected into the given session via recall.
+// Used for auto-rating at session end.
+// Scoped-read: filters on ci.user_id when userID != 0.
 func (s *SessionStore) GetInjectedHints(ctx context.Context, sessionID string) ([]memstore.ContextHint, error) {
-	rows, err := s.pool.Query(ctx, `
-		SELECT ch.id, ch.session_id, ch.cwd, ch.turn_index, ch.hint_text,
+	args := []any{sessionID}
+	userWhere := ""
+	if s.userID != 0 {
+		args = append(args, s.userID)
+		userWhere = fmt.Sprintf(" AND ci.user_id = $%d", len(args))
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT ch.id, ch.session_id, ch.cwd, ch.turn_index, ch.hint_text,
 		       ch.ref_ids, ch.retrieved_ids, ch.candidate_scores,
 		       ch.search_query, ch.ranker_version,
 		       ch.relevance, ch.desirability, ch.created_at
 		FROM context_hints ch
 		JOIN context_injections ci
 		  ON ci.ref_id = ch.id::text AND ci.ref_type = 'hint'
-		WHERE ci.session_id = $1
-		ORDER BY ci.injected_at ASC
-	`, sessionID)
+		WHERE ci.session_id = $1`+
+			userWhere+`
+		ORDER BY ci.injected_at ASC`,
+		args...,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -318,15 +577,21 @@ func (s *SessionStore) GetInjectedHints(ctx context.Context, sessionID string) (
 
 // FeedbackScores returns the average feedback score and rating count for each
 // ref across all sessions. Only refs with feedback data are included.
+// Scoped-read: filters AND user_id = s.userID when userID != 0.
+// Service-conditional: at userID 0 (service scope) spans all users.
 func (s *SessionStore) FeedbackScores(ctx context.Context, refIDs []string, refType string) (map[string]memstore.FeedbackStat, error) {
 	if len(refIDs) == 0 {
 		return nil, nil
 	}
-	rows, err := s.pool.Query(ctx, `
-		SELECT ref_id, AVG(score)::float8, COUNT(*)::int FROM context_feedback
-		WHERE ref_id = ANY($1) AND ref_type = $2
-		GROUP BY ref_id
-	`, refIDs, refType)
+	args := []any{refIDs, refType}
+	userWhere, args := s.userClause("AND", args)
+	rows, err := s.pool.Query(ctx,
+		`SELECT ref_id, AVG(score)::float8, COUNT(*)::int FROM context_feedback
+		WHERE ref_id = ANY($1) AND ref_type = $2`+
+			userWhere+`
+		GROUP BY ref_id`,
+		args...,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -345,19 +610,29 @@ func (s *SessionStore) FeedbackScores(ctx context.Context, refIDs []string, refT
 
 // UnratedFactSessions returns session IDs that have fact injections with no
 // corresponding feedback. Used by the backfill-feedback command.
+// Scoped-read: filters AND ci.user_id = s.userID when userID != 0.
+// Service-conditional: at userID 0 (service scope) spans all users.
 func (s *SessionStore) UnratedFactSessions(ctx context.Context) ([]string, error) {
-	rows, err := s.pool.Query(ctx, `
-		SELECT DISTINCT ci.session_id
+	args := []any{}
+	userWhere := ""
+	if s.userID != 0 {
+		args = append(args, s.userID)
+		userWhere = fmt.Sprintf(" AND ci.user_id = $%d", len(args))
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT DISTINCT ci.session_id
 		FROM context_injections ci
-		WHERE ci.ref_type = 'fact'
+		WHERE ci.ref_type = 'fact'`+
+			userWhere+`
 		AND EXISTS (SELECT 1 FROM session_turns st WHERE st.session_id = ci.session_id)
 		AND NOT EXISTS (
 			SELECT 1 FROM context_feedback cf
 			WHERE cf.ref_id = ci.ref_id AND cf.ref_type = ci.ref_type
 			AND cf.session_id = ci.session_id
 		)
-		ORDER BY ci.session_id
-	`)
+		ORDER BY ci.session_id`,
+		args...,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -374,13 +649,18 @@ func (s *SessionStore) UnratedFactSessions(ctx context.Context) ([]string, error
 }
 
 // GetSessionTurns returns all turns for a given session, ordered by turn index.
+// Scoped-read: filters AND user_id = s.userID when userID != 0.
 func (s *SessionStore) GetSessionTurns(ctx context.Context, sessionID string) ([]memstore.SessionTurn, error) {
-	rows, err := s.pool.Query(ctx, `
-		SELECT session_id, uuid, turn_index, role, content, cwd, created_at
+	args := []any{sessionID}
+	userWhere, args := s.userClause("AND", args)
+	rows, err := s.pool.Query(ctx,
+		`SELECT session_id, uuid, turn_index, role, content, cwd, created_at
 		FROM session_turns
-		WHERE session_id = $1
-		ORDER BY turn_index ASC
-	`, sessionID)
+		WHERE session_id = $1`+
+			userWhere+`
+		ORDER BY turn_index ASC`,
+		args...,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -398,11 +678,15 @@ func (s *SessionStore) GetSessionTurns(ctx context.Context, sessionID string) ([
 
 // FeedbackScore returns the average feedback score for a ref across all sessions.
 // Returns 0 if no feedback exists.
+// Scoped-read: filters AND user_id = s.userID when userID != 0.
 func (s *SessionStore) FeedbackScore(ctx context.Context, refID, refType string) (float64, error) {
+	args := []any{refID, refType}
+	userWhere, args := s.userClause("AND", args)
 	var score float64
-	err := s.pool.QueryRow(ctx, `
-		SELECT COALESCE(AVG(score), 0) FROM context_feedback
-		WHERE ref_id=$1 AND ref_type=$2
-	`, refID, refType).Scan(&score)
+	err := s.pool.QueryRow(ctx,
+		`SELECT COALESCE(AVG(score), 0) FROM context_feedback
+		WHERE ref_id=$1 AND ref_type=$2`+userWhere,
+		args...,
+	).Scan(&score)
 	return score, err
 }

--- a/pgstore/session_store.go
+++ b/pgstore/session_store.go
@@ -131,7 +131,10 @@ func (s *SessionStore) userClause(conjunction string, args []any) (string, []any
 }
 
 func (s *SessionStore) migrate(ctx context.Context) error {
-	stmts := []string{
+	// Phase 1: create tables, columns, and indexes. This includes adding the
+	// user_id column (nullable for now) so the fail-loud check and backfill in
+	// phase 2 have something to operate on.
+	baseStmts := []string{
 		`CREATE TABLE IF NOT EXISTS session_turns (
 			id         BIGSERIAL PRIMARY KEY,
 			session_id TEXT NOT NULL,
@@ -214,57 +217,42 @@ func (s *SessionStore) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS idx_context_feedback_ref ON context_feedback(ref_id, ref_type)`,
 		`CREATE INDEX IF NOT EXISTS idx_context_feedback_session ON context_feedback(session_id)`,
 
-		// --- 012a: add user_id to all five session tables ---
-
-		// 1. Add the column with a default of 0 so backfill can run before NOT NULL.
+		// --- 012a: add user_id column to all five session tables ---
+		// The column is added nullable here; phase 2 backfills it and phase 3
+		// applies NOT NULL once it is guaranteed null-free.
 		`ALTER TABLE session_turns      ADD COLUMN IF NOT EXISTS user_id BIGINT`,
 		`ALTER TABLE session_hooks      ADD COLUMN IF NOT EXISTS user_id BIGINT`,
 		`ALTER TABLE context_hints      ADD COLUMN IF NOT EXISTS user_id BIGINT`,
 		`ALTER TABLE context_injections ADD COLUMN IF NOT EXISTS user_id BIGINT`,
 		`ALTER TABLE context_feedback   ADD COLUMN IF NOT EXISTS user_id BIGINT`,
+	}
+	for _, stmt := range baseStmts {
+		if _, err := s.pool.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("session store migrate: %w\nstatement: %s", err, stmt)
+		}
+	}
 
-		// 2. Backfill existing rows to the default user. Resolves via the
-		//    memstore_users table using the default_user meta key. No-op on a
-		//    fresh DB (no rows to backfill) and no-op on re-run (already NOT NULL).
-		`DO $$ DECLARE def_uid BIGINT;
-		BEGIN
-			SELECT id INTO def_uid
-			FROM memstore_users
-			WHERE name = (SELECT value FROM memstore_meta WHERE key = 'default_user')
-			LIMIT 1;
-			IF def_uid IS NOT NULL THEN
-				UPDATE session_turns      SET user_id = def_uid WHERE user_id IS NULL;
-				UPDATE session_hooks      SET user_id = def_uid WHERE user_id IS NULL;
-				UPDATE context_hints      SET user_id = def_uid WHERE user_id IS NULL;
-				UPDATE context_injections SET user_id = def_uid WHERE user_id IS NULL;
-				UPDATE context_feedback   SET user_id = def_uid WHERE user_id IS NULL;
-			END IF;
-		END $$`,
+	// Phase 2: resolve the default user and backfill existing rows. If session
+	// data exists but no default user can be resolved, fail loudly HERE -- before
+	// the unguarded SET NOT NULL in phase 3 would otherwise either error on a
+	// null-bearing column or (if masked) leave a half-migrated table.
+	if err := s.backfillSessionUser(ctx); err != nil {
+		return err
+	}
 
-		// 3. Apply NOT NULL + FK constraints (idempotent: IF NOT EXISTS for FK,
-		//    exception-guarded for NOT NULL since Postgres has no IF NOT EXISTS).
-		`DO $$ BEGIN
-			ALTER TABLE session_turns ALTER COLUMN user_id SET NOT NULL;
-		EXCEPTION WHEN others THEN NULL;
-		END $$`,
-		`DO $$ BEGIN
-			ALTER TABLE session_hooks ALTER COLUMN user_id SET NOT NULL;
-		EXCEPTION WHEN others THEN NULL;
-		END $$`,
-		`DO $$ BEGIN
-			ALTER TABLE context_hints ALTER COLUMN user_id SET NOT NULL;
-		EXCEPTION WHEN others THEN NULL;
-		END $$`,
-		`DO $$ BEGIN
-			ALTER TABLE context_injections ALTER COLUMN user_id SET NOT NULL;
-		EXCEPTION WHEN others THEN NULL;
-		END $$`,
-		`DO $$ BEGIN
-			ALTER TABLE context_feedback ALTER COLUMN user_id SET NOT NULL;
-		EXCEPTION WHEN others THEN NULL;
-		END $$`,
+	// Phase 3: apply NOT NULL, FK, indexes, and unique-key widening. SET NOT NULL
+	// is unguarded: the column is now guaranteed null-free (fresh/empty DB, or
+	// backfilled in phase 2) and SET NOT NULL is a no-op on an already-NOT-NULL
+	// column, so re-runs are safe and a genuine failure surfaces clearly.
+	constraintStmts := []string{
+		// NOT NULL (unguarded -- see phase 3 note above).
+		`ALTER TABLE session_turns      ALTER COLUMN user_id SET NOT NULL`,
+		`ALTER TABLE session_hooks      ALTER COLUMN user_id SET NOT NULL`,
+		`ALTER TABLE context_hints      ALTER COLUMN user_id SET NOT NULL`,
+		`ALTER TABLE context_injections ALTER COLUMN user_id SET NOT NULL`,
+		`ALTER TABLE context_feedback   ALTER COLUMN user_id SET NOT NULL`,
 
-		// 4. FK constraints.
+		// FK constraints.
 		`DO $$ BEGIN
 			ALTER TABLE session_turns ADD CONSTRAINT fk_session_turns_user
 				FOREIGN KEY (user_id) REFERENCES memstore_users(id) ON DELETE RESTRICT;
@@ -291,16 +279,16 @@ func (s *SessionStore) migrate(ctx context.Context) error {
 		EXCEPTION WHEN duplicate_object THEN NULL;
 		END $$`,
 
-		// 5. Indexes on user_id.
+		// Indexes on user_id.
 		`CREATE INDEX IF NOT EXISTS idx_session_turns_user      ON session_turns(user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_session_hooks_user      ON session_hooks(user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_context_hints_user      ON context_hints(user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_context_injections_user ON context_injections(user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_context_feedback_user   ON context_feedback(user_id)`,
 
-		// 6. Widen unique constraints to include user_id. Drop the old narrow
-		//    constraints first (idempotent: exception on missing), then add the
-		//    wide ones (idempotent: exception on duplicate_object).
+		// Widen unique constraints to include user_id. Drop the old narrow
+		// constraints first (idempotent: exception on missing), then add the
+		// wide ones (idempotent: exception on duplicate_object).
 		//
 		//    session_turns: was UNIQUE(session_id, uuid)
 		`DO $$ BEGIN
@@ -339,12 +327,73 @@ func (s *SessionStore) migrate(ctx context.Context) error {
 		EXCEPTION WHEN duplicate_object THEN NULL;
 		END $$`,
 	}
-	for _, stmt := range stmts {
+	for _, stmt := range constraintStmts {
 		if _, err := s.pool.Exec(ctx, stmt); err != nil {
 			return fmt.Errorf("session store migrate: %w\nstatement: %s", err, stmt)
 		}
 	}
 	return nil
+}
+
+// backfillSessionUser resolves the default user and stamps it onto any session
+// rows whose user_id is still NULL. It is the fail-loud gate before the
+// unguarded SET NOT NULL in migrate's phase 3:
+//
+//   - If a default user resolves, every NULL user_id row is backfilled to it.
+//   - If NO default user resolves but session rows exist, it returns the
+//     tier3-init error so the operator seeds identity before the column is made
+//     NOT NULL. (On the daemon path the facts-layer store has already recorded
+//     the default user, so this never fires there.)
+//   - If no default user resolves and all session tables are empty, it is a
+//     harmless no-op (a fresh DB; the column is trivially null-free).
+func (s *SessionStore) backfillSessionUser(ctx context.Context) error {
+	var defUID *int64
+	err := s.pool.QueryRow(ctx, `
+		SELECT id FROM memstore_users
+		WHERE name = (SELECT value FROM memstore_meta WHERE key = 'default_user')
+		LIMIT 1
+	`).Scan(&defUID)
+	if err != nil && err != pgx.ErrNoRows {
+		return fmt.Errorf("session store migrate: resolving default user: %w", err)
+	}
+
+	if defUID == nil {
+		// No default user. Only safe if there is no session data to backfill.
+		hasData, derr := s.hasSessionData(ctx)
+		if derr != nil {
+			return fmt.Errorf("session store migrate: checking for session data: %w", derr)
+		}
+		if hasData {
+			return fmt.Errorf("session store migrate: no default user recorded -- run 'memstore admin tier3-init --default-user <name>' before starting memstored")
+		}
+		return nil
+	}
+
+	for _, tbl := range []string{
+		"session_turns", "session_hooks", "context_hints",
+		"context_injections", "context_feedback",
+	} {
+		if _, err := s.pool.Exec(ctx,
+			`UPDATE `+tbl+` SET user_id = $1 WHERE user_id IS NULL`, *defUID,
+		); err != nil {
+			return fmt.Errorf("session store migrate: backfilling %s.user_id: %w", tbl, err)
+		}
+	}
+	return nil
+}
+
+// hasSessionData reports whether any of the five session tables holds a row.
+func (s *SessionStore) hasSessionData(ctx context.Context) (bool, error) {
+	var hasData bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM session_turns      LIMIT 1 UNION ALL
+			SELECT 1 FROM session_hooks      LIMIT 1 UNION ALL
+			SELECT 1 FROM context_hints      LIMIT 1 UNION ALL
+			SELECT 1 FROM context_injections LIMIT 1 UNION ALL
+			SELECT 1 FROM context_feedback   LIMIT 1
+		)`).Scan(&hasData)
+	return hasData, err
 }
 
 // SaveTurns upserts session turns using a single batched round-trip.

--- a/pgstore/session_store.go
+++ b/pgstore/session_store.go
@@ -3,10 +3,12 @@ package pgstore
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/matthewjhunter/memstore"
 )
@@ -55,18 +57,9 @@ func resolveSessionUser(ctx context.Context, pool *pgxpool.Pool) (int64, error) 
 	if err == pgx.ErrNoRows || (err == nil && name == "") {
 		// No default user recorded. Safe to proceed as userID=0 only if
 		// all session tables are empty.
-		var hasData bool
-		checkQ := `
-			SELECT EXISTS(
-				SELECT 1 FROM session_turns    LIMIT 1 UNION ALL
-				SELECT 1 FROM session_hooks    LIMIT 1 UNION ALL
-				SELECT 1 FROM context_hints    LIMIT 1 UNION ALL
-				SELECT 1 FROM context_injections LIMIT 1 UNION ALL
-				SELECT 1 FROM context_feedback LIMIT 1
-			)`
-		if qerr := pool.QueryRow(ctx, checkQ).Scan(&hasData); qerr != nil {
-			// Tables may not yet exist (first migration call); treat as empty.
-			return 0, nil
+		hasData, derr := hasSessionData(ctx, pool)
+		if derr != nil {
+			return 0, fmt.Errorf("checking for session data: %w", derr)
 		}
 		if hasData {
 			return 0, fmt.Errorf("no default user recorded -- run 'memstore admin tier3-init --default-user <name>' before starting memstored")
@@ -359,7 +352,7 @@ func (s *SessionStore) backfillSessionUser(ctx context.Context) error {
 
 	if defUID == nil {
 		// No default user. Only safe if there is no session data to backfill.
-		hasData, derr := s.hasSessionData(ctx)
+		hasData, derr := hasSessionData(ctx, s.pool)
 		if derr != nil {
 			return fmt.Errorf("session store migrate: checking for session data: %w", derr)
 		}
@@ -383,17 +376,29 @@ func (s *SessionStore) backfillSessionUser(ctx context.Context) error {
 }
 
 // hasSessionData reports whether any of the five session tables holds a row.
-func (s *SessionStore) hasSessionData(ctx context.Context) (bool, error) {
+// If a session table does not exist yet (pre-migration DB), Postgres raises
+// undefined_table (42P01); that is treated as "no data" so the caller can
+// proceed as userID 0 on a fresh DB. This is the single copy of the check --
+// both resolveSessionUser and backfillSessionUser route through it.
+func hasSessionData(ctx context.Context, pool *pgxpool.Pool) (bool, error) {
 	var hasData bool
-	err := s.pool.QueryRow(ctx, `
-		SELECT EXISTS(
-			SELECT 1 FROM session_turns      LIMIT 1 UNION ALL
-			SELECT 1 FROM session_hooks      LIMIT 1 UNION ALL
-			SELECT 1 FROM context_hints      LIMIT 1 UNION ALL
-			SELECT 1 FROM context_injections LIMIT 1 UNION ALL
-			SELECT 1 FROM context_feedback   LIMIT 1
-		)`).Scan(&hasData)
-	return hasData, err
+	// ORed EXISTS, not a UNION of LIMIT-1 selects: Postgres rejects a bare
+	// LIMIT before UNION ALL without parenthesizing each leg.
+	err := pool.QueryRow(ctx, `
+		SELECT EXISTS(SELECT 1 FROM session_turns)
+		    OR EXISTS(SELECT 1 FROM session_hooks)
+		    OR EXISTS(SELECT 1 FROM context_hints)
+		    OR EXISTS(SELECT 1 FROM context_injections)
+		    OR EXISTS(SELECT 1 FROM context_feedback)
+	`).Scan(&hasData)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42P01" { // undefined_table
+			return false, nil
+		}
+		return false, err
+	}
+	return hasData, nil
 }
 
 // SaveTurns upserts session turns using a single batched round-trip.

--- a/pgstore/session_store.go
+++ b/pgstore/session_store.go
@@ -87,6 +87,11 @@ func resolveSessionUser(ctx context.Context, pool *pgxpool.Pool) (int64, error) 
 	return id, nil
 }
 
+// UserID returns the user ID this store is scoped to. 0 means service scope
+// (no user predicate). Exposed so tests and admin tooling can pass the
+// resolved default-user ID to ForUser.
+func (s *SessionStore) UserID() int64 { return s.userID }
+
 // SessionStore supports per-user scoping.
 var _ memstore.SessionUserScoper = (*SessionStore)(nil)
 

--- a/pgstore/session_store_test.go
+++ b/pgstore/session_store_test.go
@@ -73,6 +73,86 @@ func TestSessionForUser_InvalidID(t *testing.T) {
 	}
 }
 
+// TestSessionMigrate_DataWithoutDefaultUser verifies the fail-loud gate:
+// when session rows exist but no default_user is recorded, NewSessionStore
+// returns the tier3-init error AND leaves user_id nullable (the failure is at
+// resolution, not a masked half-migrate that silently sets NOT NULL).
+func TestSessionMigrate_DataWithoutDefaultUser(t *testing.T) {
+	ctx := context.Background()
+	dsn := testDSN(t)
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting to postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	// Clean both layers.
+	for _, tbl := range []string{
+		"context_feedback", "context_injections", "context_hints",
+		"session_hooks", "session_turns",
+		"memstore_links", "memstore_facts", "memstore_meta",
+		"memstore_version", "memstore_users",
+	} {
+		pool.Exec(ctx, "DROP TABLE IF EXISTS "+tbl+" CASCADE")
+	}
+
+	// Build the facts-layer schema so memstore_meta + memstore_users exist,
+	// but deliberately do NOT seed default_user (no InitIdentity call). The
+	// first pgstore.New migrates the schema and fails at user resolution;
+	// that failure is expected and benign here.
+	embedder := &mockEmbedder{dim: 4}
+	if _, err := pgstore.New(ctx, pool, embedder, "test", 4, 0); err != nil && !strings.Contains(err.Error(), "tier3-init") {
+		t.Fatalf("facts schema init: %v", err)
+	}
+
+	// Pre-create session_turns with a NULLABLE user_id and seed one row, so the
+	// migration's fail-loud check has data present but no default user to stamp.
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE session_turns (
+			id         BIGSERIAL PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			uuid       TEXT NOT NULL,
+			turn_index INT NOT NULL,
+			role       TEXT NOT NULL,
+			content    TEXT NOT NULL,
+			cwd        TEXT NOT NULL DEFAULT '',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			user_id    BIGINT,
+			UNIQUE(session_id, uuid)
+		)`); err != nil {
+		t.Fatalf("creating pre-migration session_turns: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO session_turns(session_id, uuid, turn_index, role, content)
+		VALUES ('orphan-sid', 'orphan-uuid', 0, 'user', 'pre-existing row')
+	`); err != nil {
+		t.Fatalf("seeding orphan turn: %v", err)
+	}
+
+	// NewSessionStore must fail loudly with the tier3-init instruction.
+	_, err = pgstore.NewSessionStore(ctx, pool)
+	if err == nil {
+		t.Fatal("NewSessionStore should have failed (session data, no default user)")
+	}
+	if !strings.Contains(err.Error(), "tier3-init") {
+		t.Errorf("expected tier3-init error, got: %v", err)
+	}
+
+	// The column must remain nullable -- the failure was at resolution, not a
+	// masked half-migrate that silently applied SET NOT NULL.
+	var isNullable string
+	if qerr := pool.QueryRow(ctx, `
+		SELECT is_nullable FROM information_schema.columns
+		WHERE table_name = 'session_turns' AND column_name = 'user_id'
+	`).Scan(&isNullable); qerr != nil {
+		t.Fatalf("querying user_id nullability: %v", qerr)
+	}
+	if isNullable != "YES" {
+		t.Errorf("session_turns.user_id was set NOT NULL despite failed resolution (half-migrate); is_nullable=%q", isNullable)
+	}
+}
+
 // TestSessionMigrate_UserIDColumns verifies that after NewSessionStore all five
 // session tables have a user_id column that is NOT NULL and has the FK to
 // memstore_users.

--- a/pgstore/session_store_test.go
+++ b/pgstore/session_store_test.go
@@ -1,0 +1,223 @@
+package pgstore_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/matthewjhunter/memstore"
+	"github.com/matthewjhunter/memstore/internal/conformance"
+	"github.com/matthewjhunter/memstore/pgstore"
+)
+
+// newTestSessionStore creates a SessionStore against the test database, with
+// the facts-layer schema migrated first (SessionStore depends on
+// memstore_users + memstore_meta from that migration).
+func newTestSessionStore(t *testing.T) (*pgstore.SessionStore, *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	dsn := testDSN(t)
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting to postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	// Drop all session tables so each test starts clean.
+	for _, tbl := range []string{
+		"context_feedback",
+		"context_injections",
+		"context_hints",
+		"session_hooks",
+		"session_turns",
+	} {
+		pool.Exec(ctx, "DROP TABLE IF EXISTS "+tbl+" CASCADE")
+	}
+
+	// Ensure the facts-layer schema exists (memstore_users, memstore_meta).
+	// Use the same bootstrap pattern as newTestStoreNS.
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_links CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
+
+	embedder := &mockEmbedder{dim: 4}
+	if _, err := pgstore.New(ctx, pool, embedder, "test", 4, 0); err != nil && !strings.Contains(err.Error(), "tier3-init") {
+		t.Fatalf("facts schema init: %v", err)
+	}
+	if err := pgstore.InitIdentity(ctx, pool, "test", "testuser"); err != nil {
+		t.Fatalf("InitIdentity: %v", err)
+	}
+	if _, err := pgstore.New(ctx, pool, embedder, "test", 4, 0); err != nil {
+		t.Fatalf("second pgstore.New: %v", err)
+	}
+
+	ss, err := pgstore.NewSessionStore(ctx, pool)
+	if err != nil {
+		t.Fatalf("NewSessionStore: %v", err)
+	}
+	return ss, pool
+}
+
+// TestSessionForUser_InvalidID checks that ForUser rejects non-positive IDs.
+func TestSessionForUser_InvalidID(t *testing.T) {
+	ss, _ := newTestSessionStore(t)
+	for _, id := range []int64{0, -1, -999} {
+		if _, err := ss.ForUser(id); err == nil {
+			t.Errorf("ForUser(%d) should have returned an error", id)
+		}
+	}
+}
+
+// TestSessionMigrate_UserIDColumns verifies that after NewSessionStore all five
+// session tables have a user_id column that is NOT NULL and has the FK to
+// memstore_users.
+func TestSessionMigrate_UserIDColumns(t *testing.T) {
+	_, pool := newTestSessionStore(t)
+	ctx := context.Background()
+
+	tables := []string{
+		"session_turns",
+		"session_hooks",
+		"context_hints",
+		"context_injections",
+		"context_feedback",
+	}
+	for _, tbl := range tables {
+		t.Run(tbl, func(t *testing.T) {
+			// Check column exists and is NOT NULL.
+			var isNullable string
+			err := pool.QueryRow(ctx, `
+				SELECT is_nullable FROM information_schema.columns
+				WHERE table_name = $1 AND column_name = 'user_id'
+			`, tbl).Scan(&isNullable)
+			if err != nil {
+				t.Fatalf("querying user_id column for %s: %v", tbl, err)
+			}
+			if isNullable != "NO" {
+				t.Errorf("%s.user_id is nullable (expected NOT NULL)", tbl)
+			}
+
+			// Check FK exists.
+			var fkCount int
+			err = pool.QueryRow(ctx, `
+				SELECT COUNT(*) FROM information_schema.referential_constraints rc
+				JOIN information_schema.key_column_usage kcu
+				  ON kcu.constraint_name = rc.constraint_name
+				WHERE kcu.table_name = $1 AND kcu.column_name = 'user_id'
+			`, tbl).Scan(&fkCount)
+			if err != nil {
+				t.Fatalf("querying FK for %s: %v", tbl, err)
+			}
+			if fkCount == 0 {
+				t.Errorf("%s.user_id has no FK to memstore_users", tbl)
+			}
+		})
+	}
+}
+
+// TestSessionStore_DefaultScope exercises basic write+read through the
+// default-scoped SessionStore (the single-user daemon path).
+func TestSessionStore_DefaultScope(t *testing.T) {
+	ss, _ := newTestSessionStore(t)
+	ctx := context.Background()
+
+	sid := "default-scope-session"
+	turns := []memstore.SessionTurn{
+		{
+			SessionID: sid,
+			UUID:      "uuid-default-1",
+			TurnIndex: 0,
+			Role:      "user",
+			Content:   "hello default",
+			CWD:       "/tmp",
+			CreatedAt: time.Now().UTC().Truncate(time.Millisecond),
+		},
+	}
+	if err := ss.SaveTurns(ctx, sid, turns); err != nil {
+		t.Fatalf("SaveTurns: %v", err)
+	}
+
+	got, err := ss.GetSessionTurns(ctx, sid)
+	if err != nil {
+		t.Fatalf("GetSessionTurns: %v", err)
+	}
+	if len(got) != 1 || got[0].Content != "hello default" {
+		t.Errorf("unexpected turns: %v", got)
+	}
+}
+
+// TestSessionConformance_SessionIsolation wires the conformance session
+// isolation battery against pgstore, using two ForUser-scoped stores.
+func TestSessionConformance_SessionIsolation(t *testing.T) {
+	ctx := context.Background()
+	dsn := testDSN(t)
+
+	conformance.Run(t, conformance.Options{
+		// NewStore is required by conformance.Run; use a minimal stub that
+		// satisfies the interface (the session isolation subtests are all we care
+		// about here -- the full facts battery runs in store_test.go).
+		NewStore: func(t *testing.T) memstore.Store {
+			t.Helper()
+			return newTestStore(t)
+		},
+		NewTwoUserSessionStores: func(t *testing.T) (memstore.SessionStore, memstore.SessionStore) {
+			t.Helper()
+			pool, err := pgxpool.New(ctx, dsn)
+			if err != nil {
+				t.Fatalf("connecting to postgres: %v", err)
+			}
+			t.Cleanup(pool.Close)
+
+			// Clean session tables.
+			for _, tbl := range []string{
+				"context_feedback",
+				"context_injections",
+				"context_hints",
+				"session_hooks",
+				"session_turns",
+			} {
+				pool.Exec(ctx, "DROP TABLE IF EXISTS "+tbl+" CASCADE")
+			}
+
+			// Rebuild facts schema with two users.
+			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_links CASCADE`)
+			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
+			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
+			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
+
+			embedder := &mockEmbedder{dim: 4}
+			if _, err := pgstore.New(ctx, pool, embedder, "test", 4, 0); err != nil && !strings.Contains(err.Error(), "tier3-init") {
+				t.Fatalf("facts schema init: %v", err)
+			}
+			if err := pgstore.InitIdentity(ctx, pool, "test", "user-a"); err != nil {
+				t.Fatalf("InitIdentity user-a: %v", err)
+			}
+			// user-b is a second user in the same namespace.
+			uidB, err := pgstore.EnsureUser(ctx, pool, "test", "user-b")
+			if err != nil {
+				t.Fatalf("EnsureUser user-b: %v", err)
+			}
+
+			ss, err := pgstore.NewSessionStore(ctx, pool)
+			if err != nil {
+				t.Fatalf("NewSessionStore: %v", err)
+			}
+
+			storeA, err := ss.ForUser(ss.UserID())
+			if err != nil {
+				t.Fatalf("ForUser(user-a): %v", err)
+			}
+			storeB, err := ss.ForUser(uidB)
+			if err != nil {
+				t.Fatalf("ForUser(user-b): %v", err)
+			}
+			return storeA, storeB
+		},
+	})
+}

--- a/session.go
+++ b/session.go
@@ -101,6 +101,13 @@ type FeedbackScorer interface {
 	FeedbackScores(ctx context.Context, refIDs []string, refType string) (map[string]FeedbackStat, error)
 }
 
+// SessionUserScoper is implemented by session stores that support per-user
+// scoping. ForUser returns a session store whose reads and writes are scoped
+// to the given user. userID must be positive.
+type SessionUserScoper interface {
+	ForUser(userID int64) (SessionStore, error)
+}
+
 // SessionStore persists Claude Code session data: turns, hints, injections, and feedback.
 type SessionStore interface {
 	// SaveTurns upserts session turns (idempotent on session_id+uuid).


### PR DESCRIPTION
Phase 3a of 4 for v0.4.0 multi-user isolation (spec: plans/009 D4; depends on #87). The facts and links layers are isolated (#86/#87); this gives the session layer -- turns, hooks, hints, injections, feedback -- the same ownership axis. Until now two users' Claude sessions with colliding session_ids would interleave and every hint/feedback row was globally readable. Deliberately inert for the single-user daemon: it still constructs one default-scoped SessionStore. 012b wires per-request scoping on top.

What lands:
- user_id NOT NULL + FK on all five session tables (session_turns, session_hooks, context_hints, context_injections, context_feedback), backfilled to the default user. Unique keys widened to include user_id (UNIQUE(user_id, session_id, uuid) etc.) so colliding session_ids cannot collide at the DB level -- the structural backstop even if request scoping ever had a bug.
- SessionStore gains a userID field resolved at construction (mirrors PostgresStore): writes stamp it, reads/mutations filter it, userID 0 = service scope (read/maintenance only, for BackfillFeedback's cross-user UnratedFactSessions/FeedbackScores).
- SessionUserScoper capability interface (session.go) parallel to UserScoper; pgstore.SessionStore implements ForUser(userID) (memstore.SessionStore, error) + ServiceScope(). Compile-guarded.
- Session-isolation conformance family (TurnsIsolated, HintsIsolated, InjectionsIsolated, FeedbackIsolated) proving two users sharing a database see/touch none of each other's session data; gated on a NewTwoUserSessionStores option.

Migration is phased to fail loud: (1) tables + nullable user_id column, (2) a Go-level gate that resolves the default user and returns the tier3-init error if session data exists with no resolvable user, (3) unguarded SET NOT NULL (now guaranteed null-free) + FK + widened unique keys (narrow duplicate_object/undefined_object guards). No broad error-swallowing.

Review: three rounds against a fresh pgvector container. Round 1 replaced an `EXCEPTION WHEN others THEN NULL` around SET NOT NULL that masked the genuine no-default-user failure (it only failed afterward by constructor ordering, leaving a transient half-migrated table). The fail-loud bad-case test added in round 1 then surfaced a latent SQL bug (round 2): a LIMIT-before-UNION session-data check -- present but unexercised in the original code -- that made the gate fail with a confusing syntax error instead of the tier3-init message; fixed and deduped into one helper. Final: lint clean, full race suite + session battery + TestSessionMigrate_DataWithoutDefaultUser all green on a fresh DB and on re-run.

Plan: plans/012a-session-layer-isolation.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)