### PR TITLE
Delegate static-analysis CI to infodancer/workflows go-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,102 +1,18 @@
 name: CI
 
+# Thin caller: the static-analysis quartet (vet/fmt/lint/govulncheck) lives in
+# infodancer/workflows so the definition and action pins stay identical across
+# repos. The race+coverage test job needs a Postgres service container, which a
+# reusable workflow can't accept, so run_tests is false here and the test job
+# lives in test.yml. See the workflows repo README.
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
-
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: pgvector/pgvector:pg17
-        env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Run tests with coverage
-        env:
-          MEMSTORE_TEST_PG: postgres://test:test@localhost:5432/test?sslmode=disable
-        run: go test -race -count=1 -coverprofile=coverage.out ./...
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
-        with:
-          files: coverage.out
-
-  vet:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Vet
-        run: go vet ./...
-
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Check formatting
-        run: |
-          unformatted=$(gofmt -l .)
-          if [ -n "$unformatted" ]; then
-            echo "Files not formatted:"
-            echo "$unformatted"
-            exit 1
-          fi
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.10.1
-
-  govulncheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
-
-      - name: Run govulncheck
-        run: govulncheck ./...
+  ci:
+    uses: infodancer/workflows/.github/workflows/go-ci.yml@v0.2.2
+    with:
+      run_tests: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Test
+
+# The one job with real per-repo variance: it needs a pgvector service
+# container, the MEMSTORE_TEST_PG env, and a coverage upload, none of which a
+# reusable workflow can express. The static-analysis quartet is delegated to
+# infodancer/workflows in ci.yml.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests with coverage
+        env:
+          MEMSTORE_TEST_PG: postgres://test:test@localhost:5432/test?sslmode=disable
+        run: go test -race -count=1 -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: coverage.out


### PR DESCRIPTION
Replaces the per-repo vet/fmt/lint/govulncheck jobs with a thin caller to the shared reusable workflow (`infodancer/workflows/.github/workflows/go-ci.yml@v0.2.2`), so job definitions and SHA-pinned action versions stay identical across repos. The race+coverage test job needs a pgvector service container, which a reusable workflow can't accept, so it sets `run_tests: false` and keeps its own job in the new `test.yml`.

**Branch-protection note:** this renames the four static checks from `vet`/`fmt`/`lint`/`govulncheck` to `ci / vet` etc.; the `test` check name is unchanged. The required-status-check contexts on `main` are updated to match in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)