### PR TITLE
ci: pin infodancer/workflows to @v0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   ci:
-    uses: infodancer/workflows/.github/workflows/go-ci.yml@v0.2.7
+    uses: infodancer/workflows/.github/workflows/go-ci.yml@v0
     with:
       run_tests: false


### PR DESCRIPTION
Float on the major pointer instead of an exact patch, so shared-workflow fixes (the v0.2.8 lint fix that drops the remote config-schema fetch, and future ones) land without a per-repo pin bump.

Verified the pin is the only change.