### PR TITLE
Admin user commands + flip docs to v0.4.0 shipped (multi-user phase 4/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@
 Persistent memory system for AI agents with hybrid semantic search,
 cross-encoder reranking, fact supersession, and cross-session task tracking.
 
-> **⚠ Single-user notice (v0.3.0).** Memstore is single-user *by deployment*,
-> not *by enforcement*. Authentication exists end to end, but no read or
-> write path filters by user yet -- two tokens see the same facts. Don't
-> deploy memstore as a shared multi-user service until v0.4.0 lands. See
-> [`docs/MIGRATING.md`](docs/MIGRATING.md) for the full caveat.
+> **Multi-user isolation (v0.4.0).** Memstore enforces per-user isolation
+> end to end. Every read and write -- facts, links, sessions, hints, and
+> feedback -- is filtered by the user the bearer token belongs to; two
+> tokens for two users never see each other's data. A fresh PostgreSQL
+> deployment runs `memstore admin tier3-init --default-user <name>` once to
+> seed identity; an existing single-user deployment upgrades automatically
+> (the default user is inferred from your token names). See
+> [`docs/MIGRATING.md`](docs/MIGRATING.md) for the upgrade path.
 
 ## Quick Start
 

--- a/cmd/memstore/admin_cmd.go
+++ b/cmd/memstore/admin_cmd.go
@@ -25,6 +25,12 @@ func runAdmin(args []string) {
 	switch args[0] {
 	case "tier3-init":
 		runTier3Init(args[1:], os.Stdout)
+	case "user-add":
+		runUserAdd(args[1:], os.Stdout)
+	case "list-users":
+		runListUsers(args[1:], os.Stdout)
+	case "disable-user":
+		runDisableUser(args[1:], os.Stdout)
 	case "issue-token":
 		runIssueToken(args[1:], os.Stdout)
 	case "list-tokens":
@@ -45,6 +51,9 @@ func printAdminUsage(w io.Writer) {
 
 Subcommands:
   tier3-init              Seed the identity schema for a namespace (creates default user, records meta).
+  user-add <name>         Create a user in the namespace (idempotent). Prints the user id.
+  list-users              List users in the namespace (name, id).
+  disable-user <name>     Revoke all of a user's tokens. With no active token the user cannot authenticate.
   issue-token <name>      Mint a new bearer token. Prints the token ONCE; not retrievable later.
   list-tokens             List all active tokens (name, scopes, created, last used). Token values are not stored.
   revoke-token <name>     Revoke all active tokens with the given name.
@@ -109,6 +118,115 @@ func runTier3Init(args []string, out io.Writer) {
 	fmt.Fprintf(out, "Identity initialized: namespace=%q default-user=%q\n", *namespace, *defaultUser)
 }
 
+// --- user-add ---
+
+func runUserAdd(args []string, out io.Writer) {
+	fs := flag.NewFlagSet("user-add", flag.ExitOnError)
+	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG / config)")
+	namespace := fs.String("namespace", "", "namespace to create the user in (default: empty string for single-tenant)")
+	fs.Parse(args)
+
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "user-add: expected exactly one positional argument <name>")
+		os.Exit(1)
+	}
+	name := fs.Arg(0)
+
+	pool, closePool, err := openPool(*pgDSN)
+	if err != nil {
+		fail(err)
+	}
+	defer closePool()
+
+	id, err := pgstore.EnsureUser(context.Background(), pool, *namespace, name)
+	if err != nil {
+		fail(err)
+	}
+	fmt.Fprintf(out, "User %q ready in namespace %q (id=%d).\n", name, *namespace, id)
+}
+
+// --- list-users ---
+
+func runListUsers(args []string, out io.Writer) {
+	fs := flag.NewFlagSet("list-users", flag.ExitOnError)
+	pgDSN := fs.String("pg", "", "PostgreSQL DSN")
+	namespace := fs.String("namespace", "", "namespace to list (default: empty string for single-tenant)")
+	fs.Parse(args)
+
+	pool, closePool, err := openPool(*pgDSN)
+	if err != nil {
+		fail(err)
+	}
+	defer closePool()
+
+	rows, err := pool.Query(context.Background(),
+		`SELECT name, id FROM memstore_users WHERE namespace = $1 ORDER BY name`,
+		*namespace)
+	if err != nil {
+		fail(err)
+	}
+	defer rows.Close()
+
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tID")
+	n := 0
+	for rows.Next() {
+		var name string
+		var id int64
+		if err := rows.Scan(&name, &id); err != nil {
+			fail(err)
+		}
+		fmt.Fprintf(tw, "%s\t%d\n", name, id)
+		n++
+	}
+	if err := rows.Err(); err != nil {
+		fail(err)
+	}
+	tw.Flush()
+	if n == 0 {
+		fmt.Fprintf(out, "No users in namespace %q.\n", *namespace)
+	}
+}
+
+// --- disable-user ---
+
+func runDisableUser(args []string, out io.Writer) {
+	fs := flag.NewFlagSet("disable-user", flag.ExitOnError)
+	pgDSN := fs.String("pg", "", "PostgreSQL DSN")
+	namespace := fs.String("namespace", "", "namespace to look up the user in (default: empty string for single-tenant)")
+	fs.Parse(args)
+
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "disable-user: expected exactly one positional argument <name>")
+		os.Exit(1)
+	}
+	name := fs.Arg(0)
+
+	pool, closePool, err := openPool(*pgDSN)
+	if err != nil {
+		fail(err)
+	}
+	defer closePool()
+
+	ctx := context.Background()
+	userID, err := pgstore.LookupUserID(ctx, pool, *namespace, name)
+	if err != nil {
+		fail(err)
+	}
+
+	ts, closeStore, err := openTokenStore(*pgDSN)
+	if err != nil {
+		fail(err)
+	}
+	defer closeStore()
+
+	n, err := ts.RevokeByUser(ctx, userID)
+	if err != nil {
+		fail(err)
+	}
+	fmt.Fprintf(out, "Disabled user %q: revoked %d token(s). The user can no longer authenticate.\n", name, n)
+}
+
 // --- issue-token ---
 
 func runIssueToken(args []string, out io.Writer) {
@@ -140,12 +258,9 @@ func runIssueToken(args []string, out io.Writer) {
 	ctx := context.Background()
 
 	// Resolve user_id from memstore_users.
-	var userID int64
-	if err := pool.QueryRow(ctx,
-		`SELECT id FROM memstore_users WHERE namespace = $1 AND name = $2`,
-		*namespace, *userName,
-	).Scan(&userID); err != nil {
-		fail(fmt.Errorf("user %q not found in namespace %q: %w\nRun 'memstore admin tier3-init --default-user %s' to create it", *userName, *namespace, err, *userName))
+	userID, err := pgstore.LookupUserID(ctx, pool, *namespace, *userName)
+	if err != nil {
+		fail(fmt.Errorf("%w\nRun 'memstore admin user-add %s' to create it", err, *userName))
 	}
 
 	ts, closeStore, err := openTokenStore(*pgDSN)

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -6,36 +6,66 @@ the current release.
 
 For the full changelog, see [`CHANGELOG.md`](../CHANGELOG.md).
 
-## Single-user notice (v0.3.0)
+## From v0.3.0 to v0.4.0
 
-**Memstore v0.3.0 is single-user by deployment, not by enforcement.**
+v0.4.0 closes the single-user gap that v0.3.0 shipped with. Isolation is now
+**enforced**, not just deployment-assumed: every read and write -- facts,
+links, sessions, hints, and feedback -- is filtered by the user the bearer
+token belongs to. Two tokens for two users never see each other's data. A
+shared deployment where multiple people hold their own tokens is now safe.
 
-The `Identity` plumbing exists end-to-end on the request path -- bearer-token
-authentication populates an `Identity` struct on the request context, and that
-context is threaded through the HTTP handlers. But no read or write path
-filters by user yet. Two clients holding two different tokens see the same
-facts. The schema has no `user_id` column on `memstore_facts` or `api_tokens`.
+### Breaking changes
 
-**What this means in practice:**
+**Identity is required.** Each fact, link, token, and session row now carries
+a `user_id`, and tokens are bound to a user. The daemon refuses to start
+against a Postgres database that has data but no recorded default user.
 
-- A homelab deployment with one person issuing themselves tokens is fine.
-  That's the supported configuration.
-- A shared deployment where multiple people hold their own tokens is **not**
-  safe. Anyone with a valid token sees everyone's facts.
-- Embedding memstore in a service that serves end users is **not** safe for
-  the same reason.
+- **Existing single-user deployments upgrade automatically.** On first start,
+  the migration infers the default user from your existing token names (the
+  pre-v0.4.0 `<user>-<host>` convention) and assigns every existing fact,
+  link, and session to that user. No manual step if your token names share a
+  single prefix.
+- **A fresh Postgres deployment, or one the migration cannot infer a user
+  for** (no tokens, or tokens with more than one distinct prefix), stops with
+  an instruction to run:
+  ```sh
+  memstore admin tier3-init --default-user <name>
+  ```
+  once before starting `memstored`.
 
-v0.4.0 will close this gap. See
-[`docs/tier3-permissions.md`](tier3-permissions.md) for the schema design and
-the Phase 0 scope.
+**Token names move to `<user>@<host>`.** The old `<user>-<host>` convention is
+retired (hyphens are ambiguous -- they appear in user names and hostnames).
+The migration rewrites existing token names automatically (`matthew-laptop`
+becomes `matthew@laptop`; the bootstrap `legacy` token becomes
+`<default-user>@legacy`). New tokens must match the `<user>@<host>` shape.
 
-Until v0.4.0 ships:
+### Managing users
 
-- Keep the daemon on a private network, behind a single trusted operator.
-- Issue tokens only to clients you control.
-- Treat token leakage as equivalent to full database access.
-- Don't store anything in memstore that you wouldn't show to every token
-  holder.
+```sh
+# Create a user
+memstore admin user-add alice
+
+# Mint a token for a user (the token proves who the caller is)
+memstore admin issue-token alice@laptop --user alice
+
+# List users / tokens
+memstore admin list-users
+memstore admin list-tokens
+
+# Disable a user -- revokes all their tokens. With no active token the user
+# cannot authenticate. This is how you lock an account out.
+memstore admin disable-user alice
+```
+
+All `admin` commands connect directly to Postgres and are meant to run on the
+daemon host (set `--pg` or `MEMSTORE_PG`).
+
+### What did not change
+
+Clients need no changes: the bearer token they already hold keeps working
+(its name is rewritten in place, its value is unchanged), and it now scopes
+the holder to their own data automatically. The MCP tools take no new
+parameters -- identity comes from the transport, never from tool input.
 
 ## From v0.2.0 to v0.3.0
 

--- a/docs/multi-user-data-model.md
+++ b/docs/multi-user-data-model.md
@@ -1,7 +1,11 @@
 # Multi-User Data Model — Users, Projects, and Tokens
 
-Status: Proposed. Concretizes tier 3 Phase 1 (permission predicates), which
-[`tier3-permissions.md`](tier3-permissions.md) deliberately left as a stub.
+Status: SUPERSEDED for v0.4.0. Not the current plan; retained as a record of
+the discussion. v0.4.0 shipped strict owner-only isolation (each user sees
+only their own data) with NO project principals, NO project tokens, and NO
+group/role schema. None of the schema this document proposes was built. If
+shared/project memory is ever wanted, it gets a fresh design and its own
+migration against the then-current code.
 Author: Matthew + Claude
 Date: 2026-05-26
 

--- a/docs/tier3-permissions.md
+++ b/docs/tier3-permissions.md
@@ -1,8 +1,26 @@
 # Tier 3 — Identity and Permissions
 
-Status: Phase 0 design ready (identity schema). Phase 1 deferred (permission predicates).
+Status: Phase 0 (identity schema) SHIPPED in v0.4.0. Phase 1 (group/role
+permission predicates) not built -- v0.4.0 is owner-only (see below).
 Author: Matthew + Claude
 Date: 2026-05-07 (supersedes 2026-05-05 placeholder)
+
+> **As-built note (v0.4.0).** Phase 0 shipped, with deliberate divergences
+> from this design:
+> - **Owner-only, no groups or roles.** v0.4.0 enforces strict per-user
+>   isolation: a fact is visible only to its owning user, full stop. The
+>   `group_id` / `role_id` columns this doc reserved were NOT added -- the
+>   sharing model may change before it is built, so no speculative schema
+>   was shipped. If sharing is ever designed, it pays for its own migration.
+> - **`subject` freed to empty string, not NULL.** The backfill rewrites an
+>   ownership-marking `subject` to `''` (the schema's existing "unset"
+>   convention) rather than NULL, avoiding a NOT NULL constraint drop.
+> - **Links carry `user_id` too.** Enforcement needed `memstore_links` owned,
+>   not just `memstore_facts`.
+>
+> [`docs/multi-user-data-model.md`](multi-user-data-model.md) (the Phase 1
+> project-principal design) is superseded for v0.4.0 and retained only as a
+> record of the discussion.
 
 Tier 3 introduces multi-user access control to memstore. It splits into two
 phases:

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -165,6 +165,28 @@ func EnsureUser(ctx context.Context, pool *pgxpool.Pool, namespace, name string)
 	return id, nil
 }
 
+// LookupUserID returns the id of an existing user in the namespace. Unlike
+// EnsureUser it never creates a row -- it returns a not-found error when the
+// user does not exist, so callers (e.g. disable-user) cannot accidentally
+// create the principal they meant to act on.
+func LookupUserID(ctx context.Context, pool *pgxpool.Pool, namespace, name string) (int64, error) {
+	if name == "" {
+		return 0, fmt.Errorf("pgstore: LookupUserID: name must not be empty")
+	}
+	var id int64
+	err := pool.QueryRow(ctx,
+		`SELECT id FROM memstore_users WHERE namespace = $1 AND name = $2`,
+		namespace, name,
+	).Scan(&id)
+	if err == pgx.ErrNoRows {
+		return 0, fmt.Errorf("pgstore: user %q not found in namespace %q", name, namespace)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("pgstore: LookupUserID %q: %w", name, err)
+	}
+	return id, nil
+}
+
 // InitIdentity seeds the identity schema with an operator-supplied default
 // user. This is the implementation behind
 // 'memstore admin tier3-init --default-user <name>'.

--- a/pgstore/tokens.go
+++ b/pgstore/tokens.go
@@ -341,6 +341,21 @@ func (s *TokenStore) Revoke(ctx context.Context, name string) (int, error) {
 	return int(tag.RowsAffected()), nil
 }
 
+// RevokeByUser revokes every active token owned by userID and returns the
+// number revoked. This is the mechanism behind 'memstore admin disable-user':
+// a user with no active token cannot authenticate to the daemon.
+func (s *TokenStore) RevokeByUser(ctx context.Context, userID int64) (int, error) {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE api_tokens
+		   SET revoked_at = now()
+		 WHERE user_id = $1 AND revoked_at IS NULL
+	`, userID)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 // Rotate issues a new token with the same name, scopes, and owner as the
 // existing active token, then revokes the old one(s). Returns the new
 // plaintext token. If multiple active tokens share the name, all are revoked

--- a/pgstore/tokens_test.go
+++ b/pgstore/tokens_test.go
@@ -271,3 +271,77 @@ func TestTokenStore_List(t *testing.T) {
 		t.Errorf("after revoke: %v", infos)
 	}
 }
+
+func TestTokenStore_RevokeByUser(t *testing.T) {
+	ts, uid := newTokenStore(t)
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, testDSN(t))
+	if err != nil {
+		t.Fatalf("connecting to postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	// A second user, to prove RevokeByUser is scoped by user_id.
+	otherUID, err := pgstore.EnsureUser(ctx, pool, "", "other")
+	if err != nil {
+		t.Fatalf("EnsureUser: %v", err)
+	}
+
+	// Two active tokens for the default user, one for the other user.
+	if _, err := ts.Issue(ctx, "testuser@a", pgstore.IssueOpts{UserID: uid}); err != nil {
+		t.Fatalf("issue testuser@a: %v", err)
+	}
+	if _, err := ts.Issue(ctx, "testuser@b", pgstore.IssueOpts{UserID: uid}); err != nil {
+		t.Fatalf("issue testuser@b: %v", err)
+	}
+	otherTok, err := ts.Issue(ctx, "other@c", pgstore.IssueOpts{UserID: otherUID})
+	if err != nil {
+		t.Fatalf("issue other@c: %v", err)
+	}
+
+	n, err := ts.RevokeByUser(ctx, uid)
+	if err != nil {
+		t.Fatalf("RevokeByUser: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("RevokeByUser revoked %d, want 2", n)
+	}
+
+	// The other user's token is untouched.
+	if _, err := ts.Verify(ctx, otherTok); err != nil {
+		t.Errorf("other user's token should still verify after RevokeByUser: %v", err)
+	}
+
+	// A second call revokes nothing (already revoked).
+	n, err = ts.RevokeByUser(ctx, uid)
+	if err != nil {
+		t.Fatalf("RevokeByUser (second call): %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second RevokeByUser revoked %d, want 0", n)
+	}
+}
+
+func TestLookupUserID(t *testing.T) {
+	_, uid := newTokenStore(t) // seeds memstore_users with the default "testuser"
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, testDSN(t))
+	if err != nil {
+		t.Fatalf("connecting to postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	got, err := pgstore.LookupUserID(ctx, pool, "", "testuser")
+	if err != nil {
+		t.Fatalf("LookupUserID(existing): %v", err)
+	}
+	if got != uid {
+		t.Errorf("LookupUserID = %d, want %d", got, uid)
+	}
+
+	if _, err := pgstore.LookupUserID(ctx, pool, "", "nonexistent"); err == nil {
+		t.Error("LookupUserID(missing): expected a not-found error, got nil")
+	}
+}


### PR DESCRIPTION
The final v0.4.0 phase (spec: plans/009; depends on #86-#89, all merged). Phases 1-3 made the daemon fully user-isolated; this adds the operator surface to manage users and flips the docs from "v0.4.0 promised" to "v0.4.0 shipped." No isolation logic -- the boundary is done and proven (#87/#88/#89).

CLI (cmd/memstore admin):
- `user-add <name>` -- create a user in the namespace (idempotent, via EnsureUser).
- `list-users` -- list the namespace's users.
- `disable-user <name>` -- revoke all of a user's tokens; with no active token the user cannot authenticate. This is account-disable (spec 009: misbehavior is handled by disabling the account, not rate limits).
- pgstore gains `TokenStore.RevokeByUser(userID)` (the disable mechanism, scoped by user_id) and `LookupUserID` (resolve-only -- unlike EnsureUser it won't create the row). issue-token's inline user lookup now uses LookupUserID.

Docs:
- README: the v0.3.0 single-user warning is replaced with a statement that per-user isolation is enforced end to end, plus the tier3-init/inference upgrade path.
- MIGRATING: new v0.3.0 -> v0.4.0 section (identity required; default-user inference vs `tier3-init`; token names now `<user>@<host>`; the admin user commands; clients need no changes).
- tier3-permissions.md / multi-user-data-model.md: as-built status headers -- Phase 0 identity shipped, owner-only model, NO group/role schema (the reserved columns were not built; if sharing is ever wanted it gets its own migration).

Tests: `TestTokenStore_RevokeByUser` (two tokens for user A revoked, user B's untouched -- proves user_id scoping) and `TestLookupUserID` (found / not-found), pg-gated. Verified against a fresh pgvector container: new tests pass, full suite green under default parallelism (twice). Lint 0 issues, docs are plain ASCII.

Note: executed directly by the advisor rather than a dispatched executor -- the executor-subagent mechanism lost Bash access mid-session; the maintainer approved direct execution for this final low-risk plan. Reviewed and verified to the same bar.

Plan: plans/013-admin-cli-and-v040-docs.md. After this merges, v0.4.0 multi-user isolation is complete end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)