### PR TITLE
fix(pgstore): make session migration idempotent on widened unique constraints

### DIFF
--- a/pgstore/session_store.go
+++ b/pgstore/session_store.go
@@ -281,7 +281,12 @@ func (s *SessionStore) migrate(ctx context.Context) error {
 
 		// Widen unique constraints to include user_id. Drop the old narrow
 		// constraints first (idempotent: exception on missing), then add the
-		// wide ones (idempotent: exception on duplicate_object).
+		// wide ones. The add must catch BOTH duplicate_object (42710) and
+		// duplicate_table (42P07): adding a UNIQUE constraint creates a backing
+		// index of the same name, so a re-run raises 42P07 ("relation already
+		// exists"), not 42710 -- see the matching guard at uq_context_feedback_ref_session
+		// above. Catching only duplicate_object made every restart abort here,
+		// disabling the session store and extract queue.
 		//
 		//    session_turns: was UNIQUE(session_id, uuid)
 		`DO $$ BEGIN
@@ -291,7 +296,7 @@ func (s *SessionStore) migrate(ctx context.Context) error {
 		`DO $$ BEGIN
 			ALTER TABLE session_turns ADD CONSTRAINT uq_session_turns_user_session_uuid
 				UNIQUE (user_id, session_id, uuid);
-		EXCEPTION WHEN duplicate_object THEN NULL;
+		EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 		END $$`,
 
 		//    context_injections: was UNIQUE(session_id, ref_id, ref_type)
@@ -302,7 +307,7 @@ func (s *SessionStore) migrate(ctx context.Context) error {
 		`DO $$ BEGIN
 			ALTER TABLE context_injections ADD CONSTRAINT uq_context_injections_user_session_ref
 				UNIQUE (user_id, session_id, ref_id, ref_type);
-		EXCEPTION WHEN duplicate_object THEN NULL;
+		EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 		END $$`,
 
 		//    context_feedback: was UNIQUE(ref_id, ref_type, session_id) via named constraint
@@ -317,7 +322,7 @@ func (s *SessionStore) migrate(ctx context.Context) error {
 		`DO $$ BEGIN
 			ALTER TABLE context_feedback ADD CONSTRAINT uq_context_feedback_user_ref_session
 				UNIQUE (user_id, ref_id, ref_type, session_id);
-		EXCEPTION WHEN duplicate_object THEN NULL;
+		EXCEPTION WHEN duplicate_object OR duplicate_table THEN NULL;
 		END $$`,
 	}
 	for _, stmt := range constraintStmts {

--- a/pgstore/session_store_test.go
+++ b/pgstore/session_store_test.go
@@ -208,6 +208,54 @@ func TestSessionMigrate_UserIDColumns(t *testing.T) {
 	}
 }
 
+// TestSessionMigrate_Idempotent verifies that running the session-store
+// migration a second time (i.e. every daemon restart after the first) is a
+// clean no-op. Regression for a production bug where the widened-unique
+// ADD CONSTRAINT blocks caught only duplicate_object (42710); adding a UNIQUE
+// constraint creates a backing index, so a re-run raised duplicate_table
+// (42P07), which aborted Migrate and disabled the session store + extract
+// queue on every restart. The test also reproduces the prod state where the
+// old narrow constraint uq_context_feedback_ref_session was left behind, and
+// confirms the re-run cleans it up.
+func TestSessionMigrate_Idempotent(t *testing.T) {
+	_, pool := newTestSessionStore(t)
+	ctx := context.Background()
+
+	// Simulate the production database: the old narrow constraint survived a
+	// prior half-completed migration and coexists with the wide one.
+	if _, err := pool.Exec(ctx, `
+		ALTER TABLE context_feedback
+		ADD CONSTRAINT uq_context_feedback_ref_session
+		UNIQUE (ref_id, ref_type, session_id)`); err != nil {
+		t.Fatalf("seeding leftover narrow constraint: %v", err)
+	}
+
+	// A second (and third) migrate must succeed -- this is what a daemon
+	// restart does. Before the fix, the first re-run errored with 42P07.
+	for i := range 2 {
+		if _, err := pgstore.NewSessionStore(ctx, pool); err != nil {
+			t.Fatalf("re-run %d of NewSessionStore failed (migration not idempotent): %v", i+1, err)
+		}
+	}
+
+	// The leftover narrow constraint must be gone, leaving only the wide one.
+	var narrow, wide int
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			count(*) FILTER (WHERE conname = 'uq_context_feedback_ref_session'),
+			count(*) FILTER (WHERE conname = 'uq_context_feedback_user_ref_session')
+		FROM pg_constraint
+		WHERE conrelid = 'context_feedback'::regclass AND contype = 'u'`).Scan(&narrow, &wide); err != nil {
+		t.Fatalf("inspecting context_feedback constraints: %v", err)
+	}
+	if narrow != 0 {
+		t.Errorf("old narrow constraint uq_context_feedback_ref_session still present after re-migrate")
+	}
+	if wide != 1 {
+		t.Errorf("wide constraint uq_context_feedback_user_ref_session count = %d, want 1", wide)
+	}
+}
+
 // TestSessionStore_DefaultScope exercises basic write+read through the
 // default-scoped SessionStore (the single-user daemon path).
 func TestSessionStore_DefaultScope(t *testing.T) {


### PR DESCRIPTION
## What

The phase-3a session-store migration is not idempotent. The three widened-unique `ADD CONSTRAINT` blocks (`uq_session_turns_user_session_uuid`, `uq_context_injections_user_session_ref`, `uq_context_feedback_user_ref_session`) catch only `duplicate_object` (SQLSTATE 42710). Adding a `UNIQUE` constraint creates a backing index of the same name, so a re-run raises `duplicate_table` (42P07) instead — which the handler doesn't catch.

## Impact (observed in production)

The docker-memstore daemon has been failing this migration on **every restart since the constraints were first created** (~5 days). The error log:

```
session store init failed: session store migrate: ERROR: relation
"uq_session_turns_user_session_uuid" already exists (SQLSTATE 42P07)
```

`NewSessionStore` returning an error makes `cmd/memstored` log it and continue **without a session store**, which in turn **disables the extract queue** (`extract queue disabled: requires PostgreSQL session store`). So transcript auto-extraction silently stopped running. A side effect was a leftover old narrow constraint (`uq_context_feedback_ref_session`) that the aborted migration never reached the drop for.

## Fix

Catch `duplicate_object OR duplicate_table` in all three blocks, matching the already-correct guard on `uq_context_feedback_ref_session` (lines 206-209) — the same bug had been found and fixed there but not propagated to the later sites. Once `Migrate` completes again, it also drops the leftover narrow constraint.

## Test

Adds a pg-gated `TestSessionMigrate_Idempotent` that seeds the exact production state (leftover narrow constraint coexisting with the wide one), then asserts repeated `NewSessionStore` calls succeed and converge to a single wide constraint. Verified it fails with 42P07 before the fix and passes after. Full suite green against an ephemeral pgvector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)