### PR TITLE
fix(tests): sweep remaining SA5011 sites the CI linter reveals in batches

### DIFF
--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -78,6 +78,7 @@ func TestClient_InsertAndGet(t *testing.T) {
 	}
 	if f == nil {
 		t.Fatal("expected fact, got nil")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if f.Content != "memstore uses SQLite" {
 		t.Fatalf("expected 'memstore uses SQLite', got %q", f.Content)

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -72,6 +72,7 @@ func resultText(t *testing.T, r *mcp.CallToolResult) string {
 	t.Helper()
 	if r == nil {
 		t.Fatal("nil result")
+		return "" // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if len(r.Content) == 0 {
 		t.Fatal("empty content")

--- a/mcpserver/structured_output_test.go
+++ b/mcpserver/structured_output_test.go
@@ -54,6 +54,7 @@ func resultStructured[T any](t *testing.T, r *mcp.CallToolResult) T {
 	var zero T
 	if r == nil {
 		t.Fatal("nil result")
+		return zero // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if r.StructuredContent == nil {
 		t.Fatal("StructuredContent is nil; handler did not return typed output")

--- a/pgstore/session_store_test.go
+++ b/pgstore/session_store_test.go
@@ -142,6 +142,7 @@ func TestSessionMigrate_DataWithoutDefaultUser(t *testing.T) {
 	_, err = pgstore.NewSessionStore(ctx, pool)
 	if err == nil {
 		t.Fatal("NewSessionStore should have failed (session data, no default user)")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if !strings.Contains(err.Error(), "tier3-init") {
 		t.Errorf("expected tier3-init error, got: %v", err)

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -205,6 +205,7 @@ func TestInsertAndGet(t *testing.T) {
 	}
 	if f == nil {
 		t.Fatal("expected fact, got nil")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if f.Content != "memstore uses PostgreSQL" {
 		t.Fatalf("expected content 'memstore uses PostgreSQL', got %q", f.Content)
@@ -961,6 +962,7 @@ func TestConformance(t *testing.T) {
 		SetSupersededBy: func(t *testing.T, supersededByID, targetID int64) {
 			if lastPool == nil {
 				t.Fatal("SetSupersededBy called before any NewStore; no pool available")
+				return // SA5011: newer staticcheck misses that Fatal terminates
 			}
 			if _, err := lastPool.Exec(ctx,
 				`UPDATE memstore_facts SET superseded_by = $1 WHERE id = $2`,
@@ -1062,6 +1064,7 @@ func TestLinkFacts_CrossUserRejected(t *testing.T) {
 	_, err = other.LinkFacts(ctx, src, tgt, "ref", false, "", nil)
 	if err == nil {
 		t.Fatal("cross-user LinkFacts succeeded")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("cross-user LinkFacts error %q is not not-found-shaped", err)
@@ -1221,6 +1224,7 @@ func TestMigrateV4_Fresh(t *testing.T) {
 	_, err = pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
 	if err == nil {
 		t.Fatal("expected pgstore.New on a fresh DB to fail with the tier3-init instruction, got nil")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if !strings.Contains(err.Error(), "tier3-init") {
 		t.Errorf("fresh-DB construction error should mention tier3-init: %v", err)
@@ -1476,6 +1480,7 @@ func TestMigrateV4_AmbiguousUser(t *testing.T) {
 	_, err = pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 4, 512)
 	if err == nil {
 		t.Fatal("expected error for ambiguous token prefixes, got nil")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if !strings.Contains(err.Error(), "ambiguous") {
 		t.Errorf("error should mention ambiguous prefixes: %v", err)

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -127,6 +127,7 @@ func TestInsert(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected non-nil fact")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if got.Content != "Matthew prefers dark mode" {
 		t.Errorf("content = %q", got.Content)
@@ -1224,6 +1225,7 @@ func TestSupersede_RecordsTimestamp(t *testing.T) {
 	}
 	if old == nil {
 		t.Fatal("superseded fact not found")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 
 	if old.SupersededAt == nil {
@@ -1242,6 +1244,7 @@ func TestSupersede_RecordsTimestamp(t *testing.T) {
 	}
 	if newFact == nil {
 		t.Fatal("new fact not found")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if newFact.SupersededAt != nil {
 		t.Errorf("new fact should have nil SupersededAt, got %v", newFact.SupersededAt)
@@ -2031,6 +2034,7 @@ func TestConformance(t *testing.T) {
 		SetSupersededBy: func(t *testing.T, supersededByID, targetID int64) {
 			if lastDB == nil {
 				t.Fatal("SetSupersededBy called before any NewStore; no db available")
+				return // SA5011: newer staticcheck misses that Fatal terminates
 			}
 			if _, err := lastDB.ExecContext(context.Background(),
 				`UPDATE memstore_facts SET superseded_by = ? WHERE id = ?`,
@@ -2132,6 +2136,7 @@ func TestMigrateV12(t *testing.T) {
 		}
 		if f == nil {
 			t.Fatalf("Get(id=%d): nil", id)
+			return // SA5011: newer staticcheck misses that Fatal terminates
 		}
 		if f.UserID == 0 {
 			t.Errorf("fact id=%d has UserID=0; expected non-zero after V12", id)

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -143,6 +143,7 @@ func TestExportRoundTrip(t *testing.T) {
 	}
 	if oldFact == nil {
 		t.Fatal("old fact not found")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if oldFact.Metadata == nil {
 		t.Fatal("metadata not preserved")
@@ -296,6 +297,7 @@ func TestExportIncludesSuperseded(t *testing.T) {
 	}
 	if superseded == nil {
 		t.Fatal("superseded fact not found in export")
+		return // SA5011: newer staticcheck misses that Fatal terminates
 	}
 	if superseded.SupersededBy == nil {
 		t.Error("superseded fact should have SupersededBy set")


### PR DESCRIPTION
Follow-up to #121. The lint job caps same-issue reports at 3 per run, so fixing the first batch surfaced the next: a fresh run on updated main still fails on `httpclient/client_test.go` and `mcpserver/server_test.go`.

Local golangci-lint 2.11.1 reports zero SA5011 -- the `@v0` workflow's linter is newer. Rather than iterate three findings at a time through CI, this sweeps the flagged shape (nil-guarded `t.Fatal` followed by a dereference of the guarded pointer) across the repo: **16 sites in 7 files**, found by pattern match.

Same fix as #121: explicit `return` after `Fatal` -- a runtime no-op since `Fatal` never returns. Two helpers have return values (`resultText` returns `string`; `resultStructured[T]` is generic), so those return zero values.

`GOWORK=off go build ./... && go vet ./... && go test ./... -count=1` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
