### PR TITLE
Document ingest and search HTTP endpoints

### DIFF
--- a/httpapi/documents.go
+++ b/httpapi/documents.go
@@ -1,0 +1,403 @@
+package httpapi
+
+// Document ingest endpoints (docs/document-ingest.md). Two write routes
+// under the ingest scope -- the manifest sync and the per-file upload -- plus
+// a read-scoped search. The daemon owns type routing and the chunkers; the
+// client ships bytes and assertions. Nothing here may invoke a model: the
+// chunkers are import-graph-tested against that, and these handlers only
+// hash, route, chunk, verify, and store.
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/matthewjhunter/memstore"
+	"github.com/matthewjhunter/memstore/chunk"
+	"github.com/matthewjhunter/memstore/chunk/gosrc"
+	"github.com/matthewjhunter/memstore/chunk/markdown"
+)
+
+// maxDocumentBytes is the per-file size cap, applied at manifest time (so
+// oversized files never cross the wire) and re-checked at upload.
+const maxDocumentBytes = 1 << 20 // 1 MiB
+
+// The daemon's chunkers. Stateless and safe for concurrent use.
+var (
+	markdownChunker   = markdown.New()
+	goChunker         = gosrc.New()
+	lineWindowChunker = chunk.NewLineWindow()
+)
+
+// textExtensions route to the line-window fallback: languages without a
+// structural chunker yet, and plain text. lang is recorded as the extension.
+var textExtensions = map[string]bool{
+	"txt": true, "text": true, "rst": true, "adoc": true, "org": true,
+	"yaml": true, "yml": true, "toml": true, "ini": true, "cfg": true, "conf": true,
+	"sh": true, "bash": true, "sql": true, "proto": true,
+	"py": true, "js": true, "ts": true, "rb": true, "rs": true, "java": true,
+	"c": true, "h": true, "cpp": true, "hpp": true, "css": true, "html": true,
+	"xml": true, "json": true,
+}
+
+// excludedDirs are path segments whose subtrees are never ingested. Applied
+// daemon-side at manifest time: an exclusion the daemon never saw would be
+// one it could not verify (docs/document-ingest.md).
+var excludedDirs = map[string]bool{
+	"vendor":       true,
+	"node_modules": true,
+	".git":         true,
+}
+
+// routeForPath maps an extension to its chunker and lang. The table lives
+// here, on the daemon, because the daemon owns the chunkers and
+// chunker_version; a client-side copy would split that authority.
+func routeForPath(p string) (chunk.Chunker, string, bool) {
+	ext := strings.ToLower(strings.TrimPrefix(path.Ext(p), "."))
+	switch ext {
+	case "md", "markdown":
+		return markdownChunker, "markdown", true
+	case "go":
+		return goChunker, "go", true
+	}
+	if textExtensions[ext] {
+		return lineWindowChunker, ext, true
+	}
+	return nil, "", false
+}
+
+// validDocPath accepts clean, relative, forward-slash paths -- what
+// `git ls-files` and a rooted WalkDir emit. Everything else is rejected
+// outright; paths are storage keys, and a key like "../x" is a lie about
+// where the file lives.
+func validDocPath(p string) bool {
+	if p == "" || strings.HasPrefix(p, "/") || strings.Contains(p, "\\") {
+		return false
+	}
+	if clean := path.Clean(p); clean != p {
+		return false
+	}
+	return p != ".." && !strings.HasPrefix(p, "../")
+}
+
+// skipReason reports why a manifest entry is not ingestable, or "" when it
+// is. This is the server-side filter: it runs before any bytes move.
+func skipReason(p string, size int64) string {
+	for _, seg := range strings.Split(p, "/") {
+		if excludedDirs[seg] {
+			return "excluded directory: " + seg
+		}
+	}
+	if _, _, ok := routeForPath(p); !ok {
+		ext := path.Ext(p)
+		if ext == "" {
+			return "no extension"
+		}
+		return "unroutable extension: " + ext
+	}
+	if size > maxDocumentBytes {
+		return fmt.Sprintf("size %d exceeds cap %d", size, maxDocumentBytes)
+	}
+	return ""
+}
+
+// docStore narrows the per-request scoped store to the document corpus
+// interface. The SQLite backend does not carry the corpus.
+func (h *Handler) docStore(w http.ResponseWriter, r *http.Request) (memstore.DocumentStore, bool) {
+	ds, ok := storeFromCtx(r.Context(), h.store).(memstore.DocumentStore)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "this backend does not carry the document corpus (Postgres required)")
+		return nil, false
+	}
+	return ds, true
+}
+
+// handleDocumentSync implements POST /v1/documents/sync: the client sends
+// the repo identity and one {path, sha256, size} entry per enumerated file;
+// the daemon answers with what it needs, what it refuses (with reasons), and
+// which stored documents were orphaned by the manifest -- those are deleted
+// here, since a path absent from the manifest is a file that no longer
+// exists. Replace-on-(repo,path) can never notice deletions on its own; the
+// manifest's complement is what closes that hole.
+func (h *Handler) handleDocumentSync(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		RepoURL string `json:"repo_url"`
+		Entries []struct {
+			Path   string `json:"path"`
+			SHA256 string `json:"sha256"`
+			Size   int64  `json:"size"`
+		} `json:"entries"`
+	}
+	if !readJSON(r, w, &input) {
+		return
+	}
+	ds, ok := h.docStore(w, r)
+	if !ok {
+		return
+	}
+
+	type skipEntry struct {
+		Path   string `json:"path"`
+		Reason string `json:"reason"`
+	}
+
+	stored, err := ds.ListDocuments(r.Context(), input.RepoURL)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	storedSHA := make(map[string][]byte, len(stored))
+	for _, info := range stored {
+		storedSHA[info.Path] = info.FileSHA256
+	}
+
+	need := []string{}
+	skip := []skipEntry{}
+	unchanged := 0
+	seen := make(map[string]bool, len(input.Entries))
+	for _, e := range input.Entries {
+		if !validDocPath(e.Path) {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid path %q: paths must be clean, relative, forward-slash", e.Path))
+			return
+		}
+		if seen[e.Path] {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("duplicate manifest entry %q", e.Path))
+			return
+		}
+		seen[e.Path] = true
+
+		if reason := skipReason(e.Path, e.Size); reason != "" {
+			skip = append(skip, skipEntry{Path: e.Path, Reason: reason})
+			continue
+		}
+		sha, err := hex.DecodeString(e.SHA256)
+		if err != nil || len(sha) != sha256.Size {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("entry %q: sha256 must be 64 hex characters", e.Path))
+			return
+		}
+		if have, ok := storedSHA[e.Path]; ok && bytes.Equal(have, sha) {
+			unchanged++
+			continue
+		}
+		need = append(need, e.Path)
+	}
+
+	// Orphans: stored paths the manifest no longer mentions. Skipped entries
+	// count as mentioned -- the file still exists, it is just not ingestable.
+	orphaned := []string{}
+	for _, info := range stored {
+		if !seen[info.Path] {
+			orphaned = append(orphaned, info.Path)
+		}
+	}
+	if len(orphaned) > 0 {
+		if _, err := ds.DeleteDocuments(r.Context(), input.RepoURL, orphaned); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"need":      need,
+		"skip":      skip,
+		"orphaned":  orphaned,
+		"unchanged": unchanged,
+	})
+}
+
+// handleDocumentUpload implements POST /v1/documents: one file's bytes plus
+// the client's asserted git metadata. The daemon hashes and verifies,
+// routes, chunks, re-verifies every span against the bytes, and stores.
+// Content travels base64-encoded so a non-UTF-8 file fails loudly here
+// rather than being silently mangled by JSON string decoding.
+func (h *Handler) handleDocumentUpload(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		RepoURL    string     `json:"repo_url"`
+		Commit     string     `json:"commit"`
+		Path       string     `json:"path"`
+		ContentB64 string     `json:"content_b64"`
+		SHA256     string     `json:"sha256"`
+		Mtime      *time.Time `json:"mtime"`
+		Dirty      bool       `json:"dirty"`
+	}
+	if !readJSON(r, w, &input) {
+		return
+	}
+	ds, ok := h.docStore(w, r)
+	if !ok {
+		return
+	}
+	if !validDocPath(input.Path) {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid path %q: paths must be clean, relative, forward-slash", input.Path))
+		return
+	}
+
+	content, err := base64.StdEncoding.DecodeString(input.ContentB64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "content_b64 is not valid base64")
+		return
+	}
+	if reason := skipReason(input.Path, int64(len(content))); reason != "" {
+		writeError(w, http.StatusUnprocessableEntity, "not ingestable: "+reason)
+		return
+	}
+
+	// Verify the asserted hash against the actual bytes. The stored hash is
+	// what makes the span invariant checkable later; storing an unverified
+	// assertion would poison that.
+	asserted, err := hex.DecodeString(input.SHA256)
+	if err != nil || len(asserted) != sha256.Size {
+		writeError(w, http.StatusBadRequest, "sha256 must be 64 hex characters")
+		return
+	}
+	actual := sha256.Sum256(content)
+	if !bytes.Equal(asserted, actual[:]) {
+		writeError(w, http.StatusUnprocessableEntity, "sha256 does not match the uploaded bytes")
+		return
+	}
+
+	// The corpus is text: content lands in a TEXT column and comes back into
+	// context windows. Binary that slipped past extension routing stops here.
+	if !utf8.Valid(content) || bytes.IndexByte(content, 0) >= 0 {
+		writeError(w, http.StatusUnprocessableEntity, "content is not valid UTF-8 text")
+		return
+	}
+
+	chunker, lang, _ := routeForPath(input.Path)
+	res, err := chunker.Chunk(input.Path, content)
+	if errors.Is(err, gosrc.ErrUnparseable) {
+		// Work in progress and repos pinned to newer toolchains still
+		// contain searchable text; refusing them would leave silent holes.
+		// The recorded strategy is what makes the fallback visible and
+		// retryable (docs/code-chunking.md).
+		chunker = lineWindowChunker
+		res, err = chunker.Chunk(input.Path, content)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "chunking failed: "+err.Error())
+		return
+	}
+
+	chunks := make([]memstore.DocumentChunk, 0, len(res.Chunks))
+	for _, c := range res.Chunks {
+		// Re-verify the verbatim invariant against the actual bytes before
+		// anything is stored. The chunkers' own tests hold this too; this
+		// check is what makes it a property of the corpus rather than of
+		// the test suite.
+		if c.ByteStart < 0 || c.ByteEnd > len(content) || string(content[c.ByteStart:c.ByteEnd]) != c.Content {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("chunk %d failed span verification", c.Ordinal))
+			return
+		}
+		chunks = append(chunks, memstore.DocumentChunk{
+			Ordinal:      c.Ordinal,
+			Content:      c.Content,
+			ByteStart:    c.ByteStart,
+			ByteEnd:      c.ByteEnd,
+			LineStart:    c.LineStart,
+			LineEnd:      c.LineEnd,
+			HeadingPath:  c.HeadingPath,
+			HeadingLevel: c.HeadingLevel,
+			Lang:         c.Lang,
+			Package:      c.Package,
+			ImportPath:   c.ImportPath,
+			Symbol:       c.Symbol,
+			Receiver:     c.Receiver,
+			DeclKind:     c.DeclKind,
+			Exported:     c.Exported,
+			Signature:    c.Signature,
+			ScopePath:    c.ScopePath,
+			ImportsUsed:  c.ImportsUsed,
+		})
+	}
+
+	doc := memstore.Document{
+		RepoURL:    input.RepoURL,
+		Commit:     input.Commit,
+		Path:       input.Path,
+		Lang:       lang,
+		FileSHA256: actual[:],
+		Mtime:      input.Mtime,
+		Dirty:      input.Dirty,
+		// Trusted stays false until the per-user repo policy table exists;
+		// untrusted is the safe default and untrusted chunks come back
+		// fenced (docs/document-corpus.md).
+		Trusted:        false,
+		Generated:      res.Generated,
+		IsTest:         strings.HasSuffix(path.Base(input.Path), "_test.go"),
+		ChunkerVersion: chunker.Version(),
+		ChunkStrategy:  chunker.Strategy(),
+		Title:          res.Title,
+		FrontMatter:    res.FrontMatter,
+	}
+
+	id, err := ds.UpsertDocument(r.Context(), doc, chunks)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"id":       id,
+		"chunks":   len(chunks),
+		"strategy": chunker.Strategy(),
+	})
+}
+
+// handleDocumentSearch implements POST /v1/documents/search: the read side
+// of the corpus. Results are never merged with fact results -- separate
+// index, separate tool -- and every hit carries its citation.
+func (h *Handler) handleDocumentSearch(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Query            string `json:"query"`
+		MaxResults       int    `json:"max_results"`
+		RepoURL          string `json:"repo_url"`
+		PathPrefix       string `json:"path_prefix"`
+		Basename         string `json:"basename"`
+		Lang             string `json:"lang"`
+		IncludeGenerated bool   `json:"include_generated"`
+	}
+	if !readJSON(r, w, &input) {
+		return
+	}
+	if input.Query == "" {
+		writeError(w, http.StatusBadRequest, "query is required")
+		return
+	}
+	ds, ok := h.docStore(w, r)
+	if !ok {
+		return
+	}
+
+	results, err := ds.SearchDocumentChunks(r.Context(), input.Query, memstore.DocumentSearchOpts{
+		MaxResults:       input.MaxResults,
+		RepoURL:          input.RepoURL,
+		PathPrefix:       input.PathPrefix,
+		Basename:         input.Basename,
+		Lang:             input.Lang,
+		IncludeGenerated: input.IncludeGenerated,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	type hit struct {
+		memstore.DocumentSearchResult
+		Citation string `json:"citation"`
+	}
+	hits := make([]hit, 0, len(results))
+	for _, res := range results {
+		hits = append(hits, hit{DocumentSearchResult: res, Citation: res.Citation()})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"query":   input.Query,
+		"results": hits,
+	})
+}

--- a/httpapi/documents_test.go
+++ b/httpapi/documents_test.go
@@ -1,0 +1,409 @@
+package httpapi_test
+
+// Endpoint battery for the document ingest routes. Runs against a private
+// ephemeral Postgres database (gate: MEMSTORE_TEST_PG), reusing the
+// isolation fixture's pool bootstrap.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/matthewjhunter/memstore/httpapi"
+	"github.com/matthewjhunter/memstore/pgstore"
+)
+
+type docFixture struct {
+	handler     http.Handler
+	pool        *pgxpool.Pool
+	tokens      *pgstore.TokenStore
+	ingestToken string
+	readToken   string
+	writeToken  string // write scope only: must NOT reach ingest routes
+}
+
+func newDocFixture(t *testing.T) *docFixture {
+	t.Helper()
+	ctx := context.Background()
+	pool := newIsolationPool(t)
+	emb := &mockEmbedder{dim: 4}
+
+	if _, err := pgstore.New(ctx, pool, emb, "docs", 4, 0); err != nil && !strings.Contains(err.Error(), "tier3-init") {
+		t.Fatalf("pgstore.New (bootstrap): %v", err)
+	}
+	if err := pgstore.InitIdentity(ctx, pool, "docs", "doc-default"); err != nil {
+		t.Fatalf("InitIdentity: %v", err)
+	}
+	store, err := pgstore.New(ctx, pool, emb, "docs", 4, 0)
+	if err != nil {
+		t.Fatalf("pgstore.New: %v", err)
+	}
+
+	uid, err := pgstore.EnsureUser(ctx, pool, "docs", "doc-user")
+	if err != nil {
+		t.Fatalf("EnsureUser: %v", err)
+	}
+	ts, err := pgstore.NewTokenStore(ctx, pool)
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	ingestTok, err := ts.Issue(ctx, "doc-user@ingest", pgstore.IssueOpts{UserID: uid, Scopes: []string{"ingest"}})
+	if err != nil {
+		t.Fatalf("Issue ingest token: %v", err)
+	}
+	readTok, err := ts.Issue(ctx, "doc-user@read", pgstore.IssueOpts{UserID: uid, Scopes: []string{"read"}})
+	if err != nil {
+		t.Fatalf("Issue read token: %v", err)
+	}
+	writeTok, err := ts.Issue(ctx, "doc-user@write", pgstore.IssueOpts{UserID: uid, Scopes: []string{"write"}})
+	if err != nil {
+		t.Fatalf("Issue write token: %v", err)
+	}
+
+	h := httpapi.New(store, emb, "", httpapi.WithTokenVerifier(isoTokenVerifier{ts: ts}))
+	return &docFixture{handler: h, pool: pool, tokens: ts, ingestToken: ingestTok, readToken: readTok, writeToken: writeTok}
+}
+
+func (f *docFixture) do(t *testing.T, token, method, path string, body any) (*httptest.ResponseRecorder, map[string]json.RawMessage) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	f.handler.ServeHTTP(w, req)
+
+	var out map[string]json.RawMessage
+	if w.Body.Len() > 0 {
+		if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+			t.Fatalf("response is not JSON: %v\n%s", err, w.Body.String())
+		}
+	}
+	return w, out
+}
+
+func uploadBody(repo, filePath, content string) map[string]any {
+	sum := sha256.Sum256([]byte(content))
+	return map[string]any{
+		"repo_url":    repo,
+		"commit":      "abc123",
+		"path":        filePath,
+		"content_b64": base64.StdEncoding.EncodeToString([]byte(content)),
+		"sha256":      hex.EncodeToString(sum[:]),
+	}
+}
+
+func syncEntry(filePath, content string) map[string]any {
+	sum := sha256.Sum256([]byte(content))
+	return map[string]any{
+		"path":   filePath,
+		"sha256": hex.EncodeToString(sum[:]),
+		"size":   len(content),
+	}
+}
+
+func TestDocumentEndpoints_SyncUploadRoundTrip(t *testing.T) {
+	f := newDocFixture(t)
+	const repo = "https://github.com/matthewjhunter/example"
+
+	readme := "# Example\n\nThis project demonstrates the ingest wire protocol end to end.\n"
+	binaryName := "cmd/tool.bin"
+
+	// First sync: everything new; the binary is refused before any bytes move.
+	w, out := f.do(t, f.ingestToken, "POST", "/v1/documents/sync", map[string]any{
+		"repo_url": repo,
+		"entries": []map[string]any{
+			syncEntry("README.md", readme),
+			syncEntry(binaryName, "\x00\x01"),
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("sync: %d %s", w.Code, w.Body.String())
+	}
+	var need []string
+	if err := json.Unmarshal(out["need"], &need); err != nil || len(need) != 1 || need[0] != "README.md" {
+		t.Fatalf("need = %s (err %v), want [README.md]", out["need"], err)
+	}
+	var skip []struct{ Path, Reason string }
+	if err := json.Unmarshal(out["skip"], &skip); err != nil || len(skip) != 1 || skip[0].Path != binaryName {
+		t.Fatalf("skip = %s, want the .bin entry", out["skip"])
+	}
+
+	// Upload the needed file.
+	w, out = f.do(t, f.ingestToken, "POST", "/v1/documents", uploadBody(repo, "README.md", readme))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("upload: %d %s", w.Code, w.Body.String())
+	}
+	var strategy string
+	json.Unmarshal(out["strategy"], &strategy)
+	if strategy != "markdown" {
+		t.Errorf("strategy = %q, want markdown", strategy)
+	}
+
+	// Second sync with the same manifest: nothing needed, nothing orphaned.
+	w, out = f.do(t, f.ingestToken, "POST", "/v1/documents/sync", map[string]any{
+		"repo_url": repo,
+		"entries": []map[string]any{
+			syncEntry("README.md", readme),
+			syncEntry(binaryName, "\x00\x01"),
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("re-sync: %d %s", w.Code, w.Body.String())
+	}
+	json.Unmarshal(out["need"], &need)
+	if len(need) != 0 {
+		t.Errorf("re-sync still needs %v", need)
+	}
+	var unchanged int
+	json.Unmarshal(out["unchanged"], &unchanged)
+	if unchanged != 1 {
+		t.Errorf("unchanged = %d, want 1", unchanged)
+	}
+
+	// Search finds the ingested chunk with a citation, under the read token.
+	w, out = f.do(t, f.readToken, "POST", "/v1/documents/search", map[string]any{
+		"query": "ingest wire protocol",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("search: %d %s", w.Code, w.Body.String())
+	}
+	var results []struct {
+		Citation string `json:"citation"`
+		Path     string `json:"path"`
+		Trusted  bool   `json:"trusted"`
+	}
+	if err := json.Unmarshal(out["results"], &results); err != nil || len(results) != 1 {
+		t.Fatalf("results = %s (err %v), want exactly 1", out["results"], err)
+	}
+	if results[0].Path != "README.md" || !strings.Contains(results[0].Citation, repo+"@abc123 README.md:L") {
+		t.Errorf("citation wrong: %+v", results[0])
+	}
+	if results[0].Trusted {
+		t.Error("document trusted by default; must be untrusted until a repo policy exists")
+	}
+
+	// Third sync with README.md gone from the manifest: orphan deleted.
+	w, out = f.do(t, f.ingestToken, "POST", "/v1/documents/sync", map[string]any{
+		"repo_url": repo,
+		"entries":  []map[string]any{syncEntry(binaryName, "\x00\x01")},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("orphan sync: %d %s", w.Code, w.Body.String())
+	}
+	var orphaned []string
+	json.Unmarshal(out["orphaned"], &orphaned)
+	if len(orphaned) != 1 || orphaned[0] != "README.md" {
+		t.Fatalf("orphaned = %v, want [README.md]", orphaned)
+	}
+	_, out = f.do(t, f.readToken, "POST", "/v1/documents/search", map[string]any{"query": "ingest wire protocol"})
+	results = nil
+	json.Unmarshal(out["results"], &results)
+	if len(results) != 0 {
+		t.Errorf("deleted document still searchable: %+v", results)
+	}
+}
+
+func TestDocumentEndpoints_GoRoutingAndFallback(t *testing.T) {
+	f := newDocFixture(t)
+	const repo = "https://github.com/matthewjhunter/example"
+
+	goodGo := "// Package demo is a demonstration.\npackage demo\n\n// Answer returns the canonical answer to everything.\nfunc Answer() int { return 42 }\n"
+	w, out := f.do(t, f.ingestToken, "POST", "/v1/documents", uploadBody(repo, "demo.go", goodGo))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("go upload: %d %s", w.Code, w.Body.String())
+	}
+	var strategy string
+	json.Unmarshal(out["strategy"], &strategy)
+	if strategy != "go" {
+		t.Errorf("strategy = %q, want go", strategy)
+	}
+
+	brokenGo := "package broken\n\nfunc unclosed( {\n"
+	w, out = f.do(t, f.ingestToken, "POST", "/v1/documents", uploadBody(repo, "broken.go", brokenGo))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("broken go upload: %d %s", w.Code, w.Body.String())
+	}
+	json.Unmarshal(out["strategy"], &strategy)
+	if strategy != "line-window" {
+		t.Errorf("unparseable file strategy = %q, want line-window fallback", strategy)
+	}
+
+	testGo := "package demo\n\nfunc TestAnswer(t *T) { _ = Answer() }\n"
+	w, _ = f.do(t, f.ingestToken, "POST", "/v1/documents", uploadBody(repo, "demo_test.go", testGo))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("test file upload: %d %s", w.Code, w.Body.String())
+	}
+	// is_test is excluded from nothing by default, but must be marked.
+	w, out = f.do(t, f.readToken, "POST", "/v1/documents/search", map[string]any{"query": "TestAnswer", "basename": "demo_test.go"})
+	var results []struct {
+		IsTest bool `json:"is_test"`
+	}
+	if err := json.Unmarshal(out["results"], &results); err != nil || len(results) == 0 {
+		t.Fatalf("test-file chunk not searchable: %s", w.Body.String())
+	}
+	if !results[0].IsTest {
+		t.Error("_test.go document not marked is_test")
+	}
+}
+
+func TestDocumentEndpoints_UploadRejections(t *testing.T) {
+	f := newDocFixture(t)
+	const repo = "https://github.com/matthewjhunter/example"
+
+	cases := []struct {
+		name string
+		body func() map[string]any
+		want int
+	}{
+		{"hash mismatch", func() map[string]any {
+			b := uploadBody(repo, "a.md", "content one\n")
+			b["sha256"] = strings.Repeat("00", 32)
+			return b
+		}, http.StatusUnprocessableEntity},
+		{"bad hash encoding", func() map[string]any {
+			b := uploadBody(repo, "a.md", "content one\n")
+			b["sha256"] = "zz"
+			return b
+		}, http.StatusBadRequest},
+		{"non-UTF-8 content", func() map[string]any {
+			raw := []byte{0xff, 0xfe, 'h', 'i'}
+			sum := sha256.Sum256(raw)
+			b := uploadBody(repo, "a.md", "")
+			b["content_b64"] = base64.StdEncoding.EncodeToString(raw)
+			b["sha256"] = hex.EncodeToString(sum[:])
+			return b
+		}, http.StatusUnprocessableEntity},
+		{"unroutable extension", func() map[string]any {
+			return uploadBody(repo, "tool.bin", "not really binary\n")
+		}, http.StatusUnprocessableEntity},
+		{"vendored path", func() map[string]any {
+			return uploadBody(repo, "vendor/dep/dep.go", "package dep\n")
+		}, http.StatusUnprocessableEntity},
+		{"path traversal", func() map[string]any {
+			return uploadBody(repo, "../escape.md", "content\n")
+		}, http.StatusBadRequest},
+		{"absolute path", func() map[string]any {
+			return uploadBody(repo, "/etc/passwd.md", "content\n")
+		}, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, _ := f.do(t, f.ingestToken, "POST", "/v1/documents", tc.body())
+			if w.Code != tc.want {
+				t.Errorf("status %d, want %d: %s", w.Code, tc.want, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestDocumentEndpoints_ScopeEnforcement(t *testing.T) {
+	f := newDocFixture(t)
+	const repo = "https://github.com/matthewjhunter/example"
+
+	sync := map[string]any{"repo_url": repo, "entries": []map[string]any{}}
+	upload := uploadBody(repo, "x.md", "content\n")
+
+	// write scope does not include ingest.
+	if w, _ := f.do(t, f.writeToken, "POST", "/v1/documents/sync", sync); w.Code != http.StatusForbidden {
+		t.Errorf("write token reached sync: %d", w.Code)
+	}
+	if w, _ := f.do(t, f.writeToken, "POST", "/v1/documents", upload); w.Code != http.StatusForbidden {
+		t.Errorf("write token reached upload: %d", w.Code)
+	}
+	// ingest scope does not include read.
+	if w, _ := f.do(t, f.ingestToken, "POST", "/v1/documents/search", map[string]any{"query": "x"}); w.Code != http.StatusForbidden {
+		t.Errorf("ingest token reached search: %d", w.Code)
+	}
+	// read scope does not include ingest.
+	if w, _ := f.do(t, f.readToken, "POST", "/v1/documents", upload); w.Code != http.StatusForbidden {
+		t.Errorf("read token reached upload: %d", w.Code)
+	}
+}
+
+// User A ingests; user B's read token must see nothing through the HTTP
+// wiring -- the pgstore battery proves the store predicates, this pins the
+// per-request store scoping in ServeHTTP.
+func TestDocumentEndpoints_UserIsolation(t *testing.T) {
+	f := newDocFixture(t)
+	ctx := context.Background()
+
+	uidB, err := pgstore.EnsureUser(ctx, f.pool, "docs", "doc-user-b")
+	if err != nil {
+		t.Fatalf("EnsureUser B: %v", err)
+	}
+	readTokB, err := f.tokens.Issue(ctx, "doc-user-b@read", pgstore.IssueOpts{UserID: uidB, Scopes: []string{"read"}})
+	if err != nil {
+		t.Fatalf("Issue B token: %v", err)
+	}
+
+	const repo = "https://github.com/matthewjhunter/example"
+	content := "isolated corpus content zephyr\n"
+	if w, _ := f.do(t, f.ingestToken, "POST", "/v1/documents", uploadBody(repo, "iso.md", content)); w.Code != http.StatusCreated {
+		t.Fatalf("upload: %d", w.Code)
+	}
+
+	w, out := f.do(t, f.readToken, "POST", "/v1/documents/search", map[string]any{"query": "zephyr"})
+	var results []json.RawMessage
+	json.Unmarshal(out["results"], &results)
+	if w.Code != http.StatusOK || len(results) != 1 {
+		t.Fatalf("same-user search: %d, %d results", w.Code, len(results))
+	}
+
+	w, out = f.do(t, readTokB, "POST", "/v1/documents/search", map[string]any{"query": "zephyr"})
+	results = nil
+	json.Unmarshal(out["results"], &results)
+	if w.Code != http.StatusOK {
+		t.Fatalf("cross-user search status: %d", w.Code)
+	}
+	if len(results) != 0 {
+		t.Fatalf("user B can search user A's corpus over HTTP: %d results", len(results))
+	}
+}
+
+func TestDocumentEndpoints_SQLiteBackendIs501(t *testing.T) {
+	h := newTestHandlerWith(t) // SQLite-backed, no document corpus
+	body, _ := json.Marshal(map[string]any{"repo_url": "", "entries": []map[string]any{}})
+	req := httptest.NewRequest("POST", "/v1/documents/sync", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotImplemented {
+		t.Errorf("SQLite backend: %d, want 501", w.Code)
+	}
+}
+
+// Loose files: repo_url "" all the way through sync and upload.
+func TestDocumentEndpoints_LooseFiles(t *testing.T) {
+	f := newDocFixture(t)
+	note := "a loose note about the quokka migration\n"
+
+	if w, _ := f.do(t, f.ingestToken, "POST", "/v1/documents", uploadBody("", "notes/quokka.md", note)); w.Code != http.StatusCreated {
+		t.Fatalf("loose upload: %d", w.Code)
+	}
+	// Re-upload replaces, does not accumulate: sync with the same entry
+	// reports unchanged=1 and no orphans.
+	w, out := f.do(t, f.ingestToken, "POST", "/v1/documents/sync", map[string]any{
+		"repo_url": "",
+		"entries":  []map[string]any{syncEntry("notes/quokka.md", note)},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("loose sync: %d %s", w.Code, w.Body.String())
+	}
+	var unchanged int
+	json.Unmarshal(out["unchanged"], &unchanged)
+	if unchanged != 1 {
+		t.Errorf("loose sync unchanged = %d, want 1: %s", unchanged, w.Body.String())
+	}
+}

--- a/httpapi/handler.go
+++ b/httpapi/handler.go
@@ -279,6 +279,10 @@ func (h *Handler) registerRoutes() {
 	h.mux.HandleFunc("POST /v1/sessions/hook", h.requireScope(ScopeWrite, h.handleSessionHook), smoke.Write())
 	h.mux.HandleFunc("POST /v1/sessions/transcript", h.requireScope(ScopeWrite, h.handleSessionTranscript), smoke.Write())
 
+	h.mux.HandleFunc("POST /v1/documents/sync", h.requireScope(ScopeIngest, h.handleDocumentSync), smoke.Write())
+	h.mux.HandleFunc("POST /v1/documents", h.requireScope(ScopeIngest, h.handleDocumentUpload), smoke.Write())
+	h.mux.HandleFunc("POST /v1/documents/search", h.requireScope(ScopeRead, h.handleDocumentSearch), smoke.Skip("POST read; needs a JSON body (phase 2)"))
+
 	h.mux.HandleFunc("POST /v1/context/hints", h.requireScope(ScopeWrite, h.handleStoreHint), smoke.Write())
 	h.mux.HandleFunc("GET /v1/context/hints", h.requireScope(ScopeRead, h.handleGetHints), smoke.Skip("needs a session_id or cwd query param; not path-probeable"))
 	h.mux.HandleFunc("POST /v1/context/hints/{id}/consume", h.requireScope(ScopeWrite, h.handleConsumeHint), smoke.Write())


### PR DESCRIPTION
Third implementation increment of the document corpus: the wire protocol from docs/document-ingest.md.

- `POST /v1/documents/sync` (ingest scope): manifest in, need/skip/orphaned out. Server-side filtering at manifest time -- extension table, 1 MiB cap, vendor//node_modules/.git exclusion -- so refused files never cross the wire. Orphans (stored paths absent from the manifest) are deleted here.
- `POST /v1/documents` (ingest scope): base64 bytes + asserted git metadata. Daemon verifies the hash, requires UTF-8, routes by its own extension table, chunks (go -> line-window fallback on parse failure, strategy recorded), re-verifies every span against the bytes, stores untrusted-by-default.
- `POST /v1/documents/search` (read scope): the read side, every hit carrying its `repo@commit path:Lx-y` citation.

The ingest/read split is the point: an ingest-only token cannot search, a read token cannot ingest, and the endpoint battery pins both directions plus cross-user isolation over HTTP.

Remaining increment: the `memstore ingest <path>` CLI with the dedicated `ingest_token` config key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
