### PR TITLE
Document corpus storage layer (pgstore schema V5)

### DIFF
--- a/document.go
+++ b/document.go
@@ -1,0 +1,169 @@
+package memstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Document is the file-level identity and rigid provenance for one ingested
+// file, per docs/document-corpus.md. Every field is written by the ingest
+// path, never by a model: this is the typed-column provenance system, distinct
+// from the flexible model-written metadata facts carry.
+//
+// The uniqueness key is (namespace, user_id, repo_url, path); Commit is
+// deliberately outside it -- re-ingesting at a new commit replaces the row,
+// because git already stores history.
+type Document struct {
+	ID        int64  `json:"id"`
+	Namespace string `json:"namespace,omitempty"` // set automatically by the store on upsert
+	UserID    int64  `json:"user_id,omitempty"`   // owning user; resolved by the store, see ownerFor
+	RepoURL   string `json:"repo_url,omitempty"`  // canonical remote; "" = loose file (stored as NULL)
+	Commit    string `json:"commit,omitempty"`    // asserted by the ingesting client
+	Path      string `json:"path"`                // repo-relative (or ingest-root-relative) path
+	Basename  string `json:"basename"`            // derived from Path by the store
+	Lang      string `json:"lang,omitempty"`      // set by the daemon's extension routing
+
+	FileSHA256 []byte     `json:"file_sha256"` // hash of the exact bytes the chunks were cut from
+	Mtime      *time.Time `json:"mtime,omitempty"`
+	Dirty      bool       `json:"dirty"`               // file was modified/untracked in the working tree at ingest
+	Trusted    bool       `json:"trusted"`             // resolved from repo policy at ingest; not consulted live
+	Generated  bool       `json:"generated,omitempty"` // file carries a "Code generated" header
+	IsTest     bool       `json:"is_test,omitempty"`   // _test.go and equivalents
+
+	ChunkerVersion int             `json:"chunker_version"`
+	Title          string          `json:"title,omitempty"`        // from front matter when present
+	FrontMatter    json.RawMessage `json:"front_matter,omitempty"` // parsed front matter; rigid provenance, not model-writable
+
+	IngestedAt time.Time `json:"ingested_at"`
+}
+
+// DocumentChunk is one verbatim span of a document. The checkable invariant:
+// Content equals file[ByteStart:ByteEnd] at the document's recorded
+// FileSHA256. Spans are non-overlapping and monotonically increasing in
+// Ordinal; they do not cover the file (front matter and inter-block
+// whitespace are skipped by design).
+//
+// The heading/scope fields are derived context assembled into embed text at
+// embed time; they are never prepended to Content.
+type DocumentChunk struct {
+	ID         int64 `json:"id"`
+	DocumentID int64 `json:"document_id"`
+	Ordinal    int   `json:"ordinal"`
+
+	Content   string `json:"content"`
+	ByteStart int    `json:"byte_start"`
+	ByteEnd   int    `json:"byte_end"`
+	LineStart int    `json:"line_start"`
+	LineEnd   int    `json:"line_end"`
+
+	// Markdown-derived context (docs/document-chunking.md).
+	HeadingPath  string `json:"heading_path,omitempty"` // ancestors only, never the chunk's own heading
+	HeadingLevel int    `json:"heading_level,omitempty"`
+	Lang         string `json:"lang,omitempty"` // set on split-out fences
+
+	// Code-derived context (docs/code-chunking.md).
+	Package     string   `json:"package,omitempty"`
+	ImportPath  string   `json:"import_path,omitempty"`
+	Symbol      string   `json:"symbol,omitempty"`
+	Receiver    string   `json:"receiver,omitempty"`
+	DeclKind    string   `json:"decl_kind,omitempty"` // func | method | type | const | var | import | package_doc
+	Exported    bool     `json:"exported,omitempty"`
+	Signature   string   `json:"signature,omitempty"`
+	ScopePath   string   `json:"scope_path,omitempty"` // package > receiver > symbol
+	ImportsUsed []string `json:"imports_used,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// DocumentInfo is the manifest-sync view of a stored document: enough to
+// compute need/skip/orphaned against a client manifest without shipping
+// content.
+type DocumentInfo struct {
+	ID         int64  `json:"id"`
+	Path       string `json:"path"`
+	FileSHA256 []byte `json:"file_sha256"`
+	Dirty      bool   `json:"dirty"`
+}
+
+// DocumentSearchOpts filters and sizes a document-chunk search.
+//
+// Basename exists because "show me sqlite.go" is a metadata lookup, not a
+// full-text problem (docs/document-corpus.md). Generated documents are
+// excluded unless IncludeGenerated is set.
+type DocumentSearchOpts struct {
+	MaxResults       int
+	RepoURL          string // exact match; "" = all repos including loose files
+	PathPrefix       string // prefix match on document path
+	Basename         string // exact match on document basename
+	Lang             string // exact match on document lang
+	IncludeGenerated bool
+}
+
+// DocumentSearchResult is one chunk hit with the document identity needed for
+// its citation. Trusted travels with every result so the caller can fence
+// untrusted content before it reaches a context window.
+type DocumentSearchResult struct {
+	Chunk     DocumentChunk `json:"chunk"`
+	RepoURL   string        `json:"repo_url,omitempty"`
+	Commit    string        `json:"commit,omitempty"`
+	Path      string        `json:"path"`
+	Basename  string        `json:"basename"`
+	DocLang   string        `json:"doc_lang,omitempty"`
+	Trusted   bool          `json:"trusted"`
+	Dirty     bool          `json:"dirty"`
+	Generated bool          `json:"generated,omitempty"`
+	IsTest    bool          `json:"is_test,omitempty"`
+	Score     float64       `json:"score"`
+	Fallback  bool          `json:"fallback,omitempty"` // matched via decomposed-identifier fallback; ranked below exact hits
+}
+
+// Citation renders the mandatory traceability string for a chunk result:
+// repo@commit path:L120-160, degrading gracefully for loose files.
+func (r DocumentSearchResult) Citation() string {
+	loc := fmt.Sprintf("%s:L%d-%d", r.Path, r.Chunk.LineStart, r.Chunk.LineEnd)
+	if r.RepoURL == "" {
+		return loc
+	}
+	if r.Commit == "" {
+		return r.RepoURL + " " + loc
+	}
+	return r.RepoURL + "@" + r.Commit + " " + loc
+}
+
+// DocumentStore is the document-corpus storage interface. It is separate from
+// Store on purpose: documents are written only by the ingest path (never by
+// model-facing tools), do not participate in Export/Import, and have no
+// supersession -- re-ingest replaces on (repo, path). Postgres implements it;
+// the SQLite backend does not carry the corpus.
+type DocumentStore interface {
+	// UpsertDocument stores or replaces a document and its chunks atomically.
+	// Replacement is keyed on (namespace, user, repo_url, path); the previous
+	// chunk set is deleted, not merged. Basename is derived from doc.Path.
+	// Returns the document id.
+	UpsertDocument(ctx context.Context, doc Document, chunks []DocumentChunk) (int64, error)
+
+	// ListDocuments returns the manifest view of every stored document for a
+	// repo identity. repoURL "" selects loose files (repo_url IS NULL).
+	ListDocuments(ctx context.Context, repoURL string) ([]DocumentInfo, error)
+
+	// DeleteDocuments removes the named documents (chunks cascade) for a repo
+	// identity and reports how many documents were deleted. Used for orphan
+	// cleanup after a manifest sync. repoURL "" selects loose files.
+	DeleteDocuments(ctx context.Context, repoURL string, paths []string) (int64, error)
+
+	// GetDocument returns a document by id, or (nil, nil) when no document
+	// with that id is visible in the caller's scope -- matching Get's
+	// not-found contract.
+	GetDocument(ctx context.Context, id int64) (*Document, error)
+
+	// GetDocumentChunks returns a document's chunks ordered by ordinal.
+	GetDocumentChunks(ctx context.Context, documentID int64) ([]DocumentChunk, error)
+
+	// SearchDocumentChunks is FTS over chunk content: an exact pass first,
+	// then -- only if the exact pass leaves room -- a decomposed-identifier
+	// fallback appended below it (docs/embedding-model-routing.md, measured:
+	// fall back, do not blend).
+	SearchDocumentChunks(ctx context.Context, query string, opts DocumentSearchOpts) ([]DocumentSearchResult, error)
+}

--- a/document.go
+++ b/document.go
@@ -33,8 +33,9 @@ type Document struct {
 	IsTest     bool       `json:"is_test,omitempty"`   // _test.go and equivalents
 
 	ChunkerVersion int             `json:"chunker_version"`
-	Title          string          `json:"title,omitempty"`        // from front matter when present
-	FrontMatter    json.RawMessage `json:"front_matter,omitempty"` // parsed front matter; rigid provenance, not model-writable
+	ChunkStrategy  string          `json:"chunk_strategy,omitempty"` // which chunker cut this file (e.g. "markdown", "go", "line-window" for parse fallback)
+	Title          string          `json:"title,omitempty"`          // from front matter when present
+	FrontMatter    json.RawMessage `json:"front_matter,omitempty"`   // parsed front matter; rigid provenance, not model-writable
 
 	IngestedAt time.Time `json:"ingested_at"`
 }

--- a/pgstore/documents.go
+++ b/pgstore/documents.go
@@ -1,0 +1,569 @@
+package pgstore
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"unicode"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/matthewjhunter/memstore"
+)
+
+// This file implements memstore.DocumentStore: the verbatim document corpus
+// from docs/document-corpus.md. Documents and chunks are written only by the
+// ingest path (never by model-facing tools); user_id and namespace are
+// denormalized onto chunks so the isolation predicate never depends on a join.
+
+// PostgresStore carries the document corpus.
+var _ memstore.DocumentStore = (*PostgresStore)(nil)
+
+// docColumns is the canonical SELECT list for document queries.
+const docColumns = `id, namespace, user_id, repo_url, commit, path, basename, lang, file_sha256, mtime, dirty, trusted, generated, is_test, chunker_version, title, front_matter, ingested_at`
+
+// docChunkColumns is the canonical SELECT list for chunk queries. The search
+// path has its own list because it prefixes with c. and joins document
+// identity columns.
+const docChunkColumns = `id, document_id, ordinal, content, byte_start, byte_end, line_start, line_end, heading_path, heading_level, lang, package, import_path, symbol, receiver, decl_kind, exported, signature, scope_path, imports_used, created_at`
+
+// migrateV5 creates the document corpus tables (docs/document-corpus.md,
+// docs/document-chunking.md, docs/code-chunking.md).
+//
+// The chunk fts column implements the measured decomposed-with-fallback
+// design from docs/embedding-model-routing.md: the exact english tsvector at
+// weight B, plus a decomposed form -- camelCase boundaries and / . _ - :
+// separators split apart, 'simple' config so nothing is stemmed or
+// stopworded -- at weight D. Documents are always decomposed so the tokens
+// exist; queries decompose only on fallback.
+//
+// Loose files (repo_url IS NULL) need their own partial unique index because
+// Postgres treats NULLs as distinct in the main identity index -- without it,
+// loose-file re-ingest accumulates rows instead of replacing
+// (docs/document-ingest.md).
+func (s *PostgresStore) migrateV5(ctx context.Context) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS memstore_documents (
+			id              BIGSERIAL PRIMARY KEY,
+			namespace       TEXT NOT NULL,
+			user_id         BIGINT NOT NULL REFERENCES memstore_users(id),
+			repo_url        TEXT,
+			commit          TEXT NOT NULL DEFAULT '',
+			path            TEXT NOT NULL CHECK (path <> ''),
+			basename        TEXT NOT NULL,
+			lang            TEXT NOT NULL DEFAULT '',
+			file_sha256     BYTEA NOT NULL CHECK (length(file_sha256) = 32),
+			mtime           TIMESTAMPTZ,
+			dirty           BOOLEAN NOT NULL DEFAULT FALSE,
+			trusted         BOOLEAN NOT NULL DEFAULT FALSE,
+			generated       BOOLEAN NOT NULL DEFAULT FALSE,
+			is_test         BOOLEAN NOT NULL DEFAULT FALSE,
+			chunker_version INTEGER NOT NULL,
+			title           TEXT NOT NULL DEFAULT '',
+			front_matter    JSONB,
+			ingested_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_memstore_documents_identity
+			ON memstore_documents (namespace, user_id, repo_url, path)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_memstore_documents_loose
+			ON memstore_documents (namespace, user_id, path) WHERE repo_url IS NULL`,
+		`CREATE INDEX IF NOT EXISTS idx_memstore_documents_user
+			ON memstore_documents (namespace, user_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_memstore_documents_basename
+			ON memstore_documents (namespace, user_id, basename)`,
+
+		`CREATE TABLE IF NOT EXISTS memstore_document_chunks (
+			id            BIGSERIAL PRIMARY KEY,
+			namespace     TEXT NOT NULL,
+			user_id       BIGINT NOT NULL REFERENCES memstore_users(id),
+			document_id   BIGINT NOT NULL REFERENCES memstore_documents(id) ON DELETE CASCADE,
+			ordinal       INTEGER NOT NULL,
+			content       TEXT NOT NULL CHECK (octet_length(content) <= 65536),
+			byte_start    INTEGER NOT NULL,
+			byte_end      INTEGER NOT NULL,
+			line_start    INTEGER NOT NULL,
+			line_end      INTEGER NOT NULL,
+			heading_path  TEXT NOT NULL DEFAULT '',
+			heading_level INTEGER NOT NULL DEFAULT 0,
+			lang          TEXT NOT NULL DEFAULT '',
+			package       TEXT NOT NULL DEFAULT '',
+			import_path   TEXT NOT NULL DEFAULT '',
+			symbol        TEXT NOT NULL DEFAULT '',
+			receiver      TEXT NOT NULL DEFAULT '',
+			decl_kind     TEXT NOT NULL DEFAULT '',
+			exported      BOOLEAN NOT NULL DEFAULT FALSE,
+			signature     TEXT NOT NULL DEFAULT '',
+			scope_path    TEXT NOT NULL DEFAULT '',
+			imports_used  TEXT[],
+			fts           TSVECTOR GENERATED ALWAYS AS (
+				setweight(to_tsvector('english', content), 'B') ||
+				setweight(to_tsvector('simple',
+					regexp_replace(
+						regexp_replace(
+							translate(content, '/._-:', '     '),
+							'([a-z0-9])([A-Z])', '\1 \2', 'g'),
+						'([A-Z]+)([A-Z][a-z])', '\1 \2', 'g')
+				), 'D')
+			) STORED,
+			created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE (document_id, ordinal),
+			CHECK (byte_end > byte_start)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_memstore_document_chunks_fts
+			ON memstore_document_chunks USING GIN (fts)`,
+		`CREATE INDEX IF NOT EXISTS idx_memstore_document_chunks_doc
+			ON memstore_document_chunks (document_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_memstore_document_chunks_user
+			ON memstore_document_chunks (namespace, user_id)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.pool.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("pgstore V5 migration: %w\nstatement: %s", err, stmt)
+		}
+	}
+	return nil
+}
+
+// docOwnerFor resolves the user_id an incoming document should be written
+// under -- the DocumentStore analogue of ownerFor, with the same contract: a
+// scoped store writes its own user's documents and no one else's, a mismatch
+// is rejected rather than silently corrected, and service scope may write for
+// any user but must name one.
+func (s *PostgresStore) docOwnerFor(d memstore.Document) (int64, error) {
+	if s.userID != 0 {
+		if d.UserID != 0 && d.UserID != s.userID {
+			return 0, fmt.Errorf(
+				"pgstore: document carries user_id %d but this store is scoped to user %d: a scoped store cannot write another user's documents",
+				d.UserID, s.userID)
+		}
+		return s.userID, nil
+	}
+	if d.UserID == 0 {
+		return 0, errors.New("pgstore: service-scope document upsert requires an explicit Document.UserID")
+	}
+	return d.UserID, nil
+}
+
+// validateDocumentChunks enforces the span invariants from
+// docs/document-chunking.md before anything is written: ordinals dense from
+// zero, spans non-empty, non-overlapping and monotonically increasing, and
+// content length equal to the span it claims. Coverage of the whole file is
+// deliberately NOT checked -- front matter and inter-block whitespace are
+// skipped by design.
+func validateDocumentChunks(chunks []memstore.DocumentChunk) error {
+	prevEnd := 0
+	for i, c := range chunks {
+		if c.Ordinal != i {
+			return fmt.Errorf("pgstore: chunk %d has ordinal %d; ordinals must be dense from zero", i, c.Ordinal)
+		}
+		if c.ByteEnd <= c.ByteStart {
+			return fmt.Errorf("pgstore: chunk %d span [%d,%d) is empty or inverted", i, c.ByteStart, c.ByteEnd)
+		}
+		if c.ByteStart < prevEnd {
+			return fmt.Errorf("pgstore: chunk %d span [%d,%d) overlaps the previous chunk (ends at %d)", i, c.ByteStart, c.ByteEnd, prevEnd)
+		}
+		if len(c.Content) != c.ByteEnd-c.ByteStart {
+			return fmt.Errorf("pgstore: chunk %d content is %d bytes but its span [%d,%d) claims %d", i, len(c.Content), c.ByteStart, c.ByteEnd, c.ByteEnd-c.ByteStart)
+		}
+		if c.LineStart < 1 || c.LineEnd < c.LineStart {
+			return fmt.Errorf("pgstore: chunk %d has invalid line span %d-%d", i, c.LineStart, c.LineEnd)
+		}
+		prevEnd = c.ByteEnd
+	}
+	return nil
+}
+
+// UpsertDocument stores or replaces a document and its chunks atomically.
+// Replacement is keyed on (namespace, user, repo_url, path) -- commit is
+// deliberately outside the key, so re-ingesting at a new commit replaces the
+// row. The previous chunk set is deleted, never merged.
+func (s *PostgresStore) UpsertDocument(ctx context.Context, doc memstore.Document, chunks []memstore.DocumentChunk) (int64, error) {
+	owner, err := s.docOwnerFor(doc)
+	if err != nil {
+		return 0, err
+	}
+	if doc.Path == "" {
+		return 0, errors.New("pgstore: document path must not be empty")
+	}
+	if len(doc.FileSHA256) != sha256.Size {
+		return 0, fmt.Errorf("pgstore: file_sha256 must be %d bytes, got %d", sha256.Size, len(doc.FileSHA256))
+	}
+	if err := validateDocumentChunks(chunks); err != nil {
+		return 0, err
+	}
+
+	// The conflict target must name the index that actually enforces
+	// uniqueness for this identity: the loose-file case is covered by the
+	// partial index, not the main one (NULLs are distinct there).
+	conflict := `(namespace, user_id, repo_url, path)`
+	if doc.RepoURL == "" {
+		conflict = `(namespace, user_id, path) WHERE repo_url IS NULL`
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("pgstore: UpsertDocument: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var id int64
+	err = tx.QueryRow(ctx,
+		`INSERT INTO memstore_documents
+			(namespace, user_id, repo_url, commit, path, basename, lang, file_sha256,
+			 mtime, dirty, trusted, generated, is_test, chunker_version, title, front_matter)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+		 ON CONFLICT `+conflict+` DO UPDATE SET
+			commit = EXCLUDED.commit,
+			lang = EXCLUDED.lang,
+			file_sha256 = EXCLUDED.file_sha256,
+			mtime = EXCLUDED.mtime,
+			dirty = EXCLUDED.dirty,
+			trusted = EXCLUDED.trusted,
+			generated = EXCLUDED.generated,
+			is_test = EXCLUDED.is_test,
+			chunker_version = EXCLUDED.chunker_version,
+			title = EXCLUDED.title,
+			front_matter = EXCLUDED.front_matter,
+			ingested_at = NOW()
+		 RETURNING id`,
+		s.namespace, owner, nullableText(doc.RepoURL), doc.Commit, doc.Path,
+		path.Base(doc.Path), doc.Lang, doc.FileSHA256, doc.Mtime, doc.Dirty,
+		doc.Trusted, doc.Generated, doc.IsTest, doc.ChunkerVersion, doc.Title,
+		nullableJSON(doc.FrontMatter),
+	).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("pgstore: UpsertDocument: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM memstore_document_chunks WHERE document_id = $1`, id,
+	); err != nil {
+		return 0, fmt.Errorf("pgstore: UpsertDocument: clearing previous chunks: %w", err)
+	}
+
+	if len(chunks) > 0 {
+		b := &pgx.Batch{}
+		for _, c := range chunks {
+			b.Queue(
+				`INSERT INTO memstore_document_chunks
+					(namespace, user_id, document_id, ordinal, content,
+					 byte_start, byte_end, line_start, line_end,
+					 heading_path, heading_level, lang,
+					 package, import_path, symbol, receiver, decl_kind, exported,
+					 signature, scope_path, imports_used)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`,
+				s.namespace, owner, id, c.Ordinal, c.Content,
+				c.ByteStart, c.ByteEnd, c.LineStart, c.LineEnd,
+				c.HeadingPath, c.HeadingLevel, c.Lang,
+				c.Package, c.ImportPath, c.Symbol, c.Receiver, c.DeclKind, c.Exported,
+				c.Signature, c.ScopePath, c.ImportsUsed,
+			)
+		}
+		br := tx.SendBatch(ctx, b)
+		for i := range chunks {
+			if _, err := br.Exec(); err != nil {
+				br.Close()
+				return 0, fmt.Errorf("pgstore: UpsertDocument: inserting chunk %d: %w", i, err)
+			}
+		}
+		if err := br.Close(); err != nil {
+			return 0, fmt.Errorf("pgstore: UpsertDocument: closing chunk batch: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("pgstore: UpsertDocument: commit: %w", err)
+	}
+	return id, nil
+}
+
+// ListDocuments returns the manifest view of every stored document for a repo
+// identity, ordered by path. repoURL "" selects loose files (repo_url IS
+// NULL) -- unlike search, where "" means unfiltered, a manifest is always
+// scoped to one identity.
+func (s *PostgresStore) ListDocuments(ctx context.Context, repoURL string) ([]memstore.DocumentInfo, error) {
+	q := `SELECT id, path, file_sha256, dirty FROM memstore_documents WHERE namespace = $1`
+	args := []any{s.namespace}
+	if repoURL == "" {
+		q += ` AND repo_url IS NULL`
+	} else {
+		args = append(args, repoURL)
+		q += fmt.Sprintf(` AND repo_url = $%d`, len(args))
+	}
+	q, args = s.userPredicate(q, args)
+	q += ` ORDER BY path`
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: ListDocuments: %w", err)
+	}
+	defer rows.Close()
+
+	var infos []memstore.DocumentInfo
+	for rows.Next() {
+		var info memstore.DocumentInfo
+		if err := rows.Scan(&info.ID, &info.Path, &info.FileSHA256, &info.Dirty); err != nil {
+			return nil, fmt.Errorf("pgstore: scanning document info: %w", err)
+		}
+		infos = append(infos, info)
+	}
+	return infos, rows.Err()
+}
+
+// DeleteDocuments removes the named documents for a repo identity; chunks
+// cascade. Returns the number of documents actually deleted -- paths that were
+// never stored (or belong to another user) simply do not count.
+func (s *PostgresStore) DeleteDocuments(ctx context.Context, repoURL string, paths []string) (int64, error) {
+	if len(paths) == 0 {
+		return 0, nil
+	}
+	q := `DELETE FROM memstore_documents WHERE namespace = $1 AND path = ANY($2::text[])`
+	args := []any{s.namespace, paths}
+	if repoURL == "" {
+		q += ` AND repo_url IS NULL`
+	} else {
+		args = append(args, repoURL)
+		q += fmt.Sprintf(` AND repo_url = $%d`, len(args))
+	}
+	q, args = s.userPredicate(q, args)
+
+	ct, err := s.pool.Exec(ctx, q, args...)
+	if err != nil {
+		return 0, fmt.Errorf("pgstore: DeleteDocuments: %w", err)
+	}
+	return ct.RowsAffected(), nil
+}
+
+// GetDocument returns a document by id, or (nil, nil) when no document with
+// that id is visible in the caller's scope.
+func (s *PostgresStore) GetDocument(ctx context.Context, id int64) (*memstore.Document, error) {
+	q := `SELECT ` + docColumns + ` FROM memstore_documents WHERE id = $1 AND namespace = $2`
+	args := []any{id, s.namespace}
+	q, args = s.userPredicate(q, args)
+
+	doc, err := scanDocument(s.pool.QueryRow(ctx, q, args...))
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: GetDocument: %w", err)
+	}
+	return doc, nil
+}
+
+// GetDocumentChunks returns a document's chunks ordered by ordinal. A
+// document outside the caller's scope yields no chunks, matching
+// GetDocument's not-found contract.
+func (s *PostgresStore) GetDocumentChunks(ctx context.Context, documentID int64) ([]memstore.DocumentChunk, error) {
+	q := `SELECT ` + docChunkColumns + ` FROM memstore_document_chunks WHERE document_id = $1 AND namespace = $2`
+	args := []any{documentID, s.namespace}
+	q, args = s.userPredicate(q, args)
+	q += ` ORDER BY ordinal`
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: GetDocumentChunks: %w", err)
+	}
+	defer rows.Close()
+
+	var chunks []memstore.DocumentChunk
+	for rows.Next() {
+		c, err := scanDocumentChunk(rows)
+		if err != nil {
+			return nil, fmt.Errorf("pgstore: scanning chunk: %w", err)
+		}
+		chunks = append(chunks, *c)
+	}
+	return chunks, rows.Err()
+}
+
+// SearchDocumentChunks is FTS over chunk content, per the measured design in
+// docs/embedding-model-routing.md: an exact english pass first; then, only
+// when the exact pass leaves room below MaxResults, a decomposed-identifier
+// pass against the 'simple' weight-D lexemes, appended after the exact hits
+// and marked Fallback. Appending rather than blending is the measured
+// property: the fallback can only fill space an exact match was not using, so
+// queries that already work keep their ranking.
+func (s *PostgresStore) SearchDocumentChunks(ctx context.Context, query string, opts memstore.DocumentSearchOpts) ([]memstore.DocumentSearchResult, error) {
+	if opts.MaxResults <= 0 {
+		opts.MaxResults = 20
+	}
+	tsquery := quoteFTSQuery(query)
+	if tsquery == "" {
+		return nil, nil
+	}
+
+	results, err := s.searchDocChunks(ctx, "english", tsquery, opts, opts.MaxResults, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if room := opts.MaxResults - len(results); room > 0 {
+		if decomposed := decomposeQuery(query); decomposed != "" && decomposed != strings.ToLower(strings.Join(strings.Fields(query), " ")) {
+			exclude := make([]int64, 0, len(results))
+			for _, r := range results {
+				exclude = append(exclude, r.Chunk.ID)
+			}
+			fallback, err := s.searchDocChunks(ctx, "simple", quoteFTSQuery(decomposed), opts, room, exclude)
+			if err != nil {
+				return nil, err
+			}
+			for i := range fallback {
+				fallback[i].Fallback = true
+			}
+			results = append(results, fallback...)
+		}
+	}
+	return results, nil
+}
+
+// searchDocChunks runs one ranked FTS pass over chunks joined to their
+// document identity. The join carries namespace and user_id on both sides:
+// the chunk-side predicate is the isolation boundary (denormalized on
+// purpose), the join condition keeps the document row honest.
+func (s *PostgresStore) searchDocChunks(ctx context.Context, config, tsquery string, opts memstore.DocumentSearchOpts, limit int, excludeIDs []int64) ([]memstore.DocumentSearchResult, error) {
+	var b queryBuilder
+	b.write(`SELECT c.id, c.document_id, c.ordinal, c.content, c.byte_start, c.byte_end, c.line_start, c.line_end,
+			c.heading_path, c.heading_level, c.lang,
+			c.package, c.import_path, c.symbol, c.receiver, c.decl_kind, c.exported, c.signature, c.scope_path, c.imports_used,
+			c.created_at,
+			d.repo_url, d.commit, d.path, d.basename, d.lang, d.trusted, d.dirty, d.generated, d.is_test,
+			ts_rank(c.fts, plainto_tsquery('`+config+`', `, tsquery)
+	b.q += `)) AS rank
+		FROM memstore_document_chunks c
+		JOIN memstore_documents d
+		  ON d.id = c.document_id AND d.namespace = c.namespace AND d.user_id = c.user_id
+		WHERE c.fts @@ plainto_tsquery('` + config + `', `
+	b.write(``, tsquery)
+	b.q += `)`
+
+	b.write(` AND c.namespace = `, s.namespace)
+	s.appendUserFilter(&b, "c.user_id")
+	if !opts.IncludeGenerated {
+		b.q += ` AND NOT d.generated`
+	}
+	if opts.RepoURL != "" {
+		b.write(` AND d.repo_url = `, opts.RepoURL)
+	}
+	if opts.PathPrefix != "" {
+		b.write(` AND starts_with(d.path, `, opts.PathPrefix)
+		b.q += `)`
+	}
+	if opts.Basename != "" {
+		b.write(` AND d.basename = `, opts.Basename)
+	}
+	if opts.Lang != "" {
+		b.write(` AND d.lang = `, opts.Lang)
+	}
+	if len(excludeIDs) > 0 {
+		b.args = append(b.args, excludeIDs)
+		b.q += fmt.Sprintf(` AND NOT (c.id = ANY($%d::bigint[]))`, len(b.args))
+	}
+	b.write(` ORDER BY rank DESC, c.document_id, c.ordinal LIMIT `, limit)
+
+	rows, err := s.pool.Query(ctx, b.q, b.args...)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: document search: %w", err)
+	}
+	defer rows.Close()
+
+	var results []memstore.DocumentSearchResult
+	for rows.Next() {
+		var r memstore.DocumentSearchResult
+		var repoURL *string
+		c := &r.Chunk
+		err := rows.Scan(
+			&c.ID, &c.DocumentID, &c.Ordinal, &c.Content, &c.ByteStart, &c.ByteEnd, &c.LineStart, &c.LineEnd,
+			&c.HeadingPath, &c.HeadingLevel, &c.Lang,
+			&c.Package, &c.ImportPath, &c.Symbol, &c.Receiver, &c.DeclKind, &c.Exported, &c.Signature, &c.ScopePath, &c.ImportsUsed,
+			&c.CreatedAt,
+			&repoURL, &r.Commit, &r.Path, &r.Basename, &r.DocLang, &r.Trusted, &r.Dirty, &r.Generated, &r.IsTest,
+			&r.Score,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("pgstore: scanning document search result: %w", err)
+		}
+		if repoURL != nil {
+			r.RepoURL = *repoURL
+		}
+		results = append(results, r)
+	}
+	return results, rows.Err()
+}
+
+// scanDocument scans one row of docColumns.
+func scanDocument(row scanner) (*memstore.Document, error) {
+	var d memstore.Document
+	var repoURL *string
+	var frontMatter []byte
+	err := row.Scan(
+		&d.ID, &d.Namespace, &d.UserID, &repoURL, &d.Commit, &d.Path, &d.Basename, &d.Lang,
+		&d.FileSHA256, &d.Mtime, &d.Dirty, &d.Trusted, &d.Generated, &d.IsTest,
+		&d.ChunkerVersion, &d.Title, &frontMatter, &d.IngestedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if repoURL != nil {
+		d.RepoURL = *repoURL
+	}
+	if len(frontMatter) > 0 {
+		d.FrontMatter = frontMatter
+	}
+	return &d, nil
+}
+
+// scanDocumentChunk scans one row of docChunkColumns.
+func scanDocumentChunk(row scanner) (*memstore.DocumentChunk, error) {
+	var c memstore.DocumentChunk
+	err := row.Scan(
+		&c.ID, &c.DocumentID, &c.Ordinal, &c.Content, &c.ByteStart, &c.ByteEnd, &c.LineStart, &c.LineEnd,
+		&c.HeadingPath, &c.HeadingLevel, &c.Lang,
+		&c.Package, &c.ImportPath, &c.Symbol, &c.Receiver, &c.DeclKind, &c.Exported, &c.Signature, &c.ScopePath, &c.ImportsUsed,
+		&c.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// nullableText maps "" to SQL NULL. Used for repo_url, where NULL is
+// semantically distinct: it is what the loose-file partial unique index keys
+// on.
+func nullableText(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// docSeparatorReplacer mirrors the separator set in the migrateV5 fts
+// expression: / . _ - : all become spaces.
+var docSeparatorReplacer = strings.NewReplacer("/", " ", ".", " ", "_", " ", "-", " ", ":", " ")
+
+// decomposeQuery applies the same decomposition to a query that migrateV5's
+// fts expression applies to chunk content: separators to spaces, camelCase
+// split at lower-to-upper and acronym boundaries, lowercased with whitespace
+// collapsed. The two must stay in agreement -- query-side tokens that the
+// document side never produced match nothing.
+func decomposeQuery(q string) string {
+	q = docSeparatorReplacer.Replace(q)
+	runes := []rune(q)
+	var b strings.Builder
+	b.Grow(len(q) + 8)
+	for i, r := range runes {
+		if i > 0 {
+			prev := runes[i-1]
+			lowerToUpper := (unicode.IsLower(prev) || unicode.IsDigit(prev)) && unicode.IsUpper(r)
+			acronymEnd := i+1 < len(runes) && unicode.IsUpper(prev) && unicode.IsUpper(r) && unicode.IsLower(runes[i+1])
+			if lowerToUpper || acronymEnd {
+				b.WriteByte(' ')
+			}
+		}
+		b.WriteRune(r)
+	}
+	return strings.ToLower(strings.Join(strings.Fields(b.String()), " "))
+}

--- a/pgstore/documents.go
+++ b/pgstore/documents.go
@@ -22,7 +22,7 @@ import (
 var _ memstore.DocumentStore = (*PostgresStore)(nil)
 
 // docColumns is the canonical SELECT list for document queries.
-const docColumns = `id, namespace, user_id, repo_url, commit, path, basename, lang, file_sha256, mtime, dirty, trusted, generated, is_test, chunker_version, title, front_matter, ingested_at`
+const docColumns = `id, namespace, user_id, repo_url, commit, path, basename, lang, file_sha256, mtime, dirty, trusted, generated, is_test, chunker_version, chunk_strategy, title, front_matter, ingested_at`
 
 // docChunkColumns is the canonical SELECT list for chunk queries. The search
 // path has its own list because it prefixes with c. and joins document
@@ -61,6 +61,7 @@ func (s *PostgresStore) migrateV5(ctx context.Context) error {
 			generated       BOOLEAN NOT NULL DEFAULT FALSE,
 			is_test         BOOLEAN NOT NULL DEFAULT FALSE,
 			chunker_version INTEGER NOT NULL,
+			chunk_strategy  TEXT NOT NULL DEFAULT '',
 			title           TEXT NOT NULL DEFAULT '',
 			front_matter    JSONB,
 			ingested_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -212,8 +213,8 @@ func (s *PostgresStore) UpsertDocument(ctx context.Context, doc memstore.Documen
 	err = tx.QueryRow(ctx,
 		`INSERT INTO memstore_documents
 			(namespace, user_id, repo_url, commit, path, basename, lang, file_sha256,
-			 mtime, dirty, trusted, generated, is_test, chunker_version, title, front_matter)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+			 mtime, dirty, trusted, generated, is_test, chunker_version, chunk_strategy, title, front_matter)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 		 ON CONFLICT `+conflict+` DO UPDATE SET
 			commit = EXCLUDED.commit,
 			lang = EXCLUDED.lang,
@@ -224,14 +225,15 @@ func (s *PostgresStore) UpsertDocument(ctx context.Context, doc memstore.Documen
 			generated = EXCLUDED.generated,
 			is_test = EXCLUDED.is_test,
 			chunker_version = EXCLUDED.chunker_version,
+			chunk_strategy = EXCLUDED.chunk_strategy,
 			title = EXCLUDED.title,
 			front_matter = EXCLUDED.front_matter,
 			ingested_at = NOW()
 		 RETURNING id`,
 		s.namespace, owner, nullableText(doc.RepoURL), doc.Commit, doc.Path,
 		path.Base(doc.Path), doc.Lang, doc.FileSHA256, doc.Mtime, doc.Dirty,
-		doc.Trusted, doc.Generated, doc.IsTest, doc.ChunkerVersion, doc.Title,
-		nullableJSON(doc.FrontMatter),
+		doc.Trusted, doc.Generated, doc.IsTest, doc.ChunkerVersion, doc.ChunkStrategy,
+		doc.Title, nullableJSON(doc.FrontMatter),
 	).Scan(&id)
 	if err != nil {
 		return 0, fmt.Errorf("pgstore: UpsertDocument: %w", err)
@@ -501,7 +503,7 @@ func scanDocument(row scanner) (*memstore.Document, error) {
 	err := row.Scan(
 		&d.ID, &d.Namespace, &d.UserID, &repoURL, &d.Commit, &d.Path, &d.Basename, &d.Lang,
 		&d.FileSHA256, &d.Mtime, &d.Dirty, &d.Trusted, &d.Generated, &d.IsTest,
-		&d.ChunkerVersion, &d.Title, &frontMatter, &d.IngestedAt,
+		&d.ChunkerVersion, &d.ChunkStrategy, &d.Title, &frontMatter, &d.IngestedAt,
 	)
 	if err != nil {
 		return nil, err

--- a/pgstore/documents_test.go
+++ b/pgstore/documents_test.go
@@ -1,0 +1,613 @@
+package pgstore_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/matthewjhunter/memstore"
+	"github.com/matthewjhunter/memstore/pgstore"
+)
+
+// docStore narrows a store to the document interface, failing loudly if the
+// backend stops implementing it.
+func docStore(t *testing.T, s memstore.Store) memstore.DocumentStore {
+	t.Helper()
+	ds, ok := s.(memstore.DocumentStore)
+	if !ok {
+		t.Fatalf("%T does not implement memstore.DocumentStore", s)
+	}
+	return ds
+}
+
+func sha(content string) []byte {
+	h := sha256.Sum256([]byte(content))
+	return h[:]
+}
+
+// testDoc builds a minimal valid document for path in repo (repo may be "").
+func testDoc(repo, path, content string) memstore.Document {
+	return memstore.Document{
+		RepoURL:        repo,
+		Commit:         "abc123",
+		Path:           path,
+		Lang:           "markdown",
+		FileSHA256:     sha(content),
+		ChunkerVersion: 1,
+	}
+}
+
+// chunksOf cuts content into one chunk per line, which satisfies the span
+// invariants (monotonic ordinals, non-overlapping byte ranges) without
+// needing a real chunker.
+func chunksOf(content string) []memstore.DocumentChunk {
+	var chunks []memstore.DocumentChunk
+	start := 0
+	line := 1
+	for _, part := range strings.SplitAfter(content, "\n") {
+		if strings.TrimSpace(part) == "" {
+			start += len(part)
+			line++
+			continue
+		}
+		text := strings.TrimSuffix(part, "\n")
+		chunks = append(chunks, memstore.DocumentChunk{
+			Ordinal:   len(chunks),
+			Content:   text,
+			ByteStart: start,
+			ByteEnd:   start + len(text),
+			LineStart: line,
+			LineEnd:   line,
+		})
+		start += len(part)
+		line++
+	}
+	return chunks
+}
+
+func mustUpsert(t *testing.T, ds memstore.DocumentStore, doc memstore.Document, chunks []memstore.DocumentChunk) int64 {
+	t.Helper()
+	id, err := ds.UpsertDocument(context.Background(), doc, chunks)
+	if err != nil {
+		t.Fatalf("UpsertDocument(%s): %v", doc.Path, err)
+	}
+	return id
+}
+
+func TestDocuments_UpsertAndGet(t *testing.T) {
+	ctx := context.Background()
+	ds := docStore(t, newTestStore(t))
+
+	content := "# Design\nThe auth design delegates to webauth.\n"
+	doc := testDoc("https://github.com/matthewjhunter/memstore", "docs/design.md", content)
+	doc.Title = "Design"
+	doc.FrontMatter = []byte(`{"title":"Design"}`)
+	doc.Trusted = true
+	chunks := chunksOf(content)
+	chunks[1].HeadingPath = "Design"
+	chunks[1].HeadingLevel = 1
+
+	id := mustUpsert(t, ds, doc, chunks)
+	if id == 0 {
+		t.Fatal("expected non-zero document id")
+	}
+
+	got, err := ds.GetDocument(ctx, id)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetDocument returned nil for a stored document")
+	}
+	if got.Basename != "design.md" {
+		t.Errorf("basename not derived from path: got %q", got.Basename)
+	}
+	if got.RepoURL != doc.RepoURL || got.Commit != "abc123" || got.Lang != "markdown" {
+		t.Errorf("identity fields mangled: %+v", got)
+	}
+	if !bytes.Equal(got.FileSHA256, doc.FileSHA256) {
+		t.Errorf("file_sha256 mangled")
+	}
+	if !got.Trusted || got.ChunkerVersion != 1 || got.Title != "Design" {
+		t.Errorf("provenance fields mangled: %+v", got)
+	}
+	if got.IngestedAt.IsZero() {
+		t.Error("ingested_at not stamped")
+	}
+	if got.UserID == 0 {
+		t.Error("user_id not stamped from store scope")
+	}
+
+	stored, err := ds.GetDocumentChunks(ctx, id)
+	if err != nil {
+		t.Fatalf("GetDocumentChunks: %v", err)
+	}
+	if len(stored) != len(chunks) {
+		t.Fatalf("chunk count: got %d want %d", len(stored), len(chunks))
+	}
+	for i, c := range stored {
+		if c.Ordinal != i {
+			t.Errorf("chunk %d: ordinal %d", i, c.Ordinal)
+		}
+		if c.Content != chunks[i].Content {
+			t.Errorf("chunk %d content mangled: %q", i, c.Content)
+		}
+		if c.Content != content[c.ByteStart:c.ByteEnd] {
+			t.Errorf("chunk %d violates the span invariant", i)
+		}
+	}
+	if stored[1].HeadingPath != "Design" || stored[1].HeadingLevel != 1 {
+		t.Errorf("derived context mangled: %+v", stored[1])
+	}
+}
+
+func TestDocuments_GetDocumentMissing(t *testing.T) {
+	ds := docStore(t, newTestStore(t))
+	got, err := ds.GetDocument(context.Background(), 999999)
+	if err != nil {
+		t.Fatalf("GetDocument on missing id: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for missing document, got %+v", got)
+	}
+}
+
+// Re-ingesting the same (repo, path) replaces the row and its chunk set;
+// commit is deliberately outside the uniqueness key.
+func TestDocuments_ReplaceOnReingest(t *testing.T) {
+	ctx := context.Background()
+	ds := docStore(t, newTestStore(t))
+	const repo = "https://github.com/matthewjhunter/memstore"
+
+	v1 := "old content line one\nold content line two\nold line three\n"
+	id1 := mustUpsert(t, ds, testDoc(repo, "README.md", v1), chunksOf(v1))
+
+	v2 := "new content\n"
+	doc2 := testDoc(repo, "README.md", v2)
+	doc2.Commit = "def456"
+	id2 := mustUpsert(t, ds, doc2, chunksOf(v2))
+
+	if id1 != id2 {
+		t.Errorf("re-ingest allocated a new document id (%d -> %d); replace should keep it", id1, id2)
+	}
+
+	infos, err := ds.ListDocuments(ctx, repo)
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 document after re-ingest, got %d", len(infos))
+	}
+	if !bytes.Equal(infos[0].FileSHA256, sha(v2)) {
+		t.Error("manifest sha not updated on re-ingest")
+	}
+
+	got, err := ds.GetDocument(ctx, id2)
+	if err != nil || got == nil {
+		t.Fatalf("GetDocument after re-ingest: %v, %v", got, err)
+	}
+	if got.Commit != "def456" {
+		t.Errorf("commit not updated: %q", got.Commit)
+	}
+
+	chunks, err := ds.GetDocumentChunks(ctx, id2)
+	if err != nil {
+		t.Fatalf("GetDocumentChunks: %v", err)
+	}
+	if len(chunks) != 1 || chunks[0].Content != "new content" {
+		t.Fatalf("old chunk set not replaced: %+v", chunks)
+	}
+}
+
+// The partial-unique-index regression test: Postgres treats NULLs as
+// distinct, so without the WHERE repo_url IS NULL index, loose-file
+// re-ingest accumulates rows instead of replacing (docs/document-ingest.md).
+func TestDocuments_LooseFileReplace(t *testing.T) {
+	ctx := context.Background()
+	ds := docStore(t, newTestStore(t))
+
+	v1 := "loose file first version\n"
+	id1 := mustUpsert(t, ds, testDoc("", "notes/todo.md", v1), chunksOf(v1))
+	v2 := "loose file second version\n"
+	id2 := mustUpsert(t, ds, testDoc("", "notes/todo.md", v2), chunksOf(v2))
+
+	if id1 != id2 {
+		t.Errorf("loose-file re-ingest allocated a new id (%d -> %d)", id1, id2)
+	}
+	infos, err := ds.ListDocuments(ctx, "")
+	if err != nil {
+		t.Fatalf("ListDocuments(loose): %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("loose-file re-ingest accumulated %d rows; want 1", len(infos))
+	}
+}
+
+// The same path may exist both as a repo file and a loose file; they are
+// distinct documents.
+func TestDocuments_LooseAndRepoCoexist(t *testing.T) {
+	ctx := context.Background()
+	ds := docStore(t, newTestStore(t))
+	const repo = "https://github.com/matthewjhunter/memstore"
+
+	c := "same path, different identity\n"
+	mustUpsert(t, ds, testDoc(repo, "README.md", c), chunksOf(c))
+	mustUpsert(t, ds, testDoc("", "README.md", c), chunksOf(c))
+
+	repoDocs, err := ds.ListDocuments(ctx, repo)
+	if err != nil {
+		t.Fatalf("ListDocuments(repo): %v", err)
+	}
+	looseDocs, err := ds.ListDocuments(ctx, "")
+	if err != nil {
+		t.Fatalf("ListDocuments(loose): %v", err)
+	}
+	if len(repoDocs) != 1 || len(looseDocs) != 1 {
+		t.Fatalf("repo/loose identities collided: repo=%d loose=%d", len(repoDocs), len(looseDocs))
+	}
+}
+
+func TestDocuments_DeleteDocuments(t *testing.T) {
+	ctx := context.Background()
+	ds := docStore(t, newTestStore(t))
+	const repo = "https://github.com/matthewjhunter/memstore"
+
+	c := "content\n"
+	keep := mustUpsert(t, ds, testDoc(repo, "keep.md", c), chunksOf(c))
+	gone := mustUpsert(t, ds, testDoc(repo, "gone.md", c), chunksOf(c))
+
+	n, err := ds.DeleteDocuments(ctx, repo, []string{"gone.md", "never-existed.md"})
+	if err != nil {
+		t.Fatalf("DeleteDocuments: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("deleted %d documents, want 1", n)
+	}
+
+	if got, err := ds.GetDocument(ctx, gone); err != nil || got != nil {
+		t.Errorf("deleted document still visible: %+v, %v", got, err)
+	}
+	if got, err := ds.GetDocument(ctx, keep); err != nil || got == nil {
+		t.Errorf("unrelated document deleted: %+v, %v", got, err)
+	}
+	// Chunks cascade with the document.
+	chunks, err := ds.GetDocumentChunks(ctx, gone)
+	if err != nil {
+		t.Fatalf("GetDocumentChunks after delete: %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Errorf("chunks survived document deletion: %d", len(chunks))
+	}
+}
+
+func TestDocuments_UpsertValidation(t *testing.T) {
+	ctx := context.Background()
+	ds := docStore(t, newTestStore(t))
+	c := "content line\n"
+
+	t.Run("empty path", func(t *testing.T) {
+		doc := testDoc("", "", c)
+		if _, err := ds.UpsertDocument(ctx, doc, chunksOf(c)); err == nil {
+			t.Error("expected error for empty path")
+		}
+	})
+	t.Run("bad sha length", func(t *testing.T) {
+		doc := testDoc("", "a.md", c)
+		doc.FileSHA256 = []byte("short")
+		if _, err := ds.UpsertDocument(ctx, doc, chunksOf(c)); err == nil {
+			t.Error("expected error for non-32-byte sha256")
+		}
+	})
+	t.Run("non-dense ordinals", func(t *testing.T) {
+		chunks := chunksOf(c)
+		chunks[0].Ordinal = 5
+		if _, err := ds.UpsertDocument(ctx, testDoc("", "b.md", c), chunks); err == nil {
+			t.Error("expected error for non-dense ordinals")
+		}
+	})
+	t.Run("overlapping spans", func(t *testing.T) {
+		two := "first line here\nsecond line here\n"
+		chunks := chunksOf(two)
+		chunks[1].ByteStart = chunks[0].ByteEnd - 3
+		if _, err := ds.UpsertDocument(ctx, testDoc("", "c.md", two), chunks); err == nil {
+			t.Error("expected error for overlapping spans")
+		}
+	})
+	t.Run("inverted span", func(t *testing.T) {
+		chunks := chunksOf(c)
+		chunks[0].ByteEnd = chunks[0].ByteStart
+		if _, err := ds.UpsertDocument(ctx, testDoc("", "d.md", c), chunks); err == nil {
+			t.Error("expected error for empty/inverted span")
+		}
+	})
+}
+
+func TestDocuments_SearchExact(t *testing.T) {
+	ctx := context.Background()
+	ds := docStore(t, newTestStore(t))
+	const repo = "https://github.com/matthewjhunter/memstore"
+
+	content := "The authentication design delegates every federation decision to webauth.\n"
+	doc := testDoc(repo, "docs/auth.md", content)
+	doc.Trusted = true
+	doc.Dirty = true
+	mustUpsert(t, ds, doc, chunksOf(content))
+
+	results, err := ds.SearchDocumentChunks(ctx, "federation decision", memstore.DocumentSearchOpts{})
+	if err != nil {
+		t.Fatalf("SearchDocumentChunks: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Fallback {
+		t.Error("exact match reported as fallback")
+	}
+	if r.Score <= 0 {
+		t.Error("expected positive score")
+	}
+	if !r.Trusted || !r.Dirty {
+		t.Errorf("trust/dirty flags did not travel: %+v", r)
+	}
+	if r.Path != "docs/auth.md" || r.Basename != "auth.md" || r.RepoURL != repo {
+		t.Errorf("citation identity mangled: %+v", r)
+	}
+	if want := repo + "@abc123 docs/auth.md:L1-1"; r.Citation() != want {
+		t.Errorf("Citation() = %q, want %q", r.Citation(), want)
+	}
+}
+
+// The measured decomposed-with-fallback design: a query like "sqlite.go"
+// finds nothing exactly (the english tsvector token for a mention of
+// "memstore/sqlite.go" is the whole path), so the decomposed fallback fires
+// and appends hits ranked below any exact ones.
+func TestDocuments_SearchDecomposedFallback(t *testing.T) {
+	ctx := context.Background()
+	ds := docStore(t, newTestStore(t))
+	const repo = "https://github.com/matthewjhunter/memstore"
+
+	content := "The single-file backend lives in memstore/sqlite.go for local use.\n"
+	mustUpsert(t, ds, testDoc(repo, "docs/backends.md", content), chunksOf(content))
+
+	results, err := ds.SearchDocumentChunks(ctx, "sqlite.go", memstore.DocumentSearchOpts{})
+	if err != nil {
+		t.Fatalf("SearchDocumentChunks: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("decomposed fallback did not fire; identifier query found nothing")
+	}
+	if !results[0].Fallback {
+		t.Error("fallback hit not marked Fallback")
+	}
+
+	// A query that hits exactly must not fire the fallback flag.
+	exact, err := ds.SearchDocumentChunks(ctx, "single-file backend", memstore.DocumentSearchOpts{})
+	if err != nil {
+		t.Fatalf("SearchDocumentChunks(exact): %v", err)
+	}
+	if len(exact) == 0 || exact[0].Fallback {
+		t.Errorf("exact query mis-ranked: %+v", exact)
+	}
+}
+
+func TestDocuments_SearchFilters(t *testing.T) {
+	ctx := context.Background()
+	ds := docStore(t, newTestStore(t))
+	repoA := "https://github.com/matthewjhunter/memstore"
+	repoB := "https://github.com/matthewjhunter/majordomo"
+
+	c1 := "shared keyword xylophone in memstore\n"
+	c2 := "shared keyword xylophone in majordomo\n"
+	mustUpsert(t, ds, testDoc(repoA, "docs/a.md", c1), chunksOf(c1))
+	mustUpsert(t, ds, testDoc(repoB, "notes/b.md", c2), chunksOf(c2))
+
+	gen := "shared keyword xylophone in generated code\n"
+	genDoc := testDoc(repoA, "gen/zz_generated.md", gen)
+	genDoc.Generated = true
+	mustUpsert(t, ds, genDoc, chunksOf(gen))
+
+	t.Run("unfiltered excludes generated", func(t *testing.T) {
+		results, err := ds.SearchDocumentChunks(ctx, "xylophone", memstore.DocumentSearchOpts{})
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(results) != 2 {
+			t.Fatalf("got %d results, want 2 (generated excluded by default)", len(results))
+		}
+	})
+	t.Run("IncludeGenerated", func(t *testing.T) {
+		results, err := ds.SearchDocumentChunks(ctx, "xylophone", memstore.DocumentSearchOpts{IncludeGenerated: true})
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(results) != 3 {
+			t.Fatalf("got %d results, want 3 with IncludeGenerated", len(results))
+		}
+	})
+	t.Run("repo filter", func(t *testing.T) {
+		results, err := ds.SearchDocumentChunks(ctx, "xylophone", memstore.DocumentSearchOpts{RepoURL: repoB})
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(results) != 1 || results[0].RepoURL != repoB {
+			t.Fatalf("repo filter leaked: %+v", results)
+		}
+	})
+	t.Run("basename filter", func(t *testing.T) {
+		results, err := ds.SearchDocumentChunks(ctx, "xylophone", memstore.DocumentSearchOpts{Basename: "a.md"})
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(results) != 1 || results[0].Basename != "a.md" {
+			t.Fatalf("basename filter leaked: %+v", results)
+		}
+	})
+	t.Run("path prefix filter", func(t *testing.T) {
+		results, err := ds.SearchDocumentChunks(ctx, "xylophone", memstore.DocumentSearchOpts{PathPrefix: "notes/"})
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(results) != 1 || results[0].Path != "notes/b.md" {
+			t.Fatalf("path prefix filter leaked: %+v", results)
+		}
+	})
+}
+
+// Documents are user-scoped: every read and write path carries the owner
+// predicate, matching the fact-side isolation battery.
+func TestDocuments_UserIsolation(t *testing.T) {
+	ctx := context.Background()
+	base := newTestStore(t)
+
+	pool, err := pgxpool.New(ctx, testDSN(t))
+	if err != nil {
+		t.Fatalf("connecting to postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	uidA, err := pgstore.EnsureUser(ctx, pool, "test", "doc-iso-a")
+	if err != nil {
+		t.Fatalf("EnsureUser: %v", err)
+	}
+	uidB, err := pgstore.EnsureUser(ctx, pool, "test", "doc-iso-b")
+	if err != nil {
+		t.Fatalf("EnsureUser: %v", err)
+	}
+	sa, err := base.ForUser(uidA)
+	if err != nil {
+		t.Fatalf("ForUser(A): %v", err)
+	}
+	sb, err := base.ForUser(uidB)
+	if err != nil {
+		t.Fatalf("ForUser(B): %v", err)
+	}
+	a, b := docStore(t, sa), docStore(t, sb)
+	const repo = "https://github.com/matthewjhunter/memstore"
+
+	content := "user A's private corpus content mentioning quixotic\n"
+	docID := mustUpsert(t, a, testDoc(repo, "private.md", content), chunksOf(content))
+
+	t.Run("GetDocument invisible cross-user", func(t *testing.T) {
+		got, err := b.GetDocument(ctx, docID)
+		if err != nil {
+			t.Fatalf("GetDocument: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("user B can read user A's document: %+v", got)
+		}
+	})
+	t.Run("GetDocumentChunks invisible cross-user", func(t *testing.T) {
+		chunks, err := b.GetDocumentChunks(ctx, docID)
+		if err != nil {
+			t.Fatalf("GetDocumentChunks: %v", err)
+		}
+		if len(chunks) != 0 {
+			t.Fatalf("user B can read user A's chunks: %d", len(chunks))
+		}
+	})
+	t.Run("ListDocuments invisible cross-user", func(t *testing.T) {
+		infos, err := b.ListDocuments(ctx, repo)
+		if err != nil {
+			t.Fatalf("ListDocuments: %v", err)
+		}
+		if len(infos) != 0 {
+			t.Fatalf("user B sees user A's manifest: %+v", infos)
+		}
+	})
+	t.Run("Search invisible cross-user", func(t *testing.T) {
+		results, err := b.SearchDocumentChunks(ctx, "quixotic", memstore.DocumentSearchOpts{})
+		if err != nil {
+			t.Fatalf("SearchDocumentChunks: %v", err)
+		}
+		if len(results) != 0 {
+			t.Fatalf("user B can search user A's corpus: %+v", results)
+		}
+	})
+	t.Run("Delete cannot cross users", func(t *testing.T) {
+		n, err := b.DeleteDocuments(ctx, repo, []string{"private.md"})
+		if err != nil {
+			t.Fatalf("DeleteDocuments: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("user B deleted %d of user A's documents", n)
+		}
+		if got, err := a.GetDocument(ctx, docID); err != nil || got == nil {
+			t.Fatalf("user A's document damaged by cross-user delete: %+v, %v", got, err)
+		}
+	})
+	t.Run("same path is a distinct document per user", func(t *testing.T) {
+		other := "user B's own file at the same path\n"
+		mustUpsert(t, b, testDoc(repo, "private.md", other), chunksOf(other))
+		aDocs, err := a.ListDocuments(ctx, repo)
+		if err != nil {
+			t.Fatalf("ListDocuments(A): %v", err)
+		}
+		if len(aDocs) != 1 || !bytes.Equal(aDocs[0].FileSHA256, sha(content)) {
+			t.Fatalf("user B's upsert replaced user A's document: %+v", aDocs)
+		}
+	})
+	t.Run("scoped store cannot write another user's document", func(t *testing.T) {
+		doc := testDoc(repo, "forged.md", content)
+		doc.UserID = uidA
+		if _, err := b.UpsertDocument(ctx, doc, chunksOf(content)); err == nil {
+			t.Fatal("scoped store accepted a document claiming another user's id")
+		}
+	})
+}
+
+// Service scope (userID 0) sees all users but must name a real owner on write,
+// mirroring ownerFor.
+func TestDocuments_ServiceScope(t *testing.T) {
+	ctx := context.Background()
+	base := newTestStore(t)
+
+	pool, err := pgxpool.New(ctx, testDSN(t))
+	if err != nil {
+		t.Fatalf("connecting to postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	uidA, err := pgstore.EnsureUser(ctx, pool, "test", "doc-svc-a")
+	if err != nil {
+		t.Fatalf("EnsureUser: %v", err)
+	}
+	svc := base.ServiceScope()
+	const repo = "https://github.com/matthewjhunter/memstore"
+	content := "service scope content\n"
+
+	t.Run("write without an owner is rejected", func(t *testing.T) {
+		if _, err := svc.UpsertDocument(ctx, testDoc(repo, "svc.md", content), chunksOf(content)); err == nil {
+			t.Fatal("service-scope upsert without an explicit UserID succeeded")
+		}
+	})
+	t.Run("write with an explicit owner lands under that owner", func(t *testing.T) {
+		doc := testDoc(repo, "svc.md", content)
+		doc.UserID = uidA
+		id, err := svc.UpsertDocument(ctx, doc, chunksOf(content))
+		if err != nil {
+			t.Fatalf("service-scope upsert: %v", err)
+		}
+		var owner int64
+		if err := pool.QueryRow(ctx,
+			`SELECT user_id FROM memstore_documents WHERE id = $1`, id,
+		).Scan(&owner); err != nil {
+			t.Fatalf("reading document owner: %v", err)
+		}
+		if owner != uidA {
+			t.Fatalf("document owner = %d, want %d", owner, uidA)
+		}
+		var chunkOwner int64
+		if err := pool.QueryRow(ctx,
+			`SELECT DISTINCT user_id FROM memstore_document_chunks WHERE document_id = $1`, id,
+		).Scan(&chunkOwner); err != nil {
+			t.Fatalf("reading chunk owner: %v", err)
+		}
+		if chunkOwner != uidA {
+			t.Fatalf("chunk owner = %d, want %d (denormalized owner must match)", chunkOwner, uidA)
+		}
+	})
+}

--- a/pgstore/documents_test.go
+++ b/pgstore/documents_test.go
@@ -83,6 +83,7 @@ func TestDocuments_UpsertAndGet(t *testing.T) {
 
 	content := "# Design\nThe auth design delegates to webauth.\n"
 	doc := testDoc("https://github.com/matthewjhunter/memstore", "docs/design.md", content)
+	doc.ChunkStrategy = "markdown"
 	doc.Title = "Design"
 	doc.FrontMatter = []byte(`{"title":"Design"}`)
 	doc.Trusted = true
@@ -111,7 +112,7 @@ func TestDocuments_UpsertAndGet(t *testing.T) {
 	if !bytes.Equal(got.FileSHA256, doc.FileSHA256) {
 		t.Errorf("file_sha256 mangled")
 	}
-	if !got.Trusted || got.ChunkerVersion != 1 || got.Title != "Design" {
+	if !got.Trusted || got.ChunkerVersion != 1 || got.Title != "Design" || got.ChunkStrategy != "markdown" {
 		t.Errorf("provenance fields mangled: %+v", got)
 	}
 	if got.IngestedAt.IsZero() {

--- a/pgstore/session_store_test.go
+++ b/pgstore/session_store_test.go
@@ -46,6 +46,8 @@ func newTestSessionStore(t *testing.T) (*pgstore.SessionStore, *pgxpool.Pool) {
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_document_chunks CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_documents CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 
 	embedder := &mockEmbedder{dim: 4}
@@ -329,6 +331,8 @@ func TestSessionConformance_SessionIsolation(t *testing.T) {
 			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_document_chunks CASCADE`)
+			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_documents CASCADE`)
 			pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 
 			embedder := &mockEmbedder{dim: 4}

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -17,7 +17,7 @@ import (
 	pgvector "github.com/pgvector/pgvector-go"
 )
 
-const schemaVersion = 4
+const schemaVersion = 5
 
 // factColumns is the canonical SELECT list for fact queries.
 // searchFTS has its own column list because it joins and adds ts_rank.
@@ -374,6 +374,12 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 
 	if version < 4 {
 		if err := s.migrateV4(ctx); err != nil {
+			return err
+		}
+	}
+
+	if version < 5 {
+		if err := s.migrateV5(ctx); err != nil {
 			return err
 		}
 	}

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -77,6 +77,8 @@ func newTestStoreNS(t *testing.T, ns string) *pgstore.PostgresStore {
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_document_chunks CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_documents CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 
 	embedder := &mockEmbedder{dim: 4}
@@ -132,6 +134,8 @@ func newTestStoreWithEmbedder(t *testing.T, embedder embedding.Embedder, dim, ca
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_document_chunks CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_documents CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 
 	// Migrate first (expected to fail at user resolution on a fresh DB),
@@ -586,6 +590,8 @@ func TestHistory_CycleTerminates(t *testing.T) {
 	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_document_chunks CASCADE`)
+	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_documents CASCADE`)
 	rawPool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 
 	// Fresh-DB construction fails at user resolution until an identity is
@@ -880,6 +886,8 @@ func TestConformance(t *testing.T) {
 		pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 		pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 		pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+		pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_document_chunks CASCADE`)
+		pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_documents CASCADE`)
 		pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 		return pool
 	}
@@ -1201,6 +1209,8 @@ func dropAll(ctx context.Context, pool *pgxpool.Pool) {
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_facts CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_version CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_document_chunks CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_documents CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 }
 
@@ -1569,13 +1579,13 @@ func TestInitIdentity(t *testing.T) {
 		t.Error("memstore_facts_user_id_fkey not found after InitIdentity")
 	}
 
-	// The schema version was recorded as 4.
+	// The current schema version was recorded.
 	var version int
 	if err := pool.QueryRow(ctx, `SELECT version FROM memstore_version`).Scan(&version); err != nil {
 		t.Fatalf("reading schema version: %v", err)
 	}
-	if version != 4 {
-		t.Errorf("schema version = %d, want 4 after InitIdentity", version)
+	if version != 5 {
+		t.Errorf("schema version = %d, want 5 after InitIdentity", version)
 	}
 
 	// Insert must succeed (non-zero userID bound to the store).

--- a/pgstore/tokens_test.go
+++ b/pgstore/tokens_test.go
@@ -27,6 +27,8 @@ func newTokenStore(t *testing.T) (*pgstore.TokenStore, int64) {
 
 	// Drop in reverse dependency order.
 	pool.Exec(ctx, `DROP TABLE IF EXISTS api_tokens`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_document_chunks CASCADE`)
+	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_documents CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_users CASCADE`)
 	pool.Exec(ctx, `DROP TABLE IF EXISTS memstore_meta CASCADE`)
 


### PR DESCRIPTION
First implementation increment of the document corpus (docs/document-corpus.md): root types + the Postgres storage layer.

## What's here

- **Root package**: `Document`, `DocumentChunk`, `DocumentInfo`, search opts/result with mandatory `Citation()`, and the `DocumentStore` interface -- deliberately separate from `Store` (ingest-path writes only, no transfer, no supersession).
- **pgstore migrateV5**: `memstore_documents` + `memstore_document_chunks`, owner denormalized onto chunks, partial unique index for loose files (the NULL-repo_url replace bug caught in the design review, now regression-tested).
- **FTS**: chunk tsvector is english weight B plus decomposed (camelCase + `/ . _ - :`) `simple` weight D; search runs exact-then-fallback, appending decomposed hits below exact ones per the measured fall-back-don't-blend result.
- **Owner enforcement**: `docOwnerFor` mirrors `ownerFor`; isolation tests cover Get/List/Search/Delete/Upsert cross-user plus service scope.

## Not here (next increments)

Chunkers (goldmark, go/ast) with the import-graph no-Generator test, the two HTTP endpoints under `ingest` scope, and the `memstore ingest` CLI.

Tests run against live Postgres (`MEMSTORE_TEST_PG`); the whole battery is green locally with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
