### PR TITLE
feat(api): enforce token scopes, with ingest never implied

### DIFF
--- a/cmd/memstore/admin_cmd.go
+++ b/cmd/memstore/admin_cmd.go
@@ -329,7 +329,7 @@ func runDisableUser(args []string, out io.Writer) {
 func runIssueToken(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("issue-token", flag.ExitOnError)
 	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG / config)")
-	scopes := fs.String("scopes", "", "comma-separated scopes (e.g. read,write,admin)")
+	scopes := fs.String("scopes", "", "comma-separated scopes: read, write, admin, ingest. admin implies read+write; ingest is never implied and must be granted explicitly")
 	expires := fs.Duration("expires", 0, "token lifetime, e.g. 90d, 720h. 0 = no expiry")
 	userName := fs.String("user", "", "user name to bind the token to (required; must exist in memstore_users)")
 	namespace := fs.String("namespace", defaultAdminNamespace(), namespaceFlagUsage)

--- a/docs/code-chunking.md
+++ b/docs/code-chunking.md
@@ -1,0 +1,190 @@
+# Chunking documents: Go source
+
+Status: design, not started
+Author: Matthew + Claude
+Date: 2026-07-19
+
+Sibling to `docs/document-chunking.md`, which covers markdown. Everything that
+document establishes is inherited: chunks are verbatim spans, sized in
+non-whitespace characters, produced deterministically, versioned via
+`chunker_version`, and never overlapping. This covers where the cuts go in Go
+source, and why the parser is `go/ast` rather than tree-sitter.
+
+## Prior art
+
+**cAST** (Findings of EMNLP 2025, arXiv 2506.15655) is the reference. Recursive
+**split-then-merge** over the AST: walk top-down, recurse into a node's children
+when it exceeds the budget rather than force-splitting it, then greedily merge
+adjacent small siblings to raise information density. Measured against fixed-size
+line chunking it gains +4.3 Recall@5 on RepoEval and +2.67 Pass@1 on SWE-bench.
+
+That is the same shape the markdown design arrived at independently. Code gets
+one thing markdown cannot have: an oversized node always has children to recurse
+into, so "never force-split" is always satisfiable. Markdown's oversized fence is
+a leaf, which is why that design has to accept oversized chunks.
+
+`gomantics/chunkx` implements cAST in Go and is worth reading. It is not worth
+depending on: it defaults to token counting and reaches tree-sitter through cgo.
+
+### Where we diverge, deliberately
+
+Every implementation surveyed **prepends context to chunk text** -- file path,
+scope chain, signatures, imports. supermemory's `code-chunk` states the reason
+exactly right: "Embedding models are trained on natural language. When you embed
+`async getUser(id: string)`, the model doesn't inherently know this is inside a
+UserService class."
+
+The pressure is real and the conclusion is right; the implementation is not
+available to us, because prepending destroys the verbatim invariant. The
+resolution is the same one markdown reached: **the context is derived columns,
+and the embedding input is assembled at embed time.** Same retrieval benefit, and
+the stored content still matches the file byte for byte.
+
+## Parser: go/ast, not tree-sitter
+
+|  | cgo | coverage |
+|---|---|---|
+| `go/ast` (stdlib) | none | Go only, exact |
+| `tree-sitter/go-tree-sitter`, `smacker/go-tree-sitter` | yes | 30+ languages |
+| `malivvan/tree-sitter` (wazero/WASM) | no | 30+ languages |
+| `odvcencio/gotreesitter` (pure-Go runtime) | no | ~205 grammars |
+
+Go first, with the stdlib parser. The tree this corpus serves is ~93 Go modules,
+so Go alone yields a corpus large enough to run the embedder bake-off, with no
+dependency and no cgo in the ingest path. `go/ast` also beats a generic grammar
+on fidelity for the things that matter here: it attaches doc comments to their
+declarations, distinguishes methods by receiver, and knows what is exported.
+
+Other languages come later via a cgo-free tree-sitter, with the line-window
+fallback covering the rest in the meantime. Choosing between the wazero wrapper
+and the pure-Go runtime is deferred until there is a second language to ingest.
+
+**The cost, stated plainly:** a Go-only first corpus biases the embedder bake-off
+toward Go. The candidate code models are trained on multi-language corpora, and a
+Go-only evaluation may not rank them the way a mixed corpus would. Accept it
+deliberately, and re-run the bake-off when a second language lands.
+
+## Boundaries
+
+**The unit is the top-level declaration.** A `FuncDecl` (function or method), or
+a `GenDecl` (a `type`, `const`, `var`, or `import` block).
+
+**A declaration's doc comment is part of its chunk.** The span starts at
+`Doc.Pos()`, not `Decl.Pos()`. In idiomatic Go the doc comment is the most
+retrievable prose in the file -- it says in English what the code does -- and
+separating it from its declaration would put the question and the answer in
+different chunks. `go/ast` attaches it for free; a generic grammar makes you
+reconstruct the association from adjacency.
+
+Then, following cAST:
+
+1. **Oversized declarations recurse into children.** A long function splits at
+   top-level statement boundaries inside its body; a large `const` or `var` block
+   splits at spec boundaries. Never split inside a statement or a composite
+   literal.
+2. **Undersized declarations merge with adjacent siblings** up to `target`. A
+   file of one-line accessors becomes a few chunks, not forty.
+3. **The package clause and imports** form the file's header chunk together with
+   the package doc comment when there is one. For a `doc.go` that is nothing but
+   package documentation, this is the whole file and it is prose -- which puts it
+   squarely in the mixed-space open question from
+   `docs/embedding-model-routing.md`.
+
+## Derived columns
+
+Assembled into embed text; never prepended to stored content.
+
+    package        package name
+    import_path    resolved module-relative import path
+    symbol         declaration name
+    receiver       receiver type for methods, NULL otherwise
+    decl_kind      func | method | type | const | var | import | package_doc
+    exported       bool
+    signature      the declaration's signature line
+    scope_path     package > receiver > symbol
+    imports_used   imports actually referenced within the span
+
+`imports_used` is lifted directly from `code-chunk`, which prepends up to ten
+referenced import symbols and reports it as one of the higher-value context
+fields. It is a genuine signal about what a function *does* -- a function
+touching `crypto/subtle` and one touching `net/http` are different in a way the
+body alone may not make obvious to an embedding model.
+
+Embed text then assembles as:
+
+    path: pgstore/store.go
+    package: pgstore
+    symbol: (*PostgresStore).appendUserFilter
+    signature: func (s *PostgresStore) appendUserFilter(b *strings.Builder, col string)
+    <the verbatim span>
+
+## What not to ingest
+
+Corpus quality is decided as much by exclusion as by chunking:
+
+- **`vendor/`** -- skipped entirely. Third-party source, already covered by the
+  repo trust rules, and it would swamp the corpus by volume.
+- **Generated files** -- detected by the standard `^// Code generated .* DO NOT
+  EDIT\.$` header. Ingested but marked `generated`, and excluded from retrieval
+  by default. Protobuf and mock output is high-volume and low-value, and left
+  unmarked it would dominate results for any type name it mentions.
+- **`_test.go` files** -- ingested and marked `is_test`. Tests document intended
+  behavior and are often the clearest statement of what a function is for, so
+  excluding them loses real signal; marking them lets retrieval choose.
+
+Both flags belong to the rigid provenance metadata: derived by the ingester from
+the file, not writable by a caller.
+
+## Unparseable files
+
+`go/parser` fails on a syntax error, or on a file using language features newer
+than the toolchain doing the ingest. That is not exceptional -- it will happen on
+work in progress and on repos pinned to newer Go versions.
+
+Such a file falls back to line-window chunking and is marked with its chunking
+strategy on the document. Falling back is right: a file that does not parse still
+contains searchable text, and refusing to ingest it creates a silent hole in the
+corpus. Recording the fallback matters so it is visible, and so re-ingest can
+retry once the toolchain catches up.
+
+## Test properties
+
+Inherits the markdown battery -- byte-identical re-chunking, exact span
+equality, non-overlap, monotonic ordinals. Go-specific additions:
+
+- A doc comment is always in the same chunk as the declaration it documents.
+- A chunk that holds whole top-level declarations re-parses as a valid
+  declaration list. (Statement-level chunks from an oversized function body do
+  not, and are exempt.)
+- No chunk boundary falls inside a string literal, composite literal, or
+  statement. Fuzz target.
+- Ingesting this repository produces zero unparseable-fallback documents.
+
+## Evaluation
+
+The research turned up the eval design that `docs/document-chunking.md` says is
+missing. supermemory found their first benchmark was trivially saturated: queries
+drawn as code prefixes from the target file hit 100% recall and measured nothing.
+Their fix is worth copying wholesale:
+
+- **Hard negatives** -- ~500 distractor files drawn from the *same repository*,
+  so retrieval has to discriminate within a codebase rather than between
+  codebases.
+- **Intersection-over-Union threshold (0.3)** against the target span, which
+  penalizes bloated chunks that technically contain the answer while burying it.
+
+That IoU metric is the missing instrument. Chunk boundary quality was flagged as
+the failure mode with no visible symptom; IoU gives it a number, and makes the
+thresholds in `document-chunking.md` measurable rather than merely reasoned.
+
+## Open questions
+
+- **Bake-off bias from a Go-only corpus.** Stated above; the mitigation is to
+  re-run once a second language is ingested.
+- **`imports_used` costs resolution work** the rest of the ingest path does not
+  need. Within a file it is a scope walk; across files it needs the import block,
+  which the header chunk already parses. Whether it is worth doing for every
+  chunk or only for function-level ones is unmeasured.
+- **Where package documentation goes.** A `doc.go` is prose in a `.go` file, so
+  the text/code space routing question applies within a single document rather
+  than between documents.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -151,6 +151,39 @@ name. Token names are global, not per-namespace.
 Other subcommands: `list-users`, `disable-user <name>` (revokes all of a user's
 tokens), `list-tokens`, `revoke-token <name>`, `rotate-token <name>`.
 
+### Scopes
+
+Tokens carry scopes, enforced per route: `read`, `write`, `admin`, `ingest`.
+Two implications and one deliberate non-implication:
+
+- `admin` implies `read` and `write`.
+- A token with no scopes gets `read` and `write` -- tokens issued before scope
+  enforcement existed keep working.
+- `ingest` (document-corpus writes) is implied by *nothing*, including `admin`.
+  It must be granted explicitly, and an `ingest`-only token cannot touch facts.
+  This is what keeps the model's credential -- typically `admin` -- away from
+  the ingest path.
+
+Unknown scope strings are rejected at issuance: matching is exact and
+lowercase, and a misspelled scope would otherwise produce a token that
+authenticates but is refused everywhere.
+
+### Multi-user isolation requires the token verifier
+
+User isolation is enforced at the storage layer -- every query is scoped to the
+user resolved from the bearer token, and two users sharing one daemon cannot
+see or touch each other's facts, links, sessions, or hints. But the user is
+*resolved from the token*, so the guarantee needs bearer auth to be active:
+
+- **mTLS is transport identity, not authorization.** A client certificate
+  authenticates the connection; it carries no user and no scopes. An mTLS-only
+  deployment (no token store) treats every caller as the default user with full
+  read/write.
+- **The SQLite backend is single-user by design.** It resolves identity from
+  the local OS user and enforces no per-user predicates. Never put SQLite
+  behind a network-reachable daemon serving more than one person; multi-user
+  deployments are Postgres only.
+
 `memstore setup` auto-detects a running daemon. To configure manually:
 
 ```bash

--- a/httpapi/handler.go
+++ b/httpapi/handler.go
@@ -238,48 +238,53 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // (search, exists, recall, generate) are Skipped with a reason until phase-2
 // body probes exist. GET /v1/context/hints needs a query param the path-based
 // prober can't supply, so it is skipped too.
+// Every route below states the scope it requires. The scope is declared here,
+// beside the route, rather than in a lookup table elsewhere: a table has to
+// re-derive which pattern matched, which duplicates the mux's routing and rots
+// silently when a path changes. See scopes.go for what each scope implies.
 func (h *Handler) registerRoutes() {
+	// Health is unauthenticated (ServeHTTP short-circuits it) and so unscoped.
 	h.mux.HandleFunc("GET /v1/health", h.handleHealth)
 
-	h.mux.HandleFunc("POST /v1/facts", h.handleInsert, smoke.Write())
-	h.mux.HandleFunc("GET /v1/facts/{id}", h.handleGet, smoke.Example("id", "1"))
-	h.mux.HandleFunc("GET /v1/facts", h.handleList)
-	h.mux.HandleFunc("DELETE /v1/facts/{id}", h.handleDelete, smoke.Write())
-	h.mux.HandleFunc("PATCH /v1/facts/{id}/metadata", h.handleUpdateMetadata, smoke.Write())
-	h.mux.HandleFunc("POST /v1/facts/{id}/supersede", h.handleSupersede, smoke.Write())
-	h.mux.HandleFunc("POST /v1/facts/{id}/confirm", h.handleConfirm, smoke.Write())
-	h.mux.HandleFunc("POST /v1/facts/touch", h.handleTouch, smoke.Write())
-	h.mux.HandleFunc("POST /v1/facts/exists", h.handleExists, smoke.Skip("POST read; needs a JSON body (phase 2)"))
-	h.mux.HandleFunc("GET /v1/facts/count", h.handleActiveCount)
-	h.mux.HandleFunc("GET /v1/facts/{id}/history", h.handleHistoryByID, smoke.Example("id", "1"))
-	h.mux.HandleFunc("GET /v1/history/{subject}", h.handleHistoryBySubject, smoke.Example("subject", "smoke"))
+	h.mux.HandleFunc("POST /v1/facts", h.requireScope(ScopeWrite, h.handleInsert), smoke.Write())
+	h.mux.HandleFunc("GET /v1/facts/{id}", h.requireScope(ScopeRead, h.handleGet), smoke.Example("id", "1"))
+	h.mux.HandleFunc("GET /v1/facts", h.requireScope(ScopeRead, h.handleList))
+	h.mux.HandleFunc("DELETE /v1/facts/{id}", h.requireScope(ScopeWrite, h.handleDelete), smoke.Write())
+	h.mux.HandleFunc("PATCH /v1/facts/{id}/metadata", h.requireScope(ScopeWrite, h.handleUpdateMetadata), smoke.Write())
+	h.mux.HandleFunc("POST /v1/facts/{id}/supersede", h.requireScope(ScopeWrite, h.handleSupersede), smoke.Write())
+	h.mux.HandleFunc("POST /v1/facts/{id}/confirm", h.requireScope(ScopeWrite, h.handleConfirm), smoke.Write())
+	h.mux.HandleFunc("POST /v1/facts/touch", h.requireScope(ScopeWrite, h.handleTouch), smoke.Write())
+	h.mux.HandleFunc("POST /v1/facts/exists", h.requireScope(ScopeRead, h.handleExists), smoke.Skip("POST read; needs a JSON body (phase 2)"))
+	h.mux.HandleFunc("GET /v1/facts/count", h.requireScope(ScopeRead, h.handleActiveCount))
+	h.mux.HandleFunc("GET /v1/facts/{id}/history", h.requireScope(ScopeRead, h.handleHistoryByID), smoke.Example("id", "1"))
+	h.mux.HandleFunc("GET /v1/history/{subject}", h.requireScope(ScopeRead, h.handleHistoryBySubject), smoke.Example("subject", "smoke"))
 
-	h.mux.HandleFunc("POST /v1/search", h.handleSearch, smoke.Skip("POST read; needs a JSON body (phase 2)"))
-	h.mux.HandleFunc("POST /v1/search/fts", h.handleSearchFTS, smoke.Skip("POST read; needs a JSON body (phase 2)"))
+	h.mux.HandleFunc("POST /v1/search", h.requireScope(ScopeRead, h.handleSearch), smoke.Skip("POST read; needs a JSON body (phase 2)"))
+	h.mux.HandleFunc("POST /v1/search/fts", h.requireScope(ScopeRead, h.handleSearchFTS), smoke.Skip("POST read; needs a JSON body (phase 2)"))
 
-	h.mux.HandleFunc("GET /v1/subsystems", h.handleListSubsystems)
+	h.mux.HandleFunc("GET /v1/subsystems", h.requireScope(ScopeRead, h.handleListSubsystems))
 
-	h.mux.HandleFunc("POST /v1/links", h.handleLinkFacts, smoke.Write())
-	h.mux.HandleFunc("GET /v1/links/{id}", h.handleGetLink, smoke.Example("id", "1"))
-	h.mux.HandleFunc("GET /v1/facts/{id}/links", h.handleGetLinks, smoke.Example("id", "1"))
-	h.mux.HandleFunc("PATCH /v1/links/{id}", h.handleUpdateLink, smoke.Write())
-	h.mux.HandleFunc("DELETE /v1/links/{id}", h.handleDeleteLink, smoke.Write())
+	h.mux.HandleFunc("POST /v1/links", h.requireScope(ScopeWrite, h.handleLinkFacts), smoke.Write())
+	h.mux.HandleFunc("GET /v1/links/{id}", h.requireScope(ScopeRead, h.handleGetLink), smoke.Example("id", "1"))
+	h.mux.HandleFunc("GET /v1/facts/{id}/links", h.requireScope(ScopeRead, h.handleGetLinks), smoke.Example("id", "1"))
+	h.mux.HandleFunc("PATCH /v1/links/{id}", h.requireScope(ScopeWrite, h.handleUpdateLink), smoke.Write())
+	h.mux.HandleFunc("DELETE /v1/links/{id}", h.requireScope(ScopeWrite, h.handleDeleteLink), smoke.Write())
 
-	h.mux.HandleFunc("POST /v1/generate", h.handleGenerate, smoke.Skip("calls the LLM; needs a JSON body (phase 2)"))
-	h.mux.HandleFunc("POST /v1/generate/json", h.handleGenerateJSON, smoke.Skip("calls the LLM; needs a JSON body (phase 2)"))
+	h.mux.HandleFunc("POST /v1/generate", h.requireScope(ScopeRead, h.handleGenerate), smoke.Skip("calls the LLM; needs a JSON body (phase 2)"))
+	h.mux.HandleFunc("POST /v1/generate/json", h.requireScope(ScopeRead, h.handleGenerateJSON), smoke.Skip("calls the LLM; needs a JSON body (phase 2)"))
 
-	h.mux.HandleFunc("POST /v1/recall", h.handleRecall, smoke.Skip("POST read; needs a JSON body (phase 2)"))
-	h.mux.HandleFunc("POST /v1/context/touch", h.handleContextTouch, smoke.Write())
+	h.mux.HandleFunc("POST /v1/recall", h.requireScope(ScopeRead, h.handleRecall), smoke.Skip("POST read; needs a JSON body (phase 2)"))
+	h.mux.HandleFunc("POST /v1/context/touch", h.requireScope(ScopeWrite, h.handleContextTouch), smoke.Write())
 
-	h.mux.HandleFunc("POST /v1/sessions/hook", h.handleSessionHook, smoke.Write())
-	h.mux.HandleFunc("POST /v1/sessions/transcript", h.handleSessionTranscript, smoke.Write())
+	h.mux.HandleFunc("POST /v1/sessions/hook", h.requireScope(ScopeWrite, h.handleSessionHook), smoke.Write())
+	h.mux.HandleFunc("POST /v1/sessions/transcript", h.requireScope(ScopeWrite, h.handleSessionTranscript), smoke.Write())
 
-	h.mux.HandleFunc("POST /v1/context/hints", h.handleStoreHint, smoke.Write())
-	h.mux.HandleFunc("GET /v1/context/hints", h.handleGetHints, smoke.Skip("needs a session_id or cwd query param; not path-probeable"))
-	h.mux.HandleFunc("POST /v1/context/hints/{id}/consume", h.handleConsumeHint, smoke.Write())
-	h.mux.HandleFunc("POST /v1/context/injections", h.handleRecordInjection, smoke.Write())
-	h.mux.HandleFunc("POST /v1/context/feedback", h.handleRecordFeedback, smoke.Write())
-	h.mux.HandleFunc("POST /v1/context/backfill-feedback", h.handleBackfillFeedback, smoke.Write())
+	h.mux.HandleFunc("POST /v1/context/hints", h.requireScope(ScopeWrite, h.handleStoreHint), smoke.Write())
+	h.mux.HandleFunc("GET /v1/context/hints", h.requireScope(ScopeRead, h.handleGetHints), smoke.Skip("needs a session_id or cwd query param; not path-probeable"))
+	h.mux.HandleFunc("POST /v1/context/hints/{id}/consume", h.requireScope(ScopeWrite, h.handleConsumeHint), smoke.Write())
+	h.mux.HandleFunc("POST /v1/context/injections", h.requireScope(ScopeWrite, h.handleRecordInjection), smoke.Write())
+	h.mux.HandleFunc("POST /v1/context/feedback", h.requireScope(ScopeWrite, h.handleRecordFeedback), smoke.Write())
+	h.mux.HandleFunc("POST /v1/context/backfill-feedback", h.requireScope(ScopeWrite, h.handleBackfillFeedback), smoke.Write())
 }
 
 // Manifest returns the smoke route manifest recorded at registration time:

--- a/httpapi/scope_enforcement_test.go
+++ b/httpapi/scope_enforcement_test.go
@@ -1,0 +1,114 @@
+package httpapi_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/matthewjhunter/memstore/httpapi"
+)
+
+// scopeVerifier maps a bearer token straight to a scope set, so enforcement can
+// be exercised without a Postgres token store. Distinct from handler_test.go's
+// stubVerifier, which binds a single token to a fixed Identity.
+type scopeVerifier map[string][]string
+
+func (v scopeVerifier) VerifyToken(_ context.Context, token string) (httpapi.Identity, error) {
+	scopes, ok := v[token]
+	if !ok {
+		return httpapi.Identity{}, errors.New("invalid")
+	}
+	return httpapi.Identity{Name: token, Scopes: scopes, Source: "bearer"}, nil
+}
+
+func newScopeHandler(t *testing.T) http.Handler {
+	t.Helper()
+	return newTestHandlerWith(t, httpapi.WithTokenVerifier(scopeVerifier{
+		"tok-read":   {httpapi.ScopeRead},
+		"tok-write":  {httpapi.ScopeWrite},
+		"tok-admin":  {httpapi.ScopeAdmin},
+		"tok-ingest": {httpapi.ScopeIngest},
+		"tok-legacy": nil,
+	}))
+}
+
+func scopeRequest(t *testing.T, h http.Handler, token, method, path string) int {
+	t.Helper()
+	body := strings.NewReader(`{"content":"x","subject":"y"}`)
+	req := httptest.NewRequest(method, path, body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w.Result().StatusCode
+}
+
+func TestScopeEnforcement(t *testing.T) {
+	h := newScopeHandler(t)
+
+	tests := []struct {
+		name     string
+		token    string
+		method   string
+		path     string
+		wantDeny bool
+	}{
+		{"read token can read", "tok-read", "GET", "/v1/facts", false},
+		{"read token cannot write", "tok-read", "POST", "/v1/facts", true},
+		{"write token can write", "tok-write", "POST", "/v1/facts", false},
+		{"write token cannot read", "tok-write", "GET", "/v1/facts", true},
+		{"admin can read", "tok-admin", "GET", "/v1/facts", false},
+		{"admin can write", "tok-admin", "POST", "/v1/facts", false},
+		{"legacy unscoped token can read", "tok-legacy", "GET", "/v1/facts", false},
+		{"legacy unscoped token can write", "tok-legacy", "POST", "/v1/facts", false},
+		{"ingest-only token cannot read facts", "tok-ingest", "GET", "/v1/facts", true},
+		{"ingest-only token cannot write facts", "tok-ingest", "POST", "/v1/facts", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code := scopeRequest(t, h, tc.token, tc.method, tc.path)
+			denied := code == http.StatusForbidden
+			if denied != tc.wantDeny {
+				t.Errorf("%s %s as %s: status %d (denied=%v), want denied=%v",
+					tc.method, tc.path, tc.token, code, denied, tc.wantDeny)
+			}
+		})
+	}
+}
+
+// An invalid credential is still a 401, not a 403 -- scope checks run after
+// authentication, and the two failures must stay distinguishable.
+func TestUnknownTokenIs401(t *testing.T) {
+	h := newScopeHandler(t)
+	if code := scopeRequest(t, h, "nope", "GET", "/v1/facts"); code != http.StatusUnauthorized {
+		t.Errorf("unknown token: status %d, want 401", code)
+	}
+}
+
+// Health stays reachable without any credential; monitoring depends on it.
+func TestHealthNeedsNoScope(t *testing.T) {
+	h := newScopeHandler(t)
+	req := httptest.NewRequest("GET", "/v1/health", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Result().StatusCode == http.StatusForbidden {
+		t.Error("health endpoint should not require a scope")
+	}
+}
+
+// With no auth configured at all there is no Identity, and every route must
+// stay reachable -- that is the unauthenticated deployment mode, and the many
+// existing tests that build a handler without a verifier depend on it.
+func TestNoAuthConfiguredSkipsScopeChecks(t *testing.T) {
+	h := newTestHandlerWith(t)
+	req := httptest.NewRequest("GET", "/v1/facts", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Result().StatusCode == http.StatusForbidden {
+		t.Error("unauthenticated mode should not enforce scopes")
+	}
+}

--- a/httpapi/scopes.go
+++ b/httpapi/scopes.go
@@ -1,0 +1,78 @@
+package httpapi
+
+import (
+	"net/http"
+	"slices"
+)
+
+// Scopes carried by API tokens. Every route declares the scope it requires at
+// registration; see registerRoutes.
+const (
+	// ScopeRead permits reads: fetching, listing, searching, recall.
+	ScopeRead = "read"
+	// ScopeWrite permits mutating facts, links, sessions, and context.
+	ScopeWrite = "write"
+	// ScopeAdmin permits administrative operations.
+	ScopeAdmin = "admin"
+	// ScopeIngest permits writing to the document corpus. It is deliberately
+	// not implied by any other scope -- see Allows.
+	ScopeIngest = "ingest"
+)
+
+// Allows reports whether the identity may exercise the given scope.
+//
+// Two implications exist, and one deliberate non-implication:
+//
+//   - ScopeAdmin implies ScopeRead and ScopeWrite. An administrator can already
+//     do both by other means; requiring the grant to be spelled out adds
+//     friction without adding a boundary.
+//
+//   - An identity with NO scopes gets ScopeRead and ScopeWrite. Tokens issued
+//     before scope enforcement existed carry an empty scope set, as does the
+//     legacy single-key auth path, and revoking their access on upgrade would
+//     break running deployments for no security gain -- they already had it.
+//
+//   - ScopeIngest is implied by NOTHING. Not by admin, not by the legacy grant.
+//     It must be granted explicitly on the token.
+//
+// That last rule is the one worth defending. The document corpus derives its
+// trustworthiness from provenance the model cannot author, and the structural
+// guarantee behind that is simply that no credential the model holds can reach
+// the ingest path. In practice the MCP server's token is often an admin token,
+// so if admin implied ingest the guarantee would be void exactly where it
+// matters. Admin is authority over the store; ingest is the authority to assert
+// where bytes came from. They are different powers and this keeps them apart.
+func (id Identity) Allows(scope string) bool {
+	if slices.Contains(id.Scopes, scope) {
+		return true
+	}
+	// Ingest is never implied.
+	if scope == ScopeIngest {
+		return false
+	}
+	if scope == ScopeRead || scope == ScopeWrite {
+		if len(id.Scopes) == 0 || slices.Contains(id.Scopes, ScopeAdmin) {
+			return true
+		}
+	}
+	return false
+}
+
+// requireScope wraps a handler so it only runs when the caller's identity
+// allows the given scope.
+//
+// When no identity is present the request passes through: that is the
+// unauthenticated configuration (neither a token verifier nor an API key is
+// wired up), which is a deployment choice, not a caller-controlled one. If auth
+// is configured, ServeHTTP has already rejected anything without a valid
+// credential before this runs.
+func (h *Handler) requireScope(scope string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, ok := IdentityFromContext(r.Context())
+		if ok && !id.Allows(scope) {
+			writeError(w, http.StatusForbidden, "token lacks the "+scope+" scope")
+			return
+		}
+		next(w, r)
+	}
+}

--- a/httpapi/scopes.go
+++ b/httpapi/scopes.go
@@ -3,20 +3,22 @@ package httpapi
 import (
 	"net/http"
 	"slices"
+
+	"github.com/matthewjhunter/memstore"
 )
 
-// Scopes carried by API tokens. Every route declares the scope it requires at
-// registration; see registerRoutes.
+// Scopes carried by API tokens, re-exported from the root package so handlers
+// and route registration read naturally. The canonical definitions live in
+// memstore.Scope* because pgstore validates against the same set at issuance
+// and must not import this package.
+//
+// Every route declares the scope it requires at registration; see
+// registerRoutes. What each implies is documented on Allows.
 const (
-	// ScopeRead permits reads: fetching, listing, searching, recall.
-	ScopeRead = "read"
-	// ScopeWrite permits mutating facts, links, sessions, and context.
-	ScopeWrite = "write"
-	// ScopeAdmin permits administrative operations.
-	ScopeAdmin = "admin"
-	// ScopeIngest permits writing to the document corpus. It is deliberately
-	// not implied by any other scope -- see Allows.
-	ScopeIngest = "ingest"
+	ScopeRead   = memstore.ScopeRead
+	ScopeWrite  = memstore.ScopeWrite
+	ScopeAdmin  = memstore.ScopeAdmin
+	ScopeIngest = memstore.ScopeIngest
 )
 
 // Allows reports whether the identity may exercise the given scope.

--- a/httpapi/scopes_test.go
+++ b/httpapi/scopes_test.go
@@ -1,0 +1,97 @@
+package httpapi
+
+import "testing"
+
+func TestIdentityAllows(t *testing.T) {
+	tests := []struct {
+		name   string
+		scopes []string
+		want   map[string]bool
+	}{
+		{
+			// Tokens issued before scope enforcement carry no scopes. They keep
+			// working for facts, and must NOT silently acquire ingest.
+			name:   "empty scopes get the legacy read+write grant, never ingest",
+			scopes: nil,
+			want: map[string]bool{
+				ScopeRead: true, ScopeWrite: true,
+				ScopeAdmin: false, ScopeIngest: false,
+			},
+		},
+		{
+			// The critical case: the MCP server's token is typically admin, and
+			// the whole provenance design rests on the model being unable to
+			// reach ingest. Admin must not be a way around that.
+			name:   "admin implies read and write but NOT ingest",
+			scopes: []string{ScopeAdmin},
+			want: map[string]bool{
+				ScopeRead: true, ScopeWrite: true,
+				ScopeAdmin: true, ScopeIngest: false,
+			},
+		},
+		{
+			name:   "explicit ingest grants only ingest",
+			scopes: []string{ScopeIngest},
+			want: map[string]bool{
+				ScopeRead: false, ScopeWrite: false,
+				ScopeAdmin: false, ScopeIngest: true,
+			},
+		},
+		{
+			name:   "read only",
+			scopes: []string{ScopeRead},
+			want: map[string]bool{
+				ScopeRead: true, ScopeWrite: false,
+				ScopeAdmin: false, ScopeIngest: false,
+			},
+		},
+		{
+			name:   "write does not imply read",
+			scopes: []string{ScopeWrite},
+			want: map[string]bool{
+				ScopeRead: false, ScopeWrite: true,
+				ScopeAdmin: false, ScopeIngest: false,
+			},
+		},
+		{
+			name:   "an ingest client can also be granted read explicitly",
+			scopes: []string{ScopeRead, ScopeIngest},
+			want: map[string]bool{
+				ScopeRead: true, ScopeWrite: false,
+				ScopeAdmin: false, ScopeIngest: true,
+			},
+		},
+		{
+			name:   "unknown scopes grant nothing",
+			scopes: []string{"superuser", "root"},
+			want: map[string]bool{
+				ScopeRead: false, ScopeWrite: false,
+				ScopeAdmin: false, ScopeIngest: false,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id := Identity{Scopes: tc.scopes}
+			for scope, want := range tc.want {
+				if got := id.Allows(scope); got != want {
+					t.Errorf("Allows(%q) = %v, want %v (scopes=%v)",
+						scope, got, want, tc.scopes)
+				}
+			}
+		})
+	}
+}
+
+// The legacy single-key path builds an Identity with no scopes. It must behave
+// like any other unscoped token: usable for facts, powerless for ingest.
+func TestLegacyIdentityCannotIngest(t *testing.T) {
+	id := Identity{Name: "legacy", Source: "legacy"}
+	if !id.Allows(ScopeWrite) {
+		t.Error("legacy identity should retain write")
+	}
+	if id.Allows(ScopeIngest) {
+		t.Error("legacy identity must not be able to ingest")
+	}
+}

--- a/pgstore/owner_test.go
+++ b/pgstore/owner_test.go
@@ -1,0 +1,84 @@
+package pgstore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/matthewjhunter/memstore"
+)
+
+// ownerFor is the single decision about which user_id a written fact carries.
+// It is pure, so it is tested directly rather than through a live database.
+func TestOwnerFor(t *testing.T) {
+	tests := []struct {
+		name      string
+		storeUser int64
+		factUser  int64
+		want      int64
+		wantErr   string
+	}{
+		{
+			// The overwhelmingly common case: a request-scoped store writing a
+			// fact that says nothing about ownership.
+			name:      "scoped store, fact silent about owner",
+			storeUser: 7,
+			factUser:  0,
+			want:      7,
+		},
+		{
+			name:      "scoped store, fact agrees with the store",
+			storeUser: 7,
+			factUser:  7,
+			want:      7,
+		},
+		{
+			// The case this function exists for. Insert used to prefer
+			// f.UserID whenever it was set, so a handler that decoded a
+			// request body straight into memstore.Fact would hand any caller a
+			// cross-user write.
+			name:      "scoped store cannot write another user's fact",
+			storeUser: 7,
+			factUser:  9,
+			wantErr:   "scoped to user 7",
+		},
+		{
+			// Service scope is the privileged daemon-internal scope. It may
+			// write for any user, but must say which.
+			name:      "service scope honours an explicit owner",
+			storeUser: 0,
+			factUser:  9,
+			want:      9,
+		},
+		{
+			// user_id is NOT NULL with an FK, so this would fail in the
+			// database anyway. Failing here makes the reason legible.
+			name:      "service scope requires an explicit owner",
+			storeUser: 0,
+			factUser:  0,
+			wantErr:   "explicit Fact.UserID",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &PostgresStore{userID: tc.storeUser}
+			got, err := s.ownerFor(memstore.Fact{UserID: tc.factUser})
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ownerFor() = %d, want error containing %q", got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q does not contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ownerFor() error = %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("ownerFor() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/pgstore/service_link_test.go
+++ b/pgstore/service_link_test.go
@@ -1,0 +1,99 @@
+package pgstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/matthewjhunter/memstore"
+	"github.com/matthewjhunter/memstore/pgstore"
+)
+
+// Service-scope LinkFacts derives the link's owner from its endpoints. Before
+// this was defined, the service-scope branch stamped user_id = 0, which
+// violates the FK to memstore_users -- dead code that failed closed, but
+// inconsistent with ownerFor's treatment of Insert.
+func TestLinkFacts_ServiceScope(t *testing.T) {
+	ctx := context.Background()
+	base := newTestStore(t)
+
+	pool, err := pgxpool.New(ctx, testDSN(t))
+	if err != nil {
+		t.Fatalf("connecting to postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	uidA, err := pgstore.EnsureUser(ctx, pool, "test", "svc-link-a")
+	if err != nil {
+		t.Fatalf("EnsureUser: %v", err)
+	}
+	uidB, err := pgstore.EnsureUser(ctx, pool, "test", "svc-link-b")
+	if err != nil {
+		t.Fatalf("EnsureUser: %v", err)
+	}
+	a, err := base.ForUser(uidA)
+	if err != nil {
+		t.Fatalf("ForUser(%d): %v", uidA, err)
+	}
+	b, err := base.ForUser(uidB)
+	if err != nil {
+		t.Fatalf("ForUser(%d): %v", uidB, err)
+	}
+
+	fa1 := mustInsert(t, a, "fact a1", "svc-link")
+	fa2 := mustInsert(t, a, "fact a2", "svc-link")
+	fb := mustInsert(t, b, "fact b1", "svc-link")
+
+	svc := base.ServiceScope()
+
+	t.Run("same-owner endpoints: link created and stamped with that owner", func(t *testing.T) {
+		linkID, err := svc.LinkFacts(ctx, fa1, fa2, "related", false, "", nil)
+		if err != nil {
+			t.Fatalf("service-scope LinkFacts: %v", err)
+		}
+		var owner int64
+		if err := pool.QueryRow(ctx,
+			`SELECT user_id FROM memstore_links WHERE id = $1`, linkID,
+		).Scan(&owner); err != nil {
+			t.Fatalf("reading link owner: %v", err)
+		}
+		if owner != uidA {
+			t.Errorf("link user_id = %d, want %d (the endpoints' owner)", owner, uidA)
+		}
+		// The owner sees the link through their own scope.
+		l, err := a.GetLink(ctx, linkID)
+		if err != nil || l == nil {
+			t.Errorf("owner cannot see service-created link: link=%v err=%v", l, err)
+		}
+	})
+
+	t.Run("cross-user endpoints: rejected, nothing inserted", func(t *testing.T) {
+		var before int64
+		pool.QueryRow(ctx, `SELECT COUNT(*) FROM memstore_links`).Scan(&before)
+
+		if _, err := svc.LinkFacts(ctx, fa1, fb, "related", false, "", nil); err == nil {
+			t.Fatal("service-scope link across users succeeded, want error")
+		}
+
+		var after int64
+		pool.QueryRow(ctx, `SELECT COUNT(*) FROM memstore_links`).Scan(&after)
+		if after != before {
+			t.Errorf("link count changed %d -> %d on rejected cross-user link", before, after)
+		}
+	})
+
+	t.Run("self-link under service scope", func(t *testing.T) {
+		if _, err := svc.LinkFacts(ctx, fa1, fa1, "self", false, "", nil); err != nil {
+			t.Errorf("service-scope self-link: %v", err)
+		}
+	})
+}
+
+func mustInsert(t *testing.T, s memstore.Store, content, subject string) int64 {
+	t.Helper()
+	id, err := s.Insert(context.Background(), memstore.Fact{Content: content, Subject: subject})
+	if err != nil {
+		t.Fatalf("insert %q: %v", content, err)
+	}
+	return id
+}

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -776,13 +776,13 @@ func (s *PostgresStore) Insert(ctx context.Context, f memstore.Fact) (int64, err
 		emb = &v
 	}
 
-	userID := s.userID
-	if f.UserID != 0 {
-		userID = f.UserID
+	userID, err := s.ownerFor(f)
+	if err != nil {
+		return 0, err
 	}
 
 	var id int64
-	err := s.pool.QueryRow(ctx,
+	err = s.pool.QueryRow(ctx,
 		`INSERT INTO memstore_facts (namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		 RETURNING id`,
@@ -797,6 +797,18 @@ func (s *PostgresStore) Insert(ctx context.Context, f memstore.Fact) (int64, err
 
 // InsertBatch inserts multiple facts in a single transaction.
 func (s *PostgresStore) InsertBatch(ctx context.Context, facts []memstore.Fact) error {
+	// Resolve ownership for every fact before opening the transaction. A
+	// rejected owner is a caller bug, not a data condition, and finding it on
+	// fact 400 of 500 would mean a pointless round trip and rollback.
+	owners := make([]int64, len(facts))
+	for i := range facts {
+		owner, err := s.ownerFor(facts[i])
+		if err != nil {
+			return fmt.Errorf("pgstore: fact %d of %d: %w", i+1, len(facts), err)
+		}
+		owners[i] = owner
+	}
+
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("pgstore: beginning transaction: %w", err)
@@ -815,10 +827,7 @@ func (s *PostgresStore) InsertBatch(ctx context.Context, facts []memstore.Fact) 
 			emb = &v
 		}
 
-		userID := s.userID
-		if facts[i].UserID != 0 {
-			userID = facts[i].UserID
-		}
+		userID := owners[i]
 
 		err := tx.QueryRow(ctx,
 			`INSERT INTO memstore_facts (namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, embedding, created_at)
@@ -1696,6 +1705,36 @@ func (s *PostgresStore) appendNamespaceFilter(b *queryBuilder, nsCol string, all
 
 // appendUserFilter adds the owner predicate for scoped stores. Service-scope
 // stores (userID == 0) carry no user predicate and see all users' rows.
+// ownerFor resolves the user_id an incoming fact should be written under. It is
+// the only place that decision is made, for Insert and InsertBatch alike.
+//
+// A scoped store writes its own user's facts and no one else's. Insert used to
+// prefer f.UserID whenever it was non-zero, which was harmless only because no
+// caller set it and no handler decoded into memstore.Fact -- the field carries a
+// json tag, so a future handler that decoded a request body directly into a Fact
+// would have handed any authenticated caller a cross-user write with nothing
+// failing to signal it. A mismatch is rejected rather than silently corrected,
+// because a caller that supplied the wrong owner has a bug worth surfacing.
+//
+// Service scope (userID == 0) is the privileged daemon-internal scope and may
+// write for any user, but must name one: memstore_facts.user_id is NOT NULL with
+// a foreign key, so a zero here fails in the database regardless. Failing early
+// makes the reason legible.
+func (s *PostgresStore) ownerFor(f memstore.Fact) (int64, error) {
+	if s.userID != 0 {
+		if f.UserID != 0 && f.UserID != s.userID {
+			return 0, fmt.Errorf(
+				"pgstore: fact carries user_id %d but this store is scoped to user %d: a scoped store cannot write another user's facts",
+				f.UserID, s.userID)
+		}
+		return s.userID, nil
+	}
+	if f.UserID == 0 {
+		return 0, errors.New("pgstore: service-scope insert requires an explicit Fact.UserID")
+	}
+	return f.UserID, nil
+}
+
 func (s *PostgresStore) appendUserFilter(b *queryBuilder, col string) {
 	if s.userID == 0 {
 		return

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -1424,13 +1424,30 @@ func (s *PostgresStore) LinkFacts(ctx context.Context, sourceID, targetID int64,
 	var id int64
 	var err error
 	if s.userID == 0 {
-		// Service scope: no ownership guard.
+		// Service scope: derive the link's owner from its endpoints. A link
+		// belongs to whoever owns the facts it connects, and a link may never
+		// span users -- that is an isolation invariant, not a convenience. The
+		// GROUP BY yields one row per distinct owner among the endpoints; only
+		// a single-owner group can reach the expected DISTINCT-id count, so
+		// cross-user pairs insert nothing and fail like a missing fact.
+		//
+		// The previous branch stamped user_id = 0, which the FK to
+		// memstore_users rejects at runtime -- dead code that failed closed,
+		// and inconsistent with ownerFor's handling of Insert.
 		err = s.pool.QueryRow(ctx,
 			`INSERT INTO memstore_links (namespace, user_id, source_id, target_id, link_type, bidirectional, label, metadata, created_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			 SELECT $1, o.user_id, $2, $3, $4, $5, $6, $7, $8
+			 FROM (SELECT user_id, COUNT(DISTINCT id) AS n
+			       FROM memstore_facts
+			       WHERE id IN ($2, $3) AND namespace = $1
+			       GROUP BY user_id) o
+			 WHERE o.n = (CASE WHEN $2 = $3 THEN 1 ELSE 2 END)
 			 RETURNING id`,
-			s.namespace, s.userID, sourceID, targetID, linkType, bidirectional, label, nullableBytes(metaJSON), time.Now().UTC(),
+			s.namespace, sourceID, targetID, linkType, bidirectional, label, nullableBytes(metaJSON), time.Now().UTC(),
 		).Scan(&id)
+		if err == pgx.ErrNoRows {
+			return 0, fmt.Errorf("pgstore: creating link %d->%d: facts not found or not owned by one user", sourceID, targetID)
+		}
 	} else {
 		// Guarded insert: both endpoints must exist in the store's namespace
 		// and belong to the store's user. A foreign fact fails exactly like a

--- a/pgstore/tokens.go
+++ b/pgstore/tokens.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/matthewjhunter/memstore"
 )
 
 // TokenStore manages API tokens used by memstored for bearer-token auth.
@@ -238,6 +239,13 @@ func (s *TokenStore) Issue(ctx context.Context, name string, opts IssueOpts) (st
 	}
 	if opts.UserID == 0 {
 		return "", errors.New("token store issue: UserID is required")
+	}
+	// Reject unknown scopes here rather than storing them. Scope matching at
+	// request time is exact, so a typo yields a token that authenticates and is
+	// refused everywhere, with nothing to explain it. Issuance is the last point
+	// at which the mistake is cheap.
+	if err := memstore.ValidateScopes(opts.Scopes); err != nil {
+		return "", fmt.Errorf("token store issue: %w", err)
 	}
 	token, err := generateToken()
 	if err != nil {

--- a/scopes.go
+++ b/scopes.go
@@ -1,0 +1,54 @@
+package memstore
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Token scopes. These name the authority a credential carries, and are the
+// canonical spelling for both ends: pgstore stores them on api_tokens rows and
+// validates them at issuance, httpapi enforces them per route. They live here
+// because the root package is the one both of those already depend on.
+//
+// What each scope implies -- and, for ingest, what it deliberately does not --
+// is documented on httpapi.Identity.Allows, which is where the decision is made.
+const (
+	// ScopeRead permits reads: fetching, listing, searching, recall.
+	ScopeRead = "read"
+	// ScopeWrite permits mutating facts, links, sessions, and context.
+	ScopeWrite = "write"
+	// ScopeAdmin permits administrative operations, and implies read and write.
+	ScopeAdmin = "admin"
+	// ScopeIngest permits writing to the document corpus. It is implied by no
+	// other scope, including admin, and must always be granted explicitly.
+	ScopeIngest = "ingest"
+)
+
+// ValidScopes returns every recognised scope, in a stable order suitable for
+// error messages and help text.
+func ValidScopes() []string {
+	return []string{ScopeRead, ScopeWrite, ScopeAdmin, ScopeIngest}
+}
+
+// ValidateScopes reports whether every scope in the set is recognised. An empty
+// set is valid: it is how an unscoped token is represented, and such a token
+// receives the legacy read+write grant.
+//
+// This exists because an unrecognised scope fails closed and silently. Scope
+// matching is exact and case-sensitive, so "Ingest" or a typo like "ingset"
+// produces a credential that authenticates successfully and is refused by every
+// route, with nothing at issue time to say why. Worse, a non-empty scope set
+// forfeits the empty-set grant, so a misspelled scope is strictly worse than
+// passing no scopes at all. Rejecting it at the point of issue is the only
+// place the mistake is still cheap.
+func ValidateScopes(scopes []string) error {
+	valid := ValidScopes()
+	for _, s := range scopes {
+		if !slices.Contains(valid, s) {
+			return fmt.Errorf("unknown scope %q: valid scopes are %s (exact, lowercase)",
+				s, strings.Join(valid, ", "))
+		}
+	}
+	return nil
+}

--- a/scopes_test.go
+++ b/scopes_test.go
@@ -1,0 +1,75 @@
+package memstore_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/matthewjhunter/memstore"
+)
+
+func TestValidateScopes(t *testing.T) {
+	tests := []struct {
+		name    string
+		scopes  []string
+		wantErr bool
+		// errMentions, when set, must appear in the error text -- the point of
+		// validating is a usable message, not just a rejection.
+		errMentions string
+	}{
+		{
+			// The common case, and it must stay legal: an unscoped token gets
+			// the legacy read+write grant.
+			name:   "empty is valid",
+			scopes: nil,
+		},
+		{name: "read", scopes: []string{memstore.ScopeRead}},
+		{name: "write", scopes: []string{memstore.ScopeWrite}},
+		{name: "admin", scopes: []string{memstore.ScopeAdmin}},
+		{name: "ingest", scopes: []string{memstore.ScopeIngest}},
+		{
+			name:   "combination",
+			scopes: []string{memstore.ScopeRead, memstore.ScopeIngest},
+		},
+		{
+			// The motivating bug: a typo produces a token that authenticates
+			// and can do nothing, with no error at issue time saying why.
+			name:        "typo is rejected and named",
+			scopes:      []string{"ingset"},
+			wantErr:     true,
+			errMentions: "ingset",
+		},
+		{
+			// slices.Contains is case-sensitive, so this would silently fail
+			// closed at request time.
+			name:        "wrong case is rejected",
+			scopes:      []string{"Ingest"},
+			wantErr:     true,
+			errMentions: "Ingest",
+		},
+		{
+			name:        "one bad scope among good ones is rejected",
+			scopes:      []string{memstore.ScopeRead, "supseruser"},
+			wantErr:     true,
+			errMentions: "supseruser",
+		},
+		{
+			name:        "error lists the valid scopes",
+			scopes:      []string{"bogus"},
+			wantErr:     true,
+			errMentions: memstore.ScopeIngest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := memstore.ValidateScopes(tc.scopes)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateScopes(%v) error = %v, wantErr = %v",
+					tc.scopes, err, tc.wantErr)
+			}
+			if tc.errMentions != "" && !strings.Contains(err.Error(), tc.errMentions) {
+				t.Errorf("error %q does not mention %q", err, tc.errMentions)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Prerequisite for document-corpus ingest (`docs/document-corpus.md`).

## The gap

`Identity.Scopes` has been populated from the token store since the multi-user work and consulted by **nothing** -- `HasScope` appears only in `identity_test.go`. Every authenticated token could reach every endpoint.

That matters now because the document corpus derives its trustworthiness from provenance the model cannot author, and the structural guarantee behind it is that no credential the model holds reaches the ingest path. Without scope enforcement that guarantee doesn't exist.

## Rules

- **`admin` implies `read` + `write`** -- an admin can do both by other means already.
- **No scopes implies `read` + `write`** -- pre-enforcement tokens and the legacy single-key path carry empty scope sets. Revoking their access on upgrade breaks running deployments for no security gain; they already had it.
- **`ingest` is implied by nothing, including `admin`.**

The last rule is the one that carries the design. The MCP server's token is typically `admin`, so an admin-implies-ingest rule would void the guarantee precisely where it matters. Admin is authority over the store; ingest is the authority to assert where bytes came from.

## Behavior

- Scope failure → **403**; authentication failure stays **401**. The two stay distinguishable.
- `/v1/health` stays unscoped for monitoring.
- A handler with no auth configured skips scope checks -- the unauthenticated deployment mode the existing tests depend on.
- Scopes are declared per route in `registerRoutes`, not in a lookup table: a table re-derives which pattern matched, duplicating mux routing and rotting silently when a path changes.

## Compatibility

No existing token loses access. Verified by tests covering the empty-scope and legacy-identity paths.

## Tests

`GOWORK=off go test ./... -count=1` -- all packages pass. New: `httpapi/scopes_test.go` (implication matrix) and `httpapi/scope_enforcement_test.go` (end-to-end through the handler, including 401-vs-403 and the unauthenticated mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)