### PR TITLE
Fix metadata output-schema mismatch breaking recall; stop leaking API keys

### DIFF
--- a/cmd/memstore-mcp/main.go
+++ b/cmd/memstore-mcp/main.go
@@ -48,16 +48,26 @@ import (
 func main() {
 	cfg := memstore.LoadConfig()
 	remote := flag.String("remote", cfg.Remote, "memstored URL for daemon mode (empty = local SQLite)")
-	apiKey := flag.String("api-key", cfg.APIKey, "API key for memstored auth")
+	// Secrets are not flag defaults: flag prints defaults in --help output, which
+	// would echo the configured key to the terminal. Resolved from cfg after Parse.
+	apiKey := flag.String("api-key", "", "API key for memstored auth (default: from config file or MEMSTORE_API_KEY)")
 	dbPath := flag.String("db", cfg.DB, "path to SQLite database (local mode only)")
 	namespace := flag.String("namespace", cfg.Namespace, "namespace for fact isolation (local mode only)")
 	ollamaURL := flag.String("ollama", cfg.Ollama, "LLM API base URL for chat generation (local mode only)")
-	llmAPIKey := flag.String("llm-api-key", cfg.LLMAPIKey, "API key for the chat LLM provider (empty = no auth)")
+	llmAPIKey := flag.String("llm-api-key", "", "API key for the chat LLM provider (default: from config file or MEMSTORE_LLM_API_KEY; empty = no auth)")
 	genModel := flag.String("gen-model", cfg.GenModel, "LLM model for generation")
 	noEmbeddings := flag.Bool("no-embeddings", false, "run without an embedding endpoint; search degrades to FTS5-only (local mode)")
 	hookMode := flag.Bool("hook", false, "read Stop hook JSON from stdin, POST to memstored, exit")
 	transcriptPath := flag.String("transcript", "", "read JSONL transcript from path, POST to memstored, exit")
 	flag.Parse()
+
+	// Fall back to the configured secrets when the flags are unset.
+	if *apiKey == "" {
+		*apiKey = cfg.APIKey
+	}
+	if *llmAPIKey == "" {
+		*llmAPIKey = cfg.LLMAPIKey
+	}
 
 	tlsOpts := httpclient.ClientOptionsFromConfig(cfg)
 

--- a/cmd/memstored/main.go
+++ b/cmd/memstored/main.go
@@ -56,8 +56,10 @@ func run(ctx context.Context, args []string, stderr io.Writer, onListening func(
 	vecDim := fs.Int("vec-dim", cfg.VecDim, "embedding vector dimension (e.g. 768)")
 	namespace := fs.String("namespace", cfg.Namespace, "namespace")
 	ollamaURL := fs.String("ollama", cfg.Ollama, "LLM API base URL for chat generation (defaults --gen-url)")
-	apiKey := fs.String("api-key", cfg.APIKey, "API key for authentication (empty = disabled)")
-	llmAPIKey := fs.String("llm-api-key", cfg.LLMAPIKey, "API key for the chat LLM provider (empty = no auth)")
+	// Secrets are not flag defaults: flag prints defaults in --help output, which
+	// would echo the configured key to the terminal. Resolved from cfg after Parse.
+	apiKey := fs.String("api-key", "", "API key for authentication (default: from config file or MEMSTORE_API_KEY; empty = disabled)")
+	llmAPIKey := fs.String("llm-api-key", "", "API key for the chat LLM provider (default: from config file or MEMSTORE_LLM_API_KEY; empty = no auth)")
 	genModel := fs.String("gen-model", cfg.GenModel, "LLM model for generation (enables /v1/generate)")
 	genURL := fs.String("gen-url", cfg.GenURL, "separate LLM URL for generation (defaults to --ollama)")
 	embedInterval := fs.Duration("embed-interval", 2*time.Second, "embed queue poll interval")
@@ -73,6 +75,14 @@ func run(ctx context.Context, args []string, stderr io.Writer, onListening func(
 	}
 	if fs.NArg() > 0 {
 		return fmt.Errorf("unexpected argument(s): %v (memstored takes flags only, no subcommands)", fs.Args())
+	}
+
+	// Fall back to the configured secrets when the flags are unset.
+	if *apiKey == "" {
+		*apiKey = cfg.APIKey
+	}
+	if *llmAPIKey == "" {
+		*llmAPIKey = cfg.LLMAPIKey
 	}
 
 	if *pgDSN == "" {

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package memstore
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -38,6 +39,29 @@ type AppConfig struct {
 	TLSCAFile         string // PEM bundle to trust for the server cert (in addition to system roots)
 	TLSClientCertFile string // PEM cert presented to memstored when mTLS is required
 	TLSClientKeyFile  string // matching private key
+}
+
+// redactedAppConfig has AppConfig's fields but not its String method, so String
+// can format it without recursing.
+type redactedAppConfig AppConfig
+
+// String implements fmt.Stringer so that printing a config -- in a log line, a
+// test failure, a debug dump -- cannot leak its secrets. fmt routes %v and %+v
+// through String, so this covers the accidental prints, which are the ones that
+// matter: nobody deliberately writes an API key to a terminal.
+func (c AppConfig) String() string {
+	c.APIKey = redactSecret(c.APIKey)
+	c.LLMAPIKey = redactSecret(c.LLMAPIKey)
+	return fmt.Sprintf("%+v", redactedAppConfig(c))
+}
+
+// redactSecret masks a secret while preserving whether one was set at all, which
+// is usually the thing being debugged.
+func redactSecret(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "[redacted]"
 }
 
 // DefaultConfig returns the built-in defaults used when no config file exists.

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package memstore
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -22,8 +23,22 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+// clearMemstoreEnv unsets every MEMSTORE_* variable for the duration of a test.
+// LoadConfig lets the environment override both file and defaults, so a developer
+// who exports MEMSTORE_REMOTE or MEMSTORE_API_KEY in their shell would otherwise
+// see these tests fail against their own environment rather than the fixture.
+func clearMemstoreEnv(t *testing.T) {
+	t.Helper()
+	for _, kv := range os.Environ() {
+		if k, _, ok := strings.Cut(kv, "="); ok && strings.HasPrefix(k, "MEMSTORE_") {
+			t.Setenv(k, "")
+		}
+	}
+}
+
 func TestLoadConfig_MissingFile(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	clearMemstoreEnv(t)
 	cfg := LoadConfig()
 	want := DefaultConfig()
 	if cfg != want {
@@ -34,6 +49,7 @@ func TestLoadConfig_MissingFile(t *testing.T) {
 func TestLoadConfig_ParsesFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	clearMemstoreEnv(t)
 
 	configDir := filepath.Join(dir, "memstore")
 	if err := os.MkdirAll(configDir, 0700); err != nil {
@@ -69,6 +85,7 @@ gen_model = "llama3"
 func TestLoadConfig_PartialOverride(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	clearMemstoreEnv(t)
 
 	configDir := filepath.Join(dir, "memstore")
 	if err := os.MkdirAll(configDir, 0700); err != nil {
@@ -98,6 +115,7 @@ func TestLoadConfig_PartialOverride(t *testing.T) {
 func TestLoadConfig_QuotedValues(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	clearMemstoreEnv(t)
 
 	configDir := filepath.Join(dir, "memstore")
 	if err := os.MkdirAll(configDir, 0700); err != nil {
@@ -128,6 +146,7 @@ gen_model = unquoted
 func TestLoadConfig_TildeExpansion(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	clearMemstoreEnv(t)
 
 	configDir := filepath.Join(dir, "memstore")
 	if err := os.MkdirAll(configDir, 0700); err != nil {
@@ -152,6 +171,7 @@ func TestLoadConfig_TildeExpansion(t *testing.T) {
 func TestLoadConfig_CommentsAndBlanks(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	clearMemstoreEnv(t)
 
 	configDir := filepath.Join(dir, "memstore")
 	if err := os.MkdirAll(configDir, 0700); err != nil {
@@ -227,6 +247,7 @@ func TestParseConfigLine(t *testing.T) {
 func TestLoadConfig_EnvOverridesFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	clearMemstoreEnv(t)
 
 	configDir := filepath.Join(dir, "memstore")
 	if err := os.MkdirAll(configDir, 0700); err != nil {
@@ -266,6 +287,7 @@ gen_model = "from-file-gen-model"
 
 func TestLoadConfig_EnvOverridesDefaults(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no config file
+	clearMemstoreEnv(t)
 	t.Setenv("MEMSTORE_DB", "/data/memory.db")
 	t.Setenv("MEMSTORE_OLLAMA", "http://gpu:11434")
 	t.Setenv("MEMSTORE_GEN_MODEL", "qwen2.5:7b")
@@ -286,6 +308,7 @@ func TestLoadConfig_EnvOverridesDefaults(t *testing.T) {
 func TestLoadConfig_TLS(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	clearMemstoreEnv(t)
 
 	configDir := filepath.Join(dir, "memstore")
 	if err := os.MkdirAll(configDir, 0700); err != nil {

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -159,6 +159,26 @@ func (ms *MemoryServer) resolveRerank(modeStr string, threshold *float64) (memst
 	return mode, thr
 }
 
+// Metadata is domain-specific key-value data attached to a fact, link, or task,
+// and the single type both tool inputs and tool results declare it as.
+//
+// It is deliberately open. Callers attach whatever their domain needs -- provenance
+// (cwd, session_id, source), task state (status, scope, project), or anything else --
+// and the store round-trips it verbatim. The schema this infers must therefore permit
+// unknown keys, which rules out a struct: jsonschema-go gives structs
+// additionalProperties:false, so a fact carrying any key the struct didn't declare
+// would fail output validation. It also rules out a []byte-backed type such as
+// json.RawMessage, which infers an array schema for what marshals as an object.
+type Metadata map[string]any
+
+// String returns the value at key when it is a string. JSON decoding gives no
+// guarantee about a value's type, so callers reading a known key get the check for
+// free rather than re-asserting at each use.
+func (m Metadata) String(key string) (string, bool) {
+	s, ok := m[key].(string)
+	return s, ok
+}
+
 // --- Output types for structured tool results ---
 
 // SearchResult is the structured output for memory_search.
@@ -169,18 +189,18 @@ type SearchResult struct {
 
 // FactResult represents a single search result with typed fields.
 type FactResult struct {
-	ID             int64           `json:"id"`
-	Subject        string          `json:"subject"`
-	Category       string          `json:"category"`
-	Kind           string          `json:"kind,omitempty"`
-	Subsystem      string          `json:"subsystem,omitempty"`
-	Content        string          `json:"content"`
-	Score          float64         `json:"score"`
-	RerankScore    float64         `json:"rerank_score,omitempty"`
-	UseCount       int             `json:"use_count"`
-	ConfirmedCount int             `json:"confirmed_count"`
-	SupersededBy   *int64          `json:"superseded_by,omitempty"`
-	Metadata       json.RawMessage `json:"metadata,omitempty"`
+	ID             int64    `json:"id"`
+	Subject        string   `json:"subject"`
+	Category       string   `json:"category"`
+	Kind           string   `json:"kind,omitempty"`
+	Subsystem      string   `json:"subsystem,omitempty"`
+	Content        string   `json:"content"`
+	Score          float64  `json:"score"`
+	RerankScore    float64  `json:"rerank_score,omitempty"`
+	UseCount       int      `json:"use_count"`
+	ConfirmedCount int      `json:"confirmed_count"`
+	SupersededBy   *int64   `json:"superseded_by,omitempty"`
+	Metadata       Metadata `json:"metadata,omitempty"`
 }
 
 // ListResult is the structured output for memory_list.
@@ -236,16 +256,16 @@ type GetLinksResult struct {
 
 // LinkEntry represents a single link with neighbor info.
 type LinkEntry struct {
-	ID              int64           `json:"link_id"`
-	SourceID        int64           `json:"source_id"`
-	TargetID        int64           `json:"target_id"`
-	LinkType        string          `json:"link_type"`
-	Bidirectional   bool            `json:"bidirectional,omitempty"`
-	Label           string          `json:"label,omitempty"`
-	Metadata        json.RawMessage `json:"metadata,omitempty"`
-	NeighborID      int64           `json:"neighbor_id"`
-	NeighborSubject string          `json:"neighbor_subject"`
-	NeighborContent string          `json:"neighbor_content"`
+	ID              int64    `json:"link_id"`
+	SourceID        int64    `json:"source_id"`
+	TargetID        int64    `json:"target_id"`
+	LinkType        string   `json:"link_type"`
+	Bidirectional   bool     `json:"bidirectional,omitempty"`
+	Label           string   `json:"label,omitempty"`
+	Metadata        Metadata `json:"metadata,omitempty"`
+	NeighborID      int64    `json:"neighbor_id"`
+	NeighborSubject string   `json:"neighbor_subject"`
+	NeighborContent string   `json:"neighbor_content"`
 }
 
 // StoreResult is the structured output for memory_store.
@@ -293,17 +313,17 @@ type HistoryResult struct {
 
 // HistoryEntry represents a single history entry.
 type HistoryEntry struct {
-	ID             int64           `json:"id"`
-	Position       int             `json:"position"`
-	ChainLength    int             `json:"chain_length"`
-	Subject        string          `json:"subject"`
-	Category       string          `json:"category"`
-	Status         string          `json:"status"`
-	CreatedAt      string          `json:"created_at"`
-	Content        string          `json:"content"`
-	Metadata       json.RawMessage `json:"metadata,omitempty"`
-	UseCount       int             `json:"use_count"`
-	ConfirmedCount int             `json:"confirmed_count"`
+	ID             int64    `json:"id"`
+	Position       int      `json:"position"`
+	ChainLength    int      `json:"chain_length"`
+	Subject        string   `json:"subject"`
+	Category       string   `json:"category"`
+	Status         string   `json:"status"`
+	CreatedAt      string   `json:"created_at"`
+	Content        string   `json:"content"`
+	Metadata       Metadata `json:"metadata,omitempty"`
+	UseCount       int      `json:"use_count"`
+	ConfirmedCount int      `json:"confirmed_count"`
 }
 
 // ConfirmResult is the structured output for memory_confirm.
@@ -402,13 +422,13 @@ type RerankSettingsResult struct {
 
 // StoreInput is the input schema for the memory_store tool.
 type StoreInput struct {
-	Content    string         `json:"content" jsonschema:"the factual claim or memory to store"`
-	Subject    string         `json:"subject" jsonschema:"the entity this fact is about (e.g. a person or project)"`
-	Category   string         `json:"category,omitempty" jsonschema:"fact category: preference, identity, project, capability, relationship, world, or note (default: note)"`
-	Kind       string         `json:"kind,omitempty" jsonschema:"structural type: convention | failure_mode | invariant | pattern | decision | trigger (empty = unclassified)"`
-	Subsystem  string         `json:"subsystem,omitempty" jsonschema:"optional project subsystem this fact belongs to (e.g. feeds, auth, storage)"`
-	Metadata   map[string]any `json:"metadata,omitempty" jsonschema:"optional key-value metadata to attach"`
-	Supersedes *int64         `json:"supersedes,omitempty" jsonschema:"ID of an existing fact that this new fact replaces (preserves history unlike delete)"`
+	Content    string   `json:"content" jsonschema:"the factual claim or memory to store"`
+	Subject    string   `json:"subject" jsonschema:"the entity this fact is about (e.g. a person or project)"`
+	Category   string   `json:"category,omitempty" jsonschema:"fact category: preference, identity, project, capability, relationship, world, or note (default: note)"`
+	Kind       string   `json:"kind,omitempty" jsonschema:"structural type: convention | failure_mode | invariant | pattern | decision | trigger (empty = unclassified)"`
+	Subsystem  string   `json:"subsystem,omitempty" jsonschema:"optional project subsystem this fact belongs to (e.g. feeds, auth, storage)"`
+	Metadata   Metadata `json:"metadata,omitempty" jsonschema:"optional key-value metadata to attach"`
+	Supersedes *int64   `json:"supersedes,omitempty" jsonschema:"ID of an existing fact that this new fact replaces (preserves history unlike delete)"`
 }
 
 // StoreBatchInput is the input schema for the memory_store_batch tool.
@@ -418,26 +438,26 @@ type StoreBatchInput struct {
 
 // SearchInput is the input schema for the memory_search tool.
 type SearchInput struct {
-	Query             string         `json:"query" jsonschema:"natural language search query"`
-	Subject           string         `json:"subject,omitempty" jsonschema:"filter results to a specific subject entity"`
-	Category          string         `json:"category,omitempty" jsonschema:"filter results to a specific category"`
-	Kind              string         `json:"kind,omitempty" jsonschema:"filter by kind: convention, failure_mode, invariant, pattern, decision, trigger (empty = all)"`
-	Subsystem         string         `json:"subsystem,omitempty" jsonschema:"filter by subsystem (e.g. feeds, auth)"`
-	Limit             int            `json:"limit,omitempty" jsonschema:"maximum number of results (default 10)"`
-	IncludeSuperseded bool           `json:"include_superseded,omitempty" jsonschema:"if true, include superseded facts in results (tagged with [SUPERSEDED])"`
-	Metadata          map[string]any `json:"metadata,omitempty" jsonschema:"filter by metadata fields (equality match, e.g. {\"source\": \"conversation\"})"`
-	RerankMode        string         `json:"rerank_mode,omitempty" jsonschema:"override the server's rerank mode for this call: off|balanced|dominant|gate (empty = server default)"`
-	Threshold         *float64       `json:"threshold,omitempty" jsonschema:"override the relevance threshold [0,1] for this call; facts scoring below it are dropped (omit = server default)"`
+	Query             string   `json:"query" jsonschema:"natural language search query"`
+	Subject           string   `json:"subject,omitempty" jsonschema:"filter results to a specific subject entity"`
+	Category          string   `json:"category,omitempty" jsonschema:"filter results to a specific category"`
+	Kind              string   `json:"kind,omitempty" jsonschema:"filter by kind: convention, failure_mode, invariant, pattern, decision, trigger (empty = all)"`
+	Subsystem         string   `json:"subsystem,omitempty" jsonschema:"filter by subsystem (e.g. feeds, auth)"`
+	Limit             int      `json:"limit,omitempty" jsonschema:"maximum number of results (default 10)"`
+	IncludeSuperseded bool     `json:"include_superseded,omitempty" jsonschema:"if true, include superseded facts in results (tagged with [SUPERSEDED])"`
+	Metadata          Metadata `json:"metadata,omitempty" jsonschema:"filter by metadata fields (equality match, e.g. {\"source\": \"conversation\"})"`
+	RerankMode        string   `json:"rerank_mode,omitempty" jsonschema:"override the server's rerank mode for this call: off|balanced|dominant|gate (empty = server default)"`
+	Threshold         *float64 `json:"threshold,omitempty" jsonschema:"override the relevance threshold [0,1] for this call; facts scoring below it are dropped (omit = server default)"`
 }
 
 // ListInput is the input schema for the memory_list tool.
 type ListInput struct {
-	Subject   string         `json:"subject,omitempty" jsonschema:"filter by subject entity"`
-	Category  string         `json:"category,omitempty" jsonschema:"filter by category"`
-	Kind      string         `json:"kind,omitempty" jsonschema:"filter by kind: convention, failure_mode, invariant, pattern, decision, trigger (empty = all)"`
-	Subsystem string         `json:"subsystem,omitempty" jsonschema:"filter by subsystem (e.g. feeds, auth)"`
-	Limit     int            `json:"limit,omitempty" jsonschema:"maximum number of results (default 20)"`
-	Metadata  map[string]any `json:"metadata,omitempty" jsonschema:"filter by metadata fields (equality match, e.g. {\"source\": \"conversation\"})"`
+	Subject   string   `json:"subject,omitempty" jsonschema:"filter by subject entity"`
+	Category  string   `json:"category,omitempty" jsonschema:"filter by category"`
+	Kind      string   `json:"kind,omitempty" jsonschema:"filter by kind: convention, failure_mode, invariant, pattern, decision, trigger (empty = all)"`
+	Subsystem string   `json:"subsystem,omitempty" jsonschema:"filter by subsystem (e.g. feeds, auth)"`
+	Limit     int      `json:"limit,omitempty" jsonschema:"maximum number of results (default 20)"`
+	Metadata  Metadata `json:"metadata,omitempty" jsonschema:"filter by metadata fields (equality match, e.g. {\"source\": \"conversation\"})"`
 }
 
 // ListSubsystemsInput is the input schema for the memory_list_subsystems tool.
@@ -497,8 +517,8 @@ type ConfirmInput struct {
 
 // UpdateInput is the input schema for the memory_update tool.
 type UpdateInput struct {
-	ID       int64          `json:"id" jsonschema:"the fact ID to update"`
-	Metadata map[string]any `json:"metadata" jsonschema:"metadata keys to set (non-nil) or delete (nil)"`
+	ID       int64    `json:"id" jsonschema:"the fact ID to update"`
+	Metadata Metadata `json:"metadata" jsonschema:"metadata keys to set (non-nil) or delete (nil)"`
 }
 
 // TaskCreateInput is the input schema for the memory_task_create tool.
@@ -529,12 +549,12 @@ type StatusInput struct{}
 
 // LinkInput is the input schema for the memory_link tool.
 type LinkInput struct {
-	SourceID      int64          `json:"source_id" jsonschema:"ID of the source fact"`
-	TargetID      int64          `json:"target_id" jsonschema:"ID of the target fact"`
-	LinkType      string         `json:"link_type,omitempty" jsonschema:"edge type discriminator: passage, event, entrance, reference, etc. (default: reference)"`
-	Bidirectional bool           `json:"bidirectional,omitempty" jsonschema:"if true, edge is traversable in both directions"`
-	Label         string         `json:"label,omitempty" jsonschema:"human-readable description of this connection"`
-	Metadata      map[string]any `json:"metadata,omitempty" jsonschema:"domain-specific properties for this edge"`
+	SourceID      int64    `json:"source_id" jsonschema:"ID of the source fact"`
+	TargetID      int64    `json:"target_id" jsonschema:"ID of the target fact"`
+	LinkType      string   `json:"link_type,omitempty" jsonschema:"edge type discriminator: passage, event, entrance, reference, etc. (default: reference)"`
+	Bidirectional bool     `json:"bidirectional,omitempty" jsonschema:"if true, edge is traversable in both directions"`
+	Label         string   `json:"label,omitempty" jsonschema:"human-readable description of this connection"`
+	Metadata      Metadata `json:"metadata,omitempty" jsonschema:"domain-specific properties for this edge"`
 }
 
 // UnlinkInput is the input schema for the memory_unlink tool.
@@ -551,9 +571,9 @@ type GetLinksInput struct {
 
 // UpdateLinkInput is the input schema for the memory_update_link tool.
 type UpdateLinkInput struct {
-	LinkID   int64          `json:"link_id" jsonschema:"ID of the link to update"`
-	Label    string         `json:"label,omitempty" jsonschema:"new label (empty leaves existing label unchanged)"`
-	Metadata map[string]any `json:"metadata,omitempty" jsonschema:"metadata keys to set (non-nil) or delete (nil)"`
+	LinkID   int64    `json:"link_id" jsonschema:"ID of the link to update"`
+	Label    string   `json:"label,omitempty" jsonschema:"new label (empty leaves existing label unchanged)"`
+	Metadata Metadata `json:"metadata,omitempty" jsonschema:"metadata keys to set (non-nil) or delete (nil)"`
 }
 
 // SuggestAgentInput is the input schema for the memory_suggest_agent tool.
@@ -1120,7 +1140,7 @@ func (ms *MemoryServer) HandleSearch(ctx context.Context, _ *mcp.CallToolRequest
 			UseCount:       r.Fact.UseCount + 1,
 			ConfirmedCount: r.Fact.ConfirmedCount,
 			SupersededBy:   r.Fact.SupersededBy,
-			Metadata:       r.Fact.Metadata,
+			Metadata:       decodeMetadata(r.Fact.Metadata),
 		})
 	}
 
@@ -1311,7 +1331,7 @@ func (ms *MemoryServer) HandleList(ctx context.Context, _ *mcp.CallToolRequest, 
 			Score:          0,
 			UseCount:       f.UseCount,
 			ConfirmedCount: f.ConfirmedCount,
-			Metadata:       f.Metadata,
+			Metadata:       decodeMetadata(f.Metadata),
 		})
 	}
 	fmt.Fprintf(&b, "%d memories listed.", len(facts))
@@ -1473,7 +1493,7 @@ func (ms *MemoryServer) HandleHistory(ctx context.Context, _ *mcp.CallToolReques
 			Status:         status,
 			CreatedAt:      e.Fact.CreatedAt.Format("2006-01-02 15:04"),
 			Content:        e.Fact.Content,
-			Metadata:       e.Fact.Metadata,
+			Metadata:       decodeMetadata(e.Fact.Metadata),
 			UseCount:       e.Fact.UseCount,
 			ConfirmedCount: e.Fact.ConfirmedCount,
 		})
@@ -1625,11 +1645,8 @@ func (ms *MemoryServer) HandleTaskUpdate(ctx context.Context, _ *mcp.CallToolReq
 		return textResult(fmt.Sprintf("Error: fact %d not found", input.ID), true), TaskUpdateResult{}, nil
 	}
 
-	var meta map[string]any
-	if len(fact.Metadata) > 0 {
-		json.Unmarshal(fact.Metadata, &meta)
-	}
-	if meta == nil || meta["kind"] != "task" {
+	meta := decodeMetadata(fact.Metadata)
+	if kind, _ := meta.String("kind"); kind != "task" {
 		return textResult(fmt.Sprintf("Error: fact %d is not a task", input.ID), true), TaskUpdateResult{}, nil
 	}
 
@@ -1687,15 +1704,11 @@ func (ms *MemoryServer) HandleTaskList(ctx context.Context, _ *mcp.CallToolReque
 		row := FormatTaskRow(f)
 		b.WriteString(row)
 
-		var meta map[string]any
-		if len(f.Metadata) > 0 {
-			_ = json.Unmarshal(f.Metadata, &meta)
-		}
-
-		statusVal, _ := meta["status"].(string)
-		scopeVal, _ := meta["scope"].(string)
-		priorityVal, _ := meta["priority"].(string)
-		dueVal, _ := meta["due"].(string)
+		meta := decodeMetadata(f.Metadata)
+		statusVal, _ := meta.String("status")
+		scopeVal, _ := meta.String("scope")
+		priorityVal, _ := meta.String("priority")
+		dueVal, _ := meta.String("due")
 
 		taskResults = append(taskResults, TaskResult{
 			ID:       f.ID,
@@ -1716,15 +1729,11 @@ func (ms *MemoryServer) HandleTaskList(ctx context.Context, _ *mcp.CallToolReque
 // Every visible field is read from the fact's stored metadata — never from request
 // parameters — so the row faithfully reflects what is in the store.
 func FormatTaskRow(f memstore.Fact) string {
-	var meta map[string]any
-	if len(f.Metadata) > 0 {
-		_ = json.Unmarshal(f.Metadata, &meta)
-	}
-
-	status, _ := meta["status"].(string)
-	scope, _ := meta["scope"].(string)
-	priority, _ := meta["priority"].(string)
-	due, _ := meta["due"].(string)
+	meta := decodeMetadata(f.Metadata)
+	status, _ := meta.String("status")
+	scope, _ := meta.String("scope")
+	priority, _ := meta.String("priority")
+	due, _ := meta.String("due")
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "[id=%d] [%s] %s (scope=%s, priority=%s",
@@ -1756,9 +1765,9 @@ func (ms *MemoryServer) HandleListSubsystems(ctx context.Context, _ *mcp.CallToo
 	return textResult(b.String(), false), out, nil
 }
 
-// metadataFilters converts a map[string]any (from MCP input) to memstore.MetadataFilter
+// metadataFilters converts Metadata (from MCP input) to memstore.MetadataFilter
 // equality conditions.
-func metadataFilters(m map[string]any) []memstore.MetadataFilter {
+func metadataFilters(m Metadata) []memstore.MetadataFilter {
 	if len(m) == 0 {
 		return nil
 	}
@@ -1767,6 +1776,21 @@ func metadataFilters(m map[string]any) []memstore.MetadataFilter {
 		filters = append(filters, memstore.MetadataFilter{Key: k, Op: "=", Value: v})
 	}
 	return filters
+}
+
+// decodeMetadata converts the store's raw metadata JSON into the Metadata the
+// structured output schema declares. Unparseable or absent metadata decodes to nil
+// rather than failing the call: metadata is decoration on a recalled fact, not the
+// fact itself.
+func decodeMetadata(raw json.RawMessage) Metadata {
+	if len(raw) == 0 {
+		return nil
+	}
+	var m Metadata
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	return m
 }
 
 // --- Link handlers ---
@@ -1875,7 +1899,7 @@ func (ms *MemoryServer) HandleGetLinks(ctx context.Context, _ *mcp.CallToolReque
 				LinkType:        l.LinkType,
 				Bidirectional:   l.Bidirectional,
 				Label:           l.Label,
-				Metadata:        l.Metadata,
+				Metadata:        decodeMetadata(l.Metadata),
 				NeighborID:      f.ID,
 				NeighborSubject: f.Subject,
 				NeighborContent: preview,
@@ -1888,7 +1912,7 @@ func (ms *MemoryServer) HandleGetLinks(ctx context.Context, _ *mcp.CallToolReque
 				LinkType:      l.LinkType,
 				Bidirectional: l.Bidirectional,
 				Label:         l.Label,
-				Metadata:      l.Metadata,
+				Metadata:      decodeMetadata(l.Metadata),
 				NeighborID:    neighborID,
 			})
 		}
@@ -2035,7 +2059,7 @@ func (ms *MemoryServer) HandleGetContext(ctx context.Context, _ *mcp.CallToolReq
 			Score:          0,
 			UseCount:       f.UseCount,
 			ConfirmedCount: f.ConfirmedCount,
-			Metadata:       f.Metadata,
+			Metadata:       decodeMetadata(f.Metadata),
 		})
 	}
 
@@ -2052,7 +2076,7 @@ func (ms *MemoryServer) HandleGetContext(ctx context.Context, _ *mcp.CallToolReq
 			Score:          0,
 			UseCount:       f.UseCount,
 			ConfirmedCount: f.ConfirmedCount,
-			Metadata:       f.Metadata,
+			Metadata:       decodeMetadata(f.Metadata),
 		})
 	}
 
@@ -2069,7 +2093,7 @@ func (ms *MemoryServer) HandleGetContext(ctx context.Context, _ *mcp.CallToolReq
 			Score:          0,
 			UseCount:       f.UseCount,
 			ConfirmedCount: f.ConfirmedCount,
-			Metadata:       f.Metadata,
+			Metadata:       decodeMetadata(f.Metadata),
 		})
 	}
 
@@ -2133,7 +2157,7 @@ func (ms *MemoryServer) HandleGetContext(ctx context.Context, _ *mcp.CallToolReq
 				Score:          r.Combined,
 				UseCount:       r.Fact.UseCount,
 				ConfirmedCount: r.Fact.ConfirmedCount,
-				Metadata:       r.Fact.Metadata,
+				Metadata:       decodeMetadata(r.Fact.Metadata),
 			})
 		}
 	}
@@ -2169,14 +2193,7 @@ func writeContextFact(b *strings.Builder, f memstore.Fact) {
 
 // contextFactQuality returns the quality tag if the fact is a local-model draft, or "" otherwise.
 func contextFactQuality(f memstore.Fact) string {
-	if len(f.Metadata) == 0 {
-		return ""
-	}
-	var meta map[string]any
-	if err := json.Unmarshal(f.Metadata, &meta); err != nil {
-		return ""
-	}
-	if q, _ := meta["quality"].(string); strings.HasPrefix(q, "local") {
+	if q, _ := decodeMetadata(f.Metadata).String("quality"); strings.HasPrefix(q, "local") {
 		return q
 	}
 	return ""
@@ -2239,7 +2256,7 @@ func (ms *MemoryServer) HandleCurateContext(ctx context.Context, _ *mcp.CallTool
 			Score:          0,
 			UseCount:       f.UseCount,
 			ConfirmedCount: f.ConfirmedCount,
-			Metadata:       f.Metadata,
+			Metadata:       decodeMetadata(f.Metadata),
 		})
 	}
 
@@ -2311,11 +2328,8 @@ func (ms *MemoryServer) HandleSuggestAgent(ctx context.Context, _ *mcp.CallToolR
 	// Score each agent by domain keyword overlap + content keyword match.
 	var scores []agentScore
 	for _, f := range routingFacts {
-		var meta map[string]any
-		if len(f.Metadata) > 0 {
-			json.Unmarshal(f.Metadata, &meta)
-		}
-		agentName, _ := meta["agent_name"].(string)
+		meta := decodeMetadata(f.Metadata)
+		agentName, _ := meta.String("agent_name")
 		if agentName == "" {
 			continue
 		}

--- a/mcpserver/structured_output_test.go
+++ b/mcpserver/structured_output_test.go
@@ -168,6 +168,50 @@ func TestStructuredOutput_StoreEmitsAck(t *testing.T) {
 	}
 }
 
+// TestStructuredOutput_MetadataSurvivesOutputValidation guards the fact->result
+// metadata mapping. Stored metadata is a JSON object, so the result field must be
+// typed as one: a []byte-backed type (json.RawMessage) infers an array schema, and
+// the SDK then rejects every recalled fact that carries metadata -- which is most
+// of a real store. Seeding metadata here is the whole point; a fact without it
+// passes validation either way.
+func TestStructuredOutput_MetadataSurvivesOutputValidation(t *testing.T) {
+	cs := connectSession(t)
+
+	callTool(t, cs, "memory_store", map[string]any{
+		"content":  "Matthew runs Postgres as the primary memstore backend",
+		"subject":  "metadata-canary",
+		"metadata": map[string]any{"source": "conversation", "cwd": "/home/matthew"},
+	})
+
+	// Both recall paths return FactResult; each validates against the tool's
+	// OutputSchema server-side, so a schema/type mismatch surfaces as a CallTool error.
+	for _, tc := range []struct {
+		tool string
+		args map[string]any
+	}{
+		{"memory_list", map[string]any{"subject": "metadata-canary"}},
+		{"memory_search", map[string]any{"query": "Postgres backend", "subject": "metadata-canary"}},
+	} {
+		res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: tc.tool, Arguments: tc.args})
+		if err != nil {
+			t.Fatalf("CallTool(%s) with metadata-carrying fact: %v", tc.tool, err)
+		}
+
+		var facts []mcpserver.FactResult
+		if tc.tool == "memory_list" {
+			facts = resultStructured[mcpserver.ListResult](t, res).Facts
+		} else {
+			facts = resultStructured[mcpserver.SearchResult](t, res).Results
+		}
+		if len(facts) != 1 {
+			t.Fatalf("%s: expected 1 fact, got %d", tc.tool, len(facts))
+		}
+		if got := facts[0].Metadata["source"]; got != "conversation" {
+			t.Errorf("%s: metadata[source] = %v, want \"conversation\"", tc.tool, got)
+		}
+	}
+}
+
 // TestStructuredOutput_StatusEmitsCounts covers the config/status group.
 func TestStructuredOutput_StatusEmitsCounts(t *testing.T) {
 	cs := connectSession(t)


### PR DESCRIPTION
## Why

A smoke test of the MCP server found that **any recall of a fact carrying metadata fails**. Three live calls blew up identically:

```
memory_search  → validating /properties/results/items/properties/metadata:
                 type: map[cwd:… session_id:… source:post_compact] has type "object", want one of "null, array"
memory_list    → same, on map[depends_on:links_feature phase:planned project:vtt]
memory_get_context → same, on map[source_files:[search.go]]
```

`FactResult`, `LinkEntry` and `HistoryEntry` declared `Metadata` as `json.RawMessage`. That's a `[]byte`, so schema inference typed it as `["null","array"]` — but the value marshals as a JSON object. The SDK validates results against the schema it advertises, so it rejected its own valid data. Blast radius is most of the read surface (`memory_search`, `memory_list`, `memory_get_context`, `memory_history`, `memory_get_links`), and since most stored facts carry metadata, recall was effectively broken in practice.

## What changed

**1. Metadata typing (`mcpserver/server.go`)**

A named `Metadata map[string]any` now backs both tool inputs and tool results. It stays an *open* map deliberately, and the doc comment says why: jsonschema-go gives structs `additionalProperties:false`, so a struct enumerating today's keys would reject tomorrow's — the same bug, narrowed to unknown keys. `Metadata.String` replaces the hand-rolled "unmarshal into a bare map, then type-assert" pattern at the five sites reading known keys (task guard, task list, task row formatting, quality tag, agent routing).

**2. Secret handling (`config.go`, `cmd/`)**

Found while fixing the test that surfaced above — a configured key could reach a terminal three ways:

- `AppConfig` printed with `%+v` rendered `APIKey`/`LLMAPIKey` in cleartext → `String()` now redacts both, and `fmt` routes `%v`/`%+v` through it.
- `memstore-mcp` and `memstored` passed the loaded key as the **flag default** for `-api-key`, and `flag` prints defaults in help output — so `memstore-mcp --help` echoed the key. Now empty-defaulted and resolved from config after `Parse`.
- The config tests never cleared `MEMSTORE_*` before `LoadConfig`, so a developer with `MEMSTORE_API_KEY` exported saw `TestLoadConfig_MissingFile` fail against their own shell — and the failure message printed the key.

## Testing

`TestStructuredOutput_MetadataSurvivesOutputValidation` stores a fact *with* metadata and reads it back through the in-memory SDK session via both `memory_list` and `memory_search`. The existing structured-output tests all seeded facts without metadata, which is exactly why they stayed green while recall was broken — seeding metadata is the point of the new test.

`GOWORK=off go test ./... -count=1` passes, including `TestLoadConfig_MissingFile` with `MEMSTORE_API_KEY` still exported in the shell. `memstore-mcp --help` no longer contains the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)