### PR TITLE
admin CLI: fix flag parsing, namespace defaults, and the token-issuance docs

### DIFF
--- a/cmd/memstore/admin_cmd.go
+++ b/cmd/memstore/admin_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/matthewjhunter/memstore"
 	"github.com/matthewjhunter/memstore/pgstore"
 )
 
@@ -59,7 +61,71 @@ Subcommands:
   revoke-token <name>     Revoke all active tokens with the given name.
   rotate-token <name>     Issue a new token preserving name + scopes; revoke the old one.
 
-All admin commands connect directly to PostgreSQL. Set --pg or MEMSTORE_PG.`)
+Flags may appear before or after the positional argument.
+
+All admin commands connect directly to PostgreSQL, so they must run on the
+daemon host (or anywhere with a route to it). Set --pg or MEMSTORE_PG.
+
+Commands act on the namespace from --namespace, defaulting to the one the
+daemon uses (config file / MEMSTORE_NAMESPACE, built-in default "default").`)
+}
+
+// parseAdminArgs parses an admin subcommand's flags and returns its positional
+// arguments, accepting flags before, after, or interleaved with them.
+//
+// A bare fs.Parse cannot: Go's flag package stops at the first non-flag
+// argument, so `issue-token matthew@kraken --user matthew` silently drops
+// --user and the command then complains about the positional argument -- the
+// one thing the operator got right. Anything after a bare "--" stays
+// positional.
+func parseAdminArgs(fs *flag.FlagSet, args []string) ([]string, error) {
+	var tail []string
+	for i, a := range args {
+		if a == "--" {
+			tail = args[i+1:]
+			args = args[:i]
+			break
+		}
+	}
+
+	var positional []string
+	for {
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		rest := fs.Args()
+		if len(rest) == 0 {
+			break
+		}
+		// rest[0] is a non-flag argument: set it aside and keep parsing what
+		// follows, which flag would otherwise have abandoned.
+		positional = append(positional, rest[0])
+		args = rest[1:]
+	}
+	return append(positional, tail...), nil
+}
+
+// defaultAdminNamespace is the namespace admin commands target when the
+// operator does not pass --namespace: the same one the daemon uses. It is
+// never the empty string -- admin defaulting to "" while the daemon wrote its
+// rows under "default" made list-users report an empty database on a live
+// deployment.
+func defaultAdminNamespace() string {
+	if cliConfig.Namespace != "" {
+		return cliConfig.Namespace
+	}
+	return memstore.DefaultConfig().Namespace
+}
+
+const namespaceFlagUsage = "namespace to act on (defaults to the daemon's namespace: config file / MEMSTORE_NAMESPACE)"
+
+// exactlyOneArg enforces a single positional argument, naming what was expected.
+func exactlyOneArg(cmd string, positional []string, what string) string {
+	if len(positional) != 1 {
+		fmt.Fprintf(os.Stderr, "%s: expected exactly one positional argument %s, got %d\n", cmd, what, len(positional))
+		os.Exit(1)
+	}
+	return positional[0]
 }
 
 func openPool(pgFlag string) (*pgxpool.Pool, func(), error) {
@@ -98,8 +164,10 @@ func runTier3Init(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("tier3-init", flag.ExitOnError)
 	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG / config)")
 	defaultUser := fs.String("default-user", "", "Name to seed as the default user (required)")
-	namespace := fs.String("namespace", "", "Namespace to initialize (default: empty string for single-tenant)")
-	fs.Parse(args)
+	namespace := fs.String("namespace", defaultAdminNamespace(), namespaceFlagUsage)
+	if _, err := parseAdminArgs(fs, args); err != nil {
+		fail(err)
+	}
 
 	if *defaultUser == "" {
 		fmt.Fprintln(os.Stderr, "tier3-init: --default-user is required")
@@ -123,14 +191,12 @@ func runTier3Init(args []string, out io.Writer) {
 func runUserAdd(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("user-add", flag.ExitOnError)
 	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG / config)")
-	namespace := fs.String("namespace", "", "namespace to create the user in (default: empty string for single-tenant)")
-	fs.Parse(args)
-
-	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "user-add: expected exactly one positional argument <name>")
-		os.Exit(1)
+	namespace := fs.String("namespace", defaultAdminNamespace(), namespaceFlagUsage)
+	positional, err := parseAdminArgs(fs, args)
+	if err != nil {
+		fail(err)
 	}
-	name := fs.Arg(0)
+	name := exactlyOneArg("user-add", positional, "<name>")
 
 	pool, closePool, err := openPool(*pgDSN)
 	if err != nil {
@@ -150,8 +216,10 @@ func runUserAdd(args []string, out io.Writer) {
 func runListUsers(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("list-users", flag.ExitOnError)
 	pgDSN := fs.String("pg", "", "PostgreSQL DSN")
-	namespace := fs.String("namespace", "", "namespace to list (default: empty string for single-tenant)")
-	fs.Parse(args)
+	namespace := fs.String("namespace", defaultAdminNamespace(), namespaceFlagUsage)
+	if _, err := parseAdminArgs(fs, args); err != nil {
+		fail(err)
+	}
 
 	pool, closePool, err := openPool(*pgDSN)
 	if err != nil {
@@ -185,7 +253,38 @@ func runListUsers(args []string, out io.Writer) {
 	tw.Flush()
 	if n == 0 {
 		fmt.Fprintf(out, "No users in namespace %q.\n", *namespace)
+		// An empty namespace usually means the wrong --namespace, not an empty
+		// database. Say where the users actually are.
+		if elsewhere := populatedNamespaces(context.Background(), pool, *namespace); len(elsewhere) > 0 {
+			fmt.Fprintf(out, "Users exist in namespace(s) %s -- pass --namespace to list them.\n",
+				strings.Join(elsewhere, ", "))
+		}
 	}
+}
+
+// populatedNamespaces returns every namespace other than exclude that holds at
+// least one user, quoted for display (a namespace can be the empty string).
+func populatedNamespaces(ctx context.Context, pool *pgxpool.Pool, exclude string) []string {
+	rows, err := pool.Query(ctx,
+		`SELECT DISTINCT namespace FROM memstore_users WHERE namespace <> $1 ORDER BY namespace`,
+		exclude)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var ns string
+		if err := rows.Scan(&ns); err != nil {
+			return nil
+		}
+		out = append(out, fmt.Sprintf("%q", ns))
+	}
+	if rows.Err() != nil {
+		return nil
+	}
+	return out
 }
 
 // --- disable-user ---
@@ -193,14 +292,12 @@ func runListUsers(args []string, out io.Writer) {
 func runDisableUser(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("disable-user", flag.ExitOnError)
 	pgDSN := fs.String("pg", "", "PostgreSQL DSN")
-	namespace := fs.String("namespace", "", "namespace to look up the user in (default: empty string for single-tenant)")
-	fs.Parse(args)
-
-	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "disable-user: expected exactly one positional argument <name>")
-		os.Exit(1)
+	namespace := fs.String("namespace", defaultAdminNamespace(), namespaceFlagUsage)
+	positional, err := parseAdminArgs(fs, args)
+	if err != nil {
+		fail(err)
 	}
-	name := fs.Arg(0)
+	name := exactlyOneArg("disable-user", positional, "<name>")
 
 	pool, closePool, err := openPool(*pgDSN)
 	if err != nil {
@@ -235,14 +332,12 @@ func runIssueToken(args []string, out io.Writer) {
 	scopes := fs.String("scopes", "", "comma-separated scopes (e.g. read,write,admin)")
 	expires := fs.Duration("expires", 0, "token lifetime, e.g. 90d, 720h. 0 = no expiry")
 	userName := fs.String("user", "", "user name to bind the token to (required; must exist in memstore_users)")
-	namespace := fs.String("namespace", "", "namespace to look up the user in (default: empty string for single-tenant)")
-	fs.Parse(args)
-
-	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "issue-token: expected exactly one positional argument <name> (format: <user>@<host>)")
-		os.Exit(1)
+	namespace := fs.String("namespace", defaultAdminNamespace(), namespaceFlagUsage)
+	positional, err := parseAdminArgs(fs, args)
+	if err != nil {
+		fail(err)
 	}
-	name := fs.Arg(0)
+	name := exactlyOneArg("issue-token", positional, "<name> (format: <user>@<host>)")
 
 	if *userName == "" {
 		fmt.Fprintln(os.Stderr, "issue-token: --user is required")
@@ -257,10 +352,16 @@ func runIssueToken(args []string, out io.Writer) {
 
 	ctx := context.Background()
 
-	// Resolve user_id from memstore_users.
+	// Resolve user_id from memstore_users. Only suggest creating the user when
+	// it exists nowhere: if it merely lives in another namespace, user-add
+	// would mint a duplicate instead of fixing the mismatch, so let
+	// LookupUserID's own message (which names that namespace) stand.
 	userID, err := pgstore.LookupUserID(ctx, pool, *namespace, *userName)
-	if err != nil {
+	if errors.Is(err, pgstore.ErrUserNotFound) {
 		fail(fmt.Errorf("%w\nRun 'memstore admin user-add %s' to create it", err, *userName))
+	}
+	if err != nil {
+		fail(err)
 	}
 
 	ts, closeStore, err := openTokenStore(*pgDSN)
@@ -280,7 +381,7 @@ func runIssueToken(args []string, out io.Writer) {
 
 	fmt.Fprintln(out, "Token issued. Capture it now -- it cannot be retrieved later.")
 	fmt.Fprintf(out, "  name:  %s\n", name)
-	fmt.Fprintf(out, "  user:  %s\n", *userName)
+	fmt.Fprintf(out, "  user:  %s (namespace %q)\n", *userName, *namespace)
 	if *scopes != "" {
 		fmt.Fprintf(out, "  scopes: %s\n", *scopes)
 	}
@@ -298,7 +399,9 @@ func runIssueToken(args []string, out io.Writer) {
 func runListTokens(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("list-tokens", flag.ExitOnError)
 	pgDSN := fs.String("pg", "", "PostgreSQL DSN")
-	fs.Parse(args)
+	if _, err := parseAdminArgs(fs, args); err != nil {
+		fail(err)
+	}
 
 	ts, closeStore, err := openTokenStore(*pgDSN)
 	if err != nil {
@@ -334,13 +437,11 @@ func runListTokens(args []string, out io.Writer) {
 func runRevokeToken(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("revoke-token", flag.ExitOnError)
 	pgDSN := fs.String("pg", "", "PostgreSQL DSN")
-	fs.Parse(args)
-
-	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "revoke-token: expected exactly one positional argument <name>")
-		os.Exit(1)
+	positional, err := parseAdminArgs(fs, args)
+	if err != nil {
+		fail(err)
 	}
-	name := fs.Arg(0)
+	name := exactlyOneArg("revoke-token", positional, "<name>")
 
 	ts, closeStore, err := openTokenStore(*pgDSN)
 	if err != nil {
@@ -364,13 +465,11 @@ func runRevokeToken(args []string, out io.Writer) {
 func runRotateToken(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("rotate-token", flag.ExitOnError)
 	pgDSN := fs.String("pg", "", "PostgreSQL DSN")
-	fs.Parse(args)
-
-	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "rotate-token: expected exactly one positional argument <name>")
-		os.Exit(1)
+	positional, err := parseAdminArgs(fs, args)
+	if err != nil {
+		fail(err)
 	}
-	name := fs.Arg(0)
+	name := exactlyOneArg("rotate-token", positional, "<name>")
 
 	ts, closeStore, err := openTokenStore(*pgDSN)
 	if err != nil {

--- a/cmd/memstore/admin_cmd_test.go
+++ b/cmd/memstore/admin_cmd_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"flag"
+	"slices"
+	"testing"
+
+	"github.com/matthewjhunter/memstore"
+)
+
+// newTestFlagSet builds a flag set shaped like issue-token's: a couple of
+// value flags and one boolean, so the permutation logic is exercised against
+// both kinds.
+func newTestFlagSet() (*flag.FlagSet, *string, *string, *bool) {
+	fs := flag.NewFlagSet("issue-token", flag.ContinueOnError)
+	user := fs.String("user", "", "user")
+	scopes := fs.String("scopes", "", "scopes")
+	force := fs.Bool("force", false, "force")
+	return fs, user, scopes, force
+}
+
+func TestParseAdminArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantPos    []string
+		wantUser   string
+		wantScopes string
+		wantForce  bool
+	}{
+		{
+			name:       "flags before positional",
+			args:       []string{"--user", "matthew", "--scopes", "admin", "matthew@kraken"},
+			wantPos:    []string{"matthew@kraken"},
+			wantUser:   "matthew",
+			wantScopes: "admin",
+		},
+		{
+			name:       "flags after positional",
+			args:       []string{"matthew@kraken", "--user", "matthew", "--scopes", "admin"},
+			wantPos:    []string{"matthew@kraken"},
+			wantUser:   "matthew",
+			wantScopes: "admin",
+		},
+		{
+			name:       "flags interleaved with positional",
+			args:       []string{"--user", "matthew", "matthew@kraken", "--scopes", "admin"},
+			wantPos:    []string{"matthew@kraken"},
+			wantUser:   "matthew",
+			wantScopes: "admin",
+		},
+		{
+			name:      "boolean flag after positional",
+			args:      []string{"matthew@kraken", "--force"},
+			wantPos:   []string{"matthew@kraken"},
+			wantForce: true,
+		},
+		{
+			name:     "equals form after positional",
+			args:     []string{"matthew@kraken", "--user=matthew"},
+			wantPos:  []string{"matthew@kraken"},
+			wantUser: "matthew",
+		},
+		{
+			name:    "no flags",
+			args:    []string{"matthew@kraken"},
+			wantPos: []string{"matthew@kraken"},
+		},
+		{
+			name:    "no args",
+			args:    nil,
+			wantPos: nil,
+		},
+		{
+			name:     "terminator makes the rest positional",
+			args:     []string{"--user", "matthew", "--", "--not-a-flag"},
+			wantPos:  []string{"--not-a-flag"},
+			wantUser: "matthew",
+		},
+		{
+			name:     "positional order is preserved",
+			args:     []string{"one", "--user", "matthew", "two", "--", "three"},
+			wantPos:  []string{"one", "two", "three"},
+			wantUser: "matthew",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs, user, scopes, force := newTestFlagSet()
+			pos, err := parseAdminArgs(fs, tt.args)
+			if err != nil {
+				t.Fatalf("parseAdminArgs(%q): %v", tt.args, err)
+			}
+			if !slices.Equal(pos, tt.wantPos) {
+				t.Errorf("positional = %q, want %q", pos, tt.wantPos)
+			}
+			if *user != tt.wantUser {
+				t.Errorf("--user = %q, want %q", *user, tt.wantUser)
+			}
+			if *scopes != tt.wantScopes {
+				t.Errorf("--scopes = %q, want %q", *scopes, tt.wantScopes)
+			}
+			if *force != tt.wantForce {
+				t.Errorf("--force = %v, want %v", *force, tt.wantForce)
+			}
+		})
+	}
+}
+
+func TestParseAdminArgs_unknownFlag(t *testing.T) {
+	fs, _, _, _ := newTestFlagSet()
+	fs.SetOutput(discard{})
+	if _, err := parseAdminArgs(fs, []string{"matthew@kraken", "--nope"}); err == nil {
+		t.Fatal("expected an error for an unknown flag, got nil")
+	}
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestDefaultAdminNamespace(t *testing.T) {
+	saved := cliConfig
+	t.Cleanup(func() { cliConfig = saved })
+
+	// The daemon's own default (memstore.DefaultConfig) is what admin commands
+	// must target when the operator has not configured a namespace -- an empty
+	// default is what made list-users report "No users in namespace """ on a
+	// live deployment whose rows live in "default".
+	cliConfig = memstore.AppConfig{}
+	if got, want := defaultAdminNamespace(), memstore.DefaultConfig().Namespace; got != want {
+		t.Errorf("defaultAdminNamespace() with unset config = %q, want %q", got, want)
+	}
+	if got := defaultAdminNamespace(); got == "" {
+		t.Error("defaultAdminNamespace() must never return the empty namespace")
+	}
+
+	cliConfig = memstore.AppConfig{Namespace: "tenant-a"}
+	if got, want := defaultAdminNamespace(), "tenant-a"; got != want {
+		t.Errorf("defaultAdminNamespace() with configured namespace = %q, want %q", got, want)
+	}
+}

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -172,9 +172,10 @@ If you were running `memstored` against SQLite:
    a `MEMSTORE_PG` like
    `postgres://user:pass@host:5432/memstore?sslmode=disable` (or with
    `sslmode=require` for non-local hosts).
-2. Issue an API token:
+2. Issue an API token (bound to a user; run on the daemon host, where
+   `MEMSTORE_PG` resolves):
    ```sh
-   memstore admin issue --name <client-name>
+   memstore admin issue-token --user <user> --scopes admin <user>@<host>
    # Prints the plaintext token once. Save it.
    ```
 3. (Recommended) Generate a TLS cert and run the daemon over HTTPS:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -228,7 +228,7 @@ Per-prompt recall fires on every user message in Claude Code. To avoid re-embedd
 
 ### Authentication
 
-Every endpoint except `/v1/health` requires a bearer token. Tokens are issued via `memstore admin issue --name <client>`; the plaintext is shown once. The daemon stores SHA-256 hashes (high-entropy input by construction -- 32 random bytes -- so a slow hash isn't necessary). Verification uses `crypto/subtle.ConstantTimeCompare` against a timing oracle.
+Every endpoint except `/v1/health` requires a bearer token. Tokens are issued via `memstore admin issue-token --user <user> <user>@<host>`; the plaintext is shown once. The daemon stores SHA-256 hashes (high-entropy input by construction -- 32 random bytes -- so a slow hash isn't necessary). Verification uses `crypto/subtle.ConstantTimeCompare` against a timing oracle.
 
 The `api_tokens` table (`pgstore/tokens.go`):
 
@@ -413,7 +413,7 @@ Deleting a fact destroys the information that it was ever believed. Supersession
 
 ### Bearer tokens + TLS, not OAuth
 
-The deployment shape is a single-operator homelab. OAuth would be over-engineered for the scale. Bearer tokens issued by the operator via `memstore admin issue` are simple, auditable (the `api_tokens` table records issuance, last-used, revocation), and adequate against the threat model. TLS covers the wire; constant-time hash comparison covers the verification timing.
+The deployment shape is a single-operator homelab. OAuth would be over-engineered for the scale. Bearer tokens issued by the operator via `memstore admin issue-token` are simple, auditable (the `api_tokens` table records issuance, last-used, revocation), and adequate against the threat model. TLS covers the wire; constant-time hash comparison covers the verification timing.
 
 When the deployment shape changes -- multi-tenant, external users, regulatory attestation -- the auth model will need to grow. v0.3.0 is single-operator; v0.4.0 adds per-user enforcement; further milestones may need a real federated identity story. See [`tier3-permissions.md`](tier3-permissions.md).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -119,9 +119,20 @@ Every endpoint except `/v1/health` requires `Authorization: Bearer <token>`.
 Tokens are issued via the CLI; the daemon stores SHA-256 hashes and verifies
 with constant-time comparison.
 
+Tokens are bound to a user, so the user has to exist first. Admin commands talk
+to PostgreSQL directly rather than through the API, so they run on the daemon
+host with `--pg` (or `MEMSTORE_PG`) pointing at the database:
+
 ```bash
-# Issue a token (plaintext shown once -- save it)
-memstore admin issue --name claude-desktop
+export MEMSTORE_PG=postgres://memstore:<password>@localhost:5432/memstore
+
+# One-time: seed the identity schema and create the user
+memstore admin tier3-init --default-user matthew
+memstore admin user-add matthew
+
+# Issue a token per client machine, so it can be revoked individually.
+# Convention for the token name is <user>@<host>; plaintext is shown once.
+memstore admin issue-token --user matthew --scopes admin matthew@laptop
 
 # Configure the client
 export MEMSTORE_REMOTE=https://memstored.lan:8230
@@ -130,6 +141,15 @@ export MEMSTORE_API_KEY=<token>
 # memstore setup will pick those up automatically
 memstore setup
 ```
+
+Every admin command acts on a namespace, defaulting to the daemon's own
+(`namespace` in the config file, or `MEMSTORE_NAMESPACE`; built-in default
+`default`). Pass `--namespace` only when administering some other tenant --
+targeting the wrong namespace is how you end up with two users of the same
+name. Token names are global, not per-namespace.
+
+Other subcommands: `list-users`, `disable-user <name>` (revokes all of a user's
+tokens), `list-tokens`, `revoke-token <name>`, `rotate-token <name>`.
 
 `memstore setup` auto-detects a running daemon. To configure manually:
 
@@ -264,7 +284,7 @@ The database directory is created automatically on first run. The default path f
 | `MEMSTORE_PG` | daemon | Postgres connection string |
 | `MEMSTORE_TLS_CERT_FILE`, `MEMSTORE_TLS_KEY_FILE` | daemon | Server cert paths |
 | `MEMSTORE_TLS_CLIENT_CA_FILE` | daemon | mTLS client trust roots |
-| `MEMSTORE_API_KEY` | daemon | Single bootstrap API key; additional tokens live in the api_tokens table (issued via `memstore tls` or admin) |
+| `MEMSTORE_API_KEY` | daemon | Single bootstrap API key; additional tokens live in the api_tokens table (issued via `memstore admin issue-token`) |
 | `MEMSTORE_EMBED_BACKEND`, `MEMSTORE_EMBED_BASE_URL`, `MEMSTORE_EMBED_MODEL`, `MEMSTORE_EMBED_API_KEY` | CLI, MCP, daemon | Embedder config (cascade to `EMBEDDING_*`) |
 | `MEMSTORE_GEN_URL`, `MEMSTORE_GEN_MODEL` | daemon, MCP | Generator/chat endpoint (separable from embedder) |
 | `MEMSTORE_RERANK_BASE_URL`, `MEMSTORE_RERANK_MODEL` | daemon | Optional cross-encoder reranker sidecar |

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -5,6 +5,7 @@ package pgstore
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -165,10 +166,23 @@ func EnsureUser(ctx context.Context, pool *pgxpool.Pool, namespace, name string)
 	return id, nil
 }
 
+// ErrUserNotFound reports that no user of that name exists in any namespace.
+// Callers may safely suggest creating one.
+var ErrUserNotFound = errors.New("user not found")
+
+// ErrUserWrongNamespace reports that the user exists, but under a different
+// namespace than the caller asked for. It is deliberately NOT an
+// ErrUserNotFound: creating the user would produce a duplicate in the wrong
+// namespace rather than fix anything. The caller passed the wrong --namespace.
+var ErrUserWrongNamespace = errors.New("user found in a different namespace")
+
 // LookupUserID returns the id of an existing user in the namespace. Unlike
 // EnsureUser it never creates a row -- it returns a not-found error when the
 // user does not exist, so callers (e.g. disable-user) cannot accidentally
 // create the principal they meant to act on.
+//
+// When the name exists in some other namespace, the error names those
+// namespaces and wraps ErrUserWrongNamespace.
 func LookupUserID(ctx context.Context, pool *pgxpool.Pool, namespace, name string) (int64, error) {
 	if name == "" {
 		return 0, fmt.Errorf("pgstore: LookupUserID: name must not be empty")
@@ -179,12 +193,48 @@ func LookupUserID(ctx context.Context, pool *pgxpool.Pool, namespace, name strin
 		namespace, name,
 	).Scan(&id)
 	if err == pgx.ErrNoRows {
-		return 0, fmt.Errorf("pgstore: user %q not found in namespace %q", name, namespace)
+		others, oerr := userNamespaces(ctx, pool, name)
+		if oerr == nil && len(others) > 0 {
+			return 0, fmt.Errorf("pgstore: user %q not found in namespace %q, but exists in %s -- pass --namespace: %w",
+				name, namespace, quoteJoin(others), ErrUserWrongNamespace)
+		}
+		return 0, fmt.Errorf("pgstore: user %q not found in namespace %q: %w", name, namespace, ErrUserNotFound)
 	}
 	if err != nil {
 		return 0, fmt.Errorf("pgstore: LookupUserID %q: %w", name, err)
 	}
 	return id, nil
+}
+
+// userNamespaces returns every namespace that holds a user of this name.
+func userNamespaces(ctx context.Context, pool *pgxpool.Pool, name string) ([]string, error) {
+	rows, err := pool.Query(ctx,
+		`SELECT namespace FROM memstore_users WHERE name = $1 ORDER BY namespace`, name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var ns string
+		if err := rows.Scan(&ns); err != nil {
+			return nil, err
+		}
+		out = append(out, ns)
+	}
+	return out, rows.Err()
+}
+
+// quoteJoin renders namespaces for an error message. Namespaces can be the
+// empty string, so they are quoted -- an unquoted one would vanish from the
+// message entirely.
+func quoteJoin(items []string) string {
+	quoted := make([]string, len(items))
+	for i, s := range items {
+		quoted[i] = fmt.Sprintf("%q", s)
+	}
+	return strings.Join(quoted, ", ")
 }
 
 // InitIdentity seeds the identity schema with an operator-supplied default

--- a/pgstore/tokens_test.go
+++ b/pgstore/tokens_test.go
@@ -3,6 +3,7 @@ package pgstore_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -343,5 +344,45 @@ func TestLookupUserID(t *testing.T) {
 
 	if _, err := pgstore.LookupUserID(ctx, pool, "", "nonexistent"); err == nil {
 		t.Error("LookupUserID(missing): expected a not-found error, got nil")
+	}
+}
+
+// A user that exists under a different namespace must be reported as such.
+// Reporting it as a plain not-found sent operators to 'user-add', which would
+// create a second user of the same name in the wrong namespace instead of
+// surfacing the mismatch.
+func TestLookupUserID_wrongNamespace(t *testing.T) {
+	newTokenStore(t) // seeds "testuser" in namespace ""
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, testDSN(t))
+	if err != nil {
+		t.Fatalf("connecting to postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	_, err = pgstore.LookupUserID(ctx, pool, "default", "testuser")
+	if err == nil {
+		t.Fatal("LookupUserID in the wrong namespace: expected an error, got nil")
+	}
+	if !errors.Is(err, pgstore.ErrUserWrongNamespace) {
+		t.Errorf("error = %v, want ErrUserWrongNamespace", err)
+	}
+	if errors.Is(err, pgstore.ErrUserNotFound) {
+		t.Errorf("error = %v, must not also be ErrUserNotFound (that is what sends operators to user-add)", err)
+	}
+	// The message has to name the namespace the user actually lives in, or the
+	// operator has no way to know which --namespace to pass.
+	if !strings.Contains(err.Error(), `""`) {
+		t.Errorf("error %q does not name the namespace the user was found in", err)
+	}
+
+	// A name that exists nowhere is still a plain not-found.
+	_, err = pgstore.LookupUserID(ctx, pool, "default", "nobody")
+	if !errors.Is(err, pgstore.ErrUserNotFound) {
+		t.Errorf("error for a wholly unknown user = %v, want ErrUserNotFound", err)
+	}
+	if errors.Is(err, pgstore.ErrUserWrongNamespace) {
+		t.Errorf("error for a wholly unknown user = %v, must not be ErrUserWrongNamespace", err)
 	}
 }


### PR DESCRIPTION
Fixes #102 and #103, both found while issuing a bearer token for a new laptop.

## What was broken

**Flags after the positional argument were silently dropped** (#102). Admin subcommands called `fs.Parse` directly, and Go's `flag` package stops at the first non-flag argument, so this:

```
memstore admin issue-token matthew@kraken --user matthew --scopes admin
```

put `--user matthew --scopes admin` into `fs.Args()` and then failed with `expected exactly one positional argument` -- blaming the positional argument, which was the one correct part of the command.

**The docs named a command that doesn't exist** (#102). `memstore admin issue --name <client>` appears in `installation.md`, `MIGRATING.md`, and `architecture.md`. It has never been a subcommand.

**Admin defaulted to a namespace nothing lives in** (#103). `--namespace` defaulted to `""` across every subcommand, while the daemon defaults to `"default"` (`memstore.DefaultConfig`) and writes its rows there. On the live deployment `list-users` reported `No users in namespace ""` over a database that has users, and `issue-token --user matthew` failed with a not-found error that told the operator to run `user-add matthew` -- which would have created a *second* `matthew` in the wrong namespace.

## What changed

- `parseAdminArgs` permutes flags and positionals, so flags work before, after, or interleaved with the positional argument. A bare `--` still ends flag parsing.
- Admin commands default `--namespace` to the daemon's namespace (config file / `MEMSTORE_NAMESPACE`, built-in `default`), never `""`.
- `list-users` on an empty namespace now names the namespaces that do hold users.
- `pgstore.LookupUserID` distinguishes the two failures: `ErrUserWrongNamespace` (names the namespace the user is actually in; deliberately *not* an `ErrUserNotFound`, so nothing suggests creating a duplicate) versus `ErrUserNotFound` (exists nowhere -- `issue-token` still suggests `user-add` here, correctly).
- Docs now show the real `issue-token` flow, including `--pg`/`MEMSTORE_PG`, the `<user>@<host>` naming convention, and per-machine tokens for per-machine revocation.

## Testing

- `cmd/memstore/admin_cmd_test.go`: table test over flag/positional orderings (before, after, interleaved, `--=` form, boolean flags, `--` terminator, order preservation) plus the namespace default.
- `pgstore/tokens_test.go`: `TestLookupUserID_wrongNamespace` asserts the sentinel split and that the message names the namespace. Full suite passes against a pgvector Postgres (`MEMSTORE_TEST_PG`).
- Exercised end-to-end against the production daemon's database: `list-users` with no flags now lists the real user, flags-after-positional issues a token, wrong-namespace issuance errors without suggesting `user-add`, and an unknown user still does suggest it. The token issued during that check was revoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)