### PR TITLE
memstore ingest CLI

### DIFF
--- a/cmd/memstore/ingest_cmd.go
+++ b/cmd/memstore/ingest_cmd.go
@@ -1,0 +1,362 @@
+package main
+
+// memstore ingest <path>: the client side of docs/document-ingest.md. A stat
+// on the path decides file versus tree. The client enumerates, hashes, and
+// ships bytes plus asserted git metadata; the daemon owns routing, chunking,
+// and every verification. Authenticates with the dedicated ingest token
+// (ingest_token / MEMSTORE_INGEST_TOKEN) -- never the shared api_key.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/matthewjhunter/memstore"
+	"github.com/matthewjhunter/memstore/httpclient"
+)
+
+// uploadParallelism bounds concurrent uploads.
+const uploadParallelism = 4
+
+// repoInfo is the client-asserted identity of a working tree.
+type repoInfo struct {
+	root    string // absolute path of the repo root; "" when not a repo
+	url     string // canonical remote; "" for loose files
+	commit  string
+	dirty   map[string]bool // repo-relative paths modified or untracked
+	isNoGit bool            // plain directory, no git
+}
+
+func runIngest(args []string) {
+	fset := flag.NewFlagSet("ingest", flag.ExitOnError)
+	remote := fset.String("remote", cliConfig.Remote, "memstored base URL")
+	fset.Parse(args)
+
+	if fset.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: memstore ingest [--remote URL] <path>")
+		os.Exit(2)
+	}
+	if *remote == "" {
+		fmt.Fprintln(os.Stderr, "ingest needs a daemon: set remote in the config or pass --remote")
+		os.Exit(2)
+	}
+	token := memstore.LoadIngestToken()
+	if token == "" {
+		fmt.Fprintln(os.Stderr, `no ingest credential: set ingest_token in the config file or MEMSTORE_INGEST_TOKEN.
+Issue one with: memstore admin issue-token --user <name> --scopes ingest <user>@<host>-ingest`)
+		os.Exit(2)
+	}
+
+	client, err := httpclient.NewWithOptions(*remote, token, httpclient.ClientOptionsFromConfig(cliConfig))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "building client: %v\n", err)
+		os.Exit(1)
+	}
+
+	target, err := filepath.Abs(fset.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolving %s: %v\n", fset.Arg(0), err)
+		os.Exit(1)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "stat %s: %v\n", target, err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	var failed int
+	if info.IsDir() {
+		failed = ingestTree(ctx, client, target)
+	} else {
+		failed = ingestFile(ctx, client, target)
+	}
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+// gitOutput runs git in dir and returns trimmed stdout, or an error.
+func gitOutput(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// discoverRepo derives the asserted repo identity for dir: root, canonical
+// remote, HEAD commit, and the per-file dirty set from `git status
+// --porcelain` (modified or untracked, matching docs/document-ingest.md).
+// A directory outside any repo comes back with isNoGit set.
+func discoverRepo(dir string) repoInfo {
+	root, err := gitOutput(dir, "rev-parse", "--show-toplevel")
+	if err != nil || root == "" {
+		return repoInfo{isNoGit: true}
+	}
+	info := repoInfo{root: root, dirty: map[string]bool{}}
+	// The raw configured URL, not `git remote get-url`: get-url applies
+	// insteadOf rewrites from the machine's git config, so the asserted
+	// identity would vary by workstation. The value in .git/config is what
+	// the clone actually is. A repo with no remote gets "" and stores as
+	// loose files.
+	info.url, _ = gitOutput(dir, "config", "--get", "remote.origin.url")
+	info.commit, _ = gitOutput(dir, "rev-parse", "HEAD")
+
+	// Porcelain lines are XY<space>path; the leading X may itself be a
+	// space, so the output must not be whitespace-trimmed before slicing.
+	statusCmd := exec.Command("git", "status", "--porcelain")
+	statusCmd.Dir = dir
+	if out, err := statusCmd.Output(); err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			if len(line) < 4 {
+				continue
+			}
+			p := line[3:]
+			// Renames report "old -> new"; the new path is the live one.
+			if i := strings.Index(p, " -> "); i >= 0 {
+				p = p[i+4:]
+			}
+			p = strings.Trim(p, `"`)
+			info.dirty[p] = true
+		}
+	}
+	return info
+}
+
+// enumerateRepo lists ingestable candidates: tracked files plus untracked-
+// but-not-ignored, exactly the set git's own ignore semantics selects.
+func enumerateRepo(root string) ([]string, error) {
+	tracked, err := gitOutput(root, "ls-files")
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files: %w", err)
+	}
+	untracked, err := gitOutput(root, "ls-files", "--others", "--exclude-standard")
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files --others: %w", err)
+	}
+	seen := map[string]bool{}
+	var paths []string
+	for _, group := range []string{tracked, untracked} {
+		for _, p := range strings.Split(group, "\n") {
+			if p == "" || seen[p] {
+				continue
+			}
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// enumerateDir is the non-repo fallback: a plain walk, paths relative to the
+// ingest root.
+func enumerateDir(root string) ([]string, error) {
+	var paths []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, filepath.ToSlash(rel))
+		return nil
+	})
+	sort.Strings(paths)
+	return paths, err
+}
+
+// hashFile returns the sha256 (hex), size, and mtime of a file.
+func hashFile(path string) (string, int64, time.Time, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", 0, time.Time{}, err
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		return "", 0, time.Time{}, err
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), int64(len(b)), st.ModTime(), nil
+}
+
+// ingestTree runs the manifest-sync protocol for a directory. Returns the
+// number of failed uploads.
+func ingestTree(ctx context.Context, client *httpclient.Client, dir string) int {
+	repo := discoverRepo(dir)
+	root := repo.root
+	var paths []string
+	var err error
+	if repo.isNoGit {
+		root = dir
+		paths, err = enumerateDir(dir)
+	} else {
+		paths, err = enumerateRepo(root)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "enumerating %s: %v\n", dir, err)
+		return 1
+	}
+
+	entries := make([]httpclient.DocSyncEntry, 0, len(paths))
+	for _, p := range paths {
+		sha, size, _, err := hashFile(filepath.Join(root, filepath.FromSlash(p)))
+		if err != nil {
+			// A file deleted or unreadable mid-walk: leave it out; the next
+			// run reconciles.
+			fmt.Fprintf(os.Stderr, "  skipping %s: %v\n", p, err)
+			continue
+		}
+		entries = append(entries, httpclient.DocSyncEntry{Path: p, SHA256: sha, Size: size})
+	}
+
+	res, err := client.SyncDocuments(ctx, repo.url, entries)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "manifest sync: %v\n", err)
+		return 1
+	}
+
+	identity := repo.url
+	switch {
+	case repo.isNoGit:
+		identity = "(loose files, no repo)"
+	case identity == "":
+		identity = "(repo with no remote; stored as loose files)"
+	}
+	fmt.Printf("repo: %s\n", identity)
+	if repo.commit != "" {
+		fmt.Printf("commit: %s (asserted)\n", repo.commit)
+	}
+	fmt.Printf("manifest: %d files, %d to upload, %d unchanged, %d skipped, %d orphans deleted\n",
+		len(entries), len(res.Need), res.Unchanged, len(res.Skip), len(res.Orphaned))
+
+	// Skips grouped by reason.
+	byReason := map[string]int{}
+	for _, s := range res.Skip {
+		byReason[s.Reason]++
+	}
+	reasons := make([]string, 0, len(byReason))
+	for r := range byReason {
+		reasons = append(reasons, r)
+	}
+	sort.Strings(reasons)
+	for _, r := range reasons {
+		fmt.Printf("  skipped %d: %s\n", byReason[r], r)
+	}
+
+	// Upload the delta with bounded parallelism.
+	type outcome struct {
+		path     string
+		chunks   int
+		strategy string
+		err      error
+	}
+	sem := make(chan struct{}, uploadParallelism)
+	results := make([]outcome, len(res.Need))
+	var wg sync.WaitGroup
+	for i, p := range res.Need {
+		wg.Add(1)
+		go func(i int, p string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			up, err := uploadOne(ctx, client, repo, root, p)
+			if err != nil {
+				results[i] = outcome{path: p, err: err}
+				return
+			}
+			results[i] = outcome{path: p, chunks: up.Chunks, strategy: up.Strategy}
+		}(i, p)
+	}
+	wg.Wait()
+
+	failed := 0
+	for _, r := range results {
+		if r.err != nil {
+			failed++
+			fmt.Fprintf(os.Stderr, "  FAILED %s: %v\n", r.path, r.err)
+			continue
+		}
+		fmt.Printf("  ingested %s (%d chunks, %s)\n", r.path, r.chunks, r.strategy)
+	}
+	if failed > 0 {
+		fmt.Fprintf(os.Stderr, "%d of %d uploads failed\n", failed, len(res.Need))
+	}
+	return failed
+}
+
+// uploadOne ships a single repo-relative path.
+func uploadOne(ctx context.Context, client *httpclient.Client, repo repoInfo, root, relPath string) (*httpclient.DocUploadResult, error) {
+	abs := filepath.Join(root, filepath.FromSlash(relPath))
+	content, err := os.ReadFile(abs)
+	if err != nil {
+		return nil, err
+	}
+	st, err := os.Stat(abs)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(content)
+	mtime := st.ModTime()
+	return client.UploadDocument(ctx, httpclient.DocUpload{
+		RepoURL: repo.url,
+		Commit:  repo.commit,
+		Path:    relPath,
+		Content: content,
+		SHA256:  hex.EncodeToString(sum[:]),
+		Mtime:   &mtime,
+		Dirty:   repo.dirty[relPath],
+	})
+}
+
+// ingestFile ships a single file: step 4 of the protocol alone, with the
+// repo identity derived by walking up for .git. Returns 1 on failure.
+func ingestFile(ctx context.Context, client *httpclient.Client, file string) int {
+	dir := filepath.Dir(file)
+	repo := discoverRepo(dir)
+
+	var relPath string
+	root := dir
+	if repo.isNoGit {
+		// Loose file: path relative to its own directory is just the name.
+		relPath = filepath.Base(file)
+		repo.url = ""
+	} else {
+		root = repo.root
+		rel, err := filepath.Rel(repo.root, file)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			fmt.Fprintf(os.Stderr, "%s is outside its repo root %s\n", file, repo.root)
+			return 1
+		}
+		relPath = filepath.ToSlash(rel)
+	}
+
+	up, err := uploadOne(ctx, client, repo, root, relPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ingest %s: %v\n", relPath, err)
+		return 1
+	}
+	fmt.Printf("ingested %s (%d chunks, %s)\n", relPath, up.Chunks, up.Strategy)
+	return 0
+}

--- a/cmd/memstore/ingest_cmd_test.go
+++ b/cmd/memstore/ingest_cmd_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/matthewjhunter/memstore/httpclient"
+)
+
+// gitRepo builds a throwaway repo: two committed files, one modified after
+// commit, one untracked, one ignored.
+func gitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(name, content string) {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	run("init", "-q")
+	run("remote", "add", "origin", "https://github.com/example/fixture")
+	write(".gitignore", "ignored.md\n")
+	write("README.md", "# Fixture\n\ncommitted content\n")
+	write("docs/design.md", "## Design\n\nmore committed content\n")
+	run("add", ".")
+	run("commit", "-q", "-m", "initial")
+	write("README.md", "# Fixture\n\nmodified after commit\n")
+	write("untracked.md", "untracked note\n")
+	write("ignored.md", "must never be enumerated\n")
+	return dir
+}
+
+func TestDiscoverAndEnumerateRepo(t *testing.T) {
+	dir := gitRepo(t)
+	repo := discoverRepo(dir)
+
+	if repo.isNoGit {
+		t.Fatal("repo not detected")
+	}
+	if repo.url != "https://github.com/example/fixture" {
+		t.Errorf("url = %q", repo.url)
+	}
+	if len(repo.commit) != 40 {
+		t.Errorf("commit = %q", repo.commit)
+	}
+	if !repo.dirty["README.md"] || !repo.dirty["untracked.md"] {
+		t.Errorf("dirty set wrong: %v", repo.dirty)
+	}
+	if repo.dirty["docs/design.md"] {
+		t.Error("clean file marked dirty")
+	}
+
+	paths, err := enumerateRepo(repo.root)
+	if err != nil {
+		t.Fatalf("enumerateRepo: %v", err)
+	}
+	want := []string{".gitignore", "README.md", "docs/design.md", "untracked.md"}
+	sort.Strings(want)
+	if len(paths) != len(want) {
+		t.Fatalf("paths = %v, want %v", paths, want)
+	}
+	for i := range want {
+		if paths[i] != want[i] {
+			t.Fatalf("paths = %v, want %v", paths, want)
+		}
+	}
+}
+
+func TestEnumerateDir(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".git"), 0o755)
+	os.WriteFile(filepath.Join(dir, ".git", "config"), []byte("x"), 0o644)
+	os.MkdirAll(filepath.Join(dir, "sub"), 0o755)
+	os.WriteFile(filepath.Join(dir, "a.md"), []byte("a"), 0o644)
+	os.WriteFile(filepath.Join(dir, "sub", "b.md"), []byte("b"), 0o644)
+
+	paths, err := enumerateDir(dir)
+	if err != nil {
+		t.Fatalf("enumerateDir: %v", err)
+	}
+	if len(paths) != 2 || paths[0] != "a.md" || paths[1] != "sub/b.md" {
+		t.Errorf("paths = %v (.git must be excluded)", paths)
+	}
+}
+
+// stubDaemon implements the two ingest routes with canned sync behavior and
+// records what the client sent.
+type stubDaemon struct {
+	mu       sync.Mutex
+	syncReq  map[string]any
+	uploads  []map[string]any
+	needAll  bool
+	skipPath string
+}
+
+func (s *stubDaemon) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/documents/sync", func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		json.NewDecoder(r.Body).Decode(&req)
+		s.mu.Lock()
+		s.syncReq = req
+		s.mu.Unlock()
+
+		need := []string{}
+		skip := []map[string]any{}
+		for _, e := range req["entries"].([]any) {
+			entry := e.(map[string]any)
+			p := entry["path"].(string)
+			if p == s.skipPath {
+				skip = append(skip, map[string]any{"path": p, "reason": "unroutable extension: .bin"})
+				continue
+			}
+			if s.needAll {
+				need = append(need, p)
+			}
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"need": need, "skip": skip, "orphaned": []string{}, "unchanged": 0,
+		})
+	})
+	mux.HandleFunc("POST /v1/documents", func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		json.NewDecoder(r.Body).Decode(&req)
+		s.mu.Lock()
+		s.uploads = append(s.uploads, req)
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"id": 1, "chunks": 3, "strategy": "markdown"})
+	})
+	return mux
+}
+
+func TestIngestTree_Protocol(t *testing.T) {
+	dir := gitRepo(t)
+	stub := &stubDaemon{needAll: true, skipPath: ".gitignore"}
+	srv := httptest.NewServer(stub.handler())
+	defer srv.Close()
+
+	client := httpclient.New(srv.URL, "test-token")
+	if failed := ingestTree(context.Background(), client, dir); failed != 0 {
+		t.Fatalf("ingestTree reported %d failures", failed)
+	}
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+
+	if stub.syncReq["repo_url"] != "https://github.com/example/fixture" {
+		t.Errorf("sync repo_url = %v", stub.syncReq["repo_url"])
+	}
+	entries := stub.syncReq["entries"].([]any)
+	if len(entries) != 4 {
+		t.Fatalf("manifest has %d entries, want 4: %v", len(entries), entries)
+	}
+
+	if len(stub.uploads) != 3 { // .gitignore skipped by the stub
+		t.Fatalf("%d uploads, want 3", len(stub.uploads))
+	}
+	byPath := map[string]map[string]any{}
+	for _, u := range stub.uploads {
+		byPath[u["path"].(string)] = u
+	}
+	readme, ok := byPath["README.md"]
+	if !ok {
+		t.Fatalf("README.md not uploaded: %v", byPath)
+	}
+	if readme["dirty"] != true {
+		t.Error("modified file not asserted dirty")
+	}
+	if clean := byPath["docs/design.md"]; clean == nil || clean["dirty"] == true {
+		t.Errorf("clean file mis-asserted: %v", clean)
+	}
+	if untracked := byPath["untracked.md"]; untracked == nil || untracked["dirty"] != true {
+		t.Errorf("untracked file not asserted dirty: %v", untracked)
+	}
+	if len(readme["commit"].(string)) != 40 {
+		t.Errorf("commit not asserted: %v", readme["commit"])
+	}
+	// The manifest carries real hashes: verify one against the working tree.
+	content, _ := os.ReadFile(filepath.Join(dir, "README.md"))
+	sum := sha256.Sum256(content)
+	found := false
+	for _, e := range entries {
+		entry := e.(map[string]any)
+		if entry["path"] == "README.md" && entry["sha256"] == hex.EncodeToString(sum[:]) {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("manifest sha for README.md does not match working-tree bytes")
+	}
+}
+
+func TestIngestFile_SingleAndLoose(t *testing.T) {
+	dir := gitRepo(t)
+	stub := &stubDaemon{}
+	srv := httptest.NewServer(stub.handler())
+	defer srv.Close()
+	client := httpclient.New(srv.URL, "test-token")
+
+	// Repo file: repo-relative path plus asserted identity.
+	if failed := ingestFile(context.Background(), client, filepath.Join(dir, "docs", "design.md")); failed != 0 {
+		t.Fatal("repo-file ingest failed")
+	}
+	// Loose file: no repo anywhere above the temp dir.
+	loose := t.TempDir()
+	loosePath := filepath.Join(loose, "note.md")
+	os.WriteFile(loosePath, []byte("loose note\n"), 0o644)
+	if failed := ingestFile(context.Background(), client, loosePath); failed != 0 {
+		t.Fatal("loose-file ingest failed")
+	}
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	if len(stub.uploads) != 2 {
+		t.Fatalf("%d uploads, want 2", len(stub.uploads))
+	}
+	repoUp, looseUp := stub.uploads[0], stub.uploads[1]
+	if repoUp["path"] != "docs/design.md" || repoUp["repo_url"] != "https://github.com/example/fixture" {
+		t.Errorf("repo-file upload wrong: %v", repoUp)
+	}
+	if looseUp["path"] != "note.md" || looseUp["repo_url"] != "" {
+		t.Errorf("loose-file upload wrong: %v", looseUp)
+	}
+}

--- a/cmd/memstore/main.go
+++ b/cmd/memstore/main.go
@@ -61,6 +61,8 @@ func main() {
 		runAdmin(os.Args[2:])
 	case "backfill-feedback":
 		runBackfillFeedback(os.Args[2:])
+	case "ingest":
+		runIngest(os.Args[2:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %q\n", os.Args[1])
 		printUsage()
@@ -82,7 +84,9 @@ Commands:
   setup              Install hooks, register MCP server, and configure memstore
   tls                Generate a self-signed CA + server cert, or issue client certs
   admin              Manage api_tokens (issue / list / revoke / rotate). Requires --pg.
-  backfill-feedback  Auto-rate all historical fact injections (requires remote)`)
+  backfill-feedback  Auto-rate all historical fact injections (requires remote)
+  ingest             Ingest a file or repo tree into the document corpus (requires
+                     remote and the dedicated ingest_token credential)`)
 }
 
 // openStore opens a Store — either remote (if cliConfig.Remote is set) or local SQLite.

--- a/config.go
+++ b/config.go
@@ -41,6 +41,35 @@ type AppConfig struct {
 	TLSClientKeyFile  string // matching private key
 }
 
+// LoadIngestToken returns the dedicated ingest credential: the ingest_token
+// config key, overridden by MEMSTORE_INGEST_TOKEN. It is deliberately NOT a
+// field on AppConfig and NOT read by LoadConfig: memstore-mcp loads AppConfig,
+// and if the ingest token rode along there, the model's process would hold the
+// exact credential the ingest scope split exists to withhold
+// (docs/document-ingest.md). Only `memstore ingest` calls this.
+func LoadIngestToken() string {
+	token := ""
+	if path := ConfigPath(); path != "" {
+		if f, err := os.Open(path); err == nil {
+			scanner := bufio.NewScanner(f)
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if line == "" || strings.HasPrefix(line, "#") {
+					continue
+				}
+				if key, value, ok := parseConfigLine(line); ok && key == "ingest_token" {
+					token = value
+				}
+			}
+			f.Close()
+		}
+	}
+	if v := os.Getenv("MEMSTORE_INGEST_TOKEN"); v != "" {
+		token = v
+	}
+	return token
+}
+
 // redactedAppConfig has AppConfig's fields but not its String method, so String
 // can format it without recursing.
 type redactedAppConfig AppConfig

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package memstore
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -369,5 +370,44 @@ func TestExpandTilde(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("expandTilde(%q) = %q, want %q", tt.input, got, tt.want)
 		}
+	}
+}
+
+// LoadIngestToken reads only its own key, with the env override winning.
+// It is deliberately separate from LoadConfig so that memstore-mcp, which
+// loads AppConfig, never holds the ingest credential.
+func TestLoadIngestToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEMSTORE_INGEST_TOKEN", "")
+
+	if got := LoadIngestToken(); got != "" {
+		t.Errorf("no config file: token = %q, want empty", got)
+	}
+
+	cfgDir := filepath.Join(dir, "memstore")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "api_key = \"shared-key\"\ningest_token = \"file-ingest-token\"\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LoadIngestToken(); got != "file-ingest-token" {
+		t.Errorf("token from file = %q", got)
+	}
+	// The shared config loader must NOT pick the ingest token up anywhere.
+	cfg := LoadConfig()
+	if cfg.APIKey != "shared-key" {
+		t.Errorf("api_key = %q", cfg.APIKey)
+	}
+	if s := fmt.Sprintf("%+v", redactedAppConfig(cfg)); strings.Contains(s, "ingest") || strings.Contains(s, "file-ingest-token") {
+		t.Errorf("AppConfig carries ingest material: %s", s)
+	}
+
+	t.Setenv("MEMSTORE_INGEST_TOKEN", "env-ingest-token")
+	if got := LoadIngestToken(); got != "env-ingest-token" {
+		t.Errorf("env override = %q", got)
 	}
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -168,6 +168,18 @@ Unknown scope strings are rejected at issuance: matching is exact and
 lowercase, and a misspelled scope would otherwise produce a token that
 authenticates but is refused everywhere.
 
+### The ingest credential is its own config key
+
+`memstore ingest` authenticates with `ingest_token` in the config file (or
+`MEMSTORE_INGEST_TOKEN`), never with `api_key`. The separation is the point:
+memstore-mcp loads `api_key` from the same config file, so granting that
+shared key the `ingest` scope would hand the model's credential the exact
+power the scope split withholds. `LoadIngestToken` is a separate loader that
+only the ingest command calls; the MCP server never reads the key. Issue the
+credential scoped to exactly `ingest`:
+
+    memstore admin issue-token --user matthew --scopes ingest matthew@laptop-ingest
+
 ### Multi-user isolation requires the token verifier
 
 User isolation is enforced at the storage layer -- every query is scoped to the

--- a/httpclient/documents.go
+++ b/httpclient/documents.go
@@ -1,0 +1,87 @@
+package httpclient
+
+// Document ingest client: the wire side of docs/document-ingest.md. Used by
+// `memstore ingest` with the dedicated ingest token -- construct a separate
+// Client with that credential; the fact-store client's api_key does not carry
+// the ingest scope.
+
+import (
+	"context"
+	"encoding/base64"
+	"time"
+)
+
+// DocSyncEntry is one manifest line: a file the client can see.
+type DocSyncEntry struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"` // hex
+	Size   int64  `json:"size"`
+}
+
+// DocSkip is one refused manifest entry with the daemon's reason.
+type DocSkip struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+// DocSyncResult is the daemon's manifest delta.
+type DocSyncResult struct {
+	Need      []string  `json:"need"`
+	Skip      []DocSkip `json:"skip"`
+	Orphaned  []string  `json:"orphaned"`
+	Unchanged int       `json:"unchanged"`
+}
+
+// SyncDocuments posts the manifest for one repo identity (repoURL "" = loose
+// files) and returns the delta. Orphaned documents are deleted server-side.
+func (c *Client) SyncDocuments(ctx context.Context, repoURL string, entries []DocSyncEntry) (*DocSyncResult, error) {
+	if entries == nil {
+		entries = []DocSyncEntry{}
+	}
+	var res DocSyncResult
+	err := c.post(ctx, "/v1/documents/sync", map[string]any{
+		"repo_url": repoURL,
+		"entries":  entries,
+	}, &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// DocUpload is one file's bytes plus the client-asserted provenance.
+type DocUpload struct {
+	RepoURL string
+	Commit  string
+	Path    string
+	Content []byte
+	SHA256  string // hex of Content
+	Mtime   *time.Time
+	Dirty   bool
+}
+
+// DocUploadResult reports what the daemon stored.
+type DocUploadResult struct {
+	ID       int64  `json:"id"`
+	Chunks   int    `json:"chunks"`
+	Strategy string `json:"strategy"`
+}
+
+// UploadDocument ships one file. The daemon hashes, verifies, chunks, and
+// stores; a hash mismatch or unroutable file comes back as an error.
+func (c *Client) UploadDocument(ctx context.Context, up DocUpload) (*DocUploadResult, error) {
+	var res DocUploadResult
+	err := c.post(ctx, "/v1/documents", map[string]any{
+		"repo_url":    up.RepoURL,
+		"commit":      up.Commit,
+		"path":        up.Path,
+		"content_b64": base64.StdEncoding.EncodeToString(up.Content),
+		"sha256":      up.SHA256,
+		"mtime":       up.Mtime,
+		"dirty":       up.Dirty,
+	}, &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}


### PR DESCRIPTION
Final implementation increment of the document corpus: the client side of docs/document-ingest.md.

- `memstore ingest <path>` -- stat decides file vs tree. Repos enumerate via `git ls-files` (+ `--others --exclude-standard`); per-file dirty from `git status --porcelain`; commit and remote asserted. Non-repo dirs walk; loose files ship with no repo identity.
- Manifest sync, then delta uploads at parallelism 4, with the per-run report from the design (ingested + chunk counts, skips by reason, orphans deleted, asserted identity). Nonzero exit on upload failure.
- The credential is `ingest_token` / `MEMSTORE_INGEST_TOKEN` via a dedicated `LoadIngestToken` that only this command calls -- it is not an AppConfig field, so memstore-mcp structurally cannot load it. Test pins AppConfig staying free of ingest material.
- Two bugs the test battery caught before they shipped: `git remote get-url` applies per-machine `insteadOf` rewrites (now reads raw `remote.origin.url`), and trimming porcelain output ate the leading status column, mis-slicing the first dirty path.

With this, the whole pipeline from docs/document-corpus.md is in: schema (#124), chunkers (#125), endpoints (#126), CLI (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
