### PR TITLE
config: rename MEMSTORE_PG to MEMSTORE_PG_SECRET and redact the DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ processing (session capture, hint generation, feedback rating), run
 go install github.com/matthewjhunter/memstore/cmd/memstored@latest
 
 # Required: Postgres with pgvector and an embedder endpoint
-export MEMSTORE_PG='postgres://memstore:secret@host:5432/memstore?sslmode=require'
+export MEMSTORE_PG_SECRET='postgres://memstore:secret@host:5432/memstore?sslmode=require'
 export MEMSTORE_EMBED_BACKEND=ollama
 export MEMSTORE_EMBED_BASE_URL=http://localhost:11434
 export MEMSTORE_EMBED_MODEL=nomic-embed-text

--- a/cmd/memstore/admin_cmd.go
+++ b/cmd/memstore/admin_cmd.go
@@ -64,7 +64,7 @@ Subcommands:
 Flags may appear before or after the positional argument.
 
 All admin commands connect directly to PostgreSQL, so they must run on the
-daemon host (or anywhere with a route to it). Set --pg or MEMSTORE_PG.
+daemon host (or anywhere with a route to it). Set --pg or MEMSTORE_PG_SECRET.
 
 Commands act on the namespace from --namespace, defaulting to the one the
 daemon uses (config file / MEMSTORE_NAMESPACE, built-in default "default").`)
@@ -134,7 +134,7 @@ func openPool(pgFlag string) (*pgxpool.Pool, func(), error) {
 		dsn = cliConfig.PG
 	}
 	if dsn == "" {
-		return nil, nil, fmt.Errorf("admin: PostgreSQL DSN required (--pg or MEMSTORE_PG)")
+		return nil, nil, fmt.Errorf("admin: PostgreSQL DSN required (--pg or MEMSTORE_PG_SECRET)")
 	}
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, dsn)
@@ -162,7 +162,7 @@ func openTokenStore(pgFlag string) (*pgstore.TokenStore, func(), error) {
 
 func runTier3Init(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("tier3-init", flag.ExitOnError)
-	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG / config)")
+	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG_SECRET / config)")
 	defaultUser := fs.String("default-user", "", "Name to seed as the default user (required)")
 	namespace := fs.String("namespace", defaultAdminNamespace(), namespaceFlagUsage)
 	if _, err := parseAdminArgs(fs, args); err != nil {
@@ -190,7 +190,7 @@ func runTier3Init(args []string, out io.Writer) {
 
 func runUserAdd(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("user-add", flag.ExitOnError)
-	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG / config)")
+	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG_SECRET / config)")
 	namespace := fs.String("namespace", defaultAdminNamespace(), namespaceFlagUsage)
 	positional, err := parseAdminArgs(fs, args)
 	if err != nil {
@@ -328,7 +328,7 @@ func runDisableUser(args []string, out io.Writer) {
 
 func runIssueToken(args []string, out io.Writer) {
 	fs := flag.NewFlagSet("issue-token", flag.ExitOnError)
-	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG / config)")
+	pgDSN := fs.String("pg", "", "PostgreSQL DSN (defaults to MEMSTORE_PG_SECRET / config)")
 	scopes := fs.String("scopes", "", "comma-separated scopes: read, write, admin, ingest. admin implies read+write; ingest is never implied and must be granted explicitly")
 	expires := fs.Duration("expires", 0, "token lifetime, e.g. 90d, 720h. 0 = no expiry")
 	userName := fs.String("user", "", "user name to bind the token to (required; must exist in memstore_users)")

--- a/cmd/memstored/main.go
+++ b/cmd/memstored/main.go
@@ -86,7 +86,7 @@ func run(ctx context.Context, args []string, stderr io.Writer, onListening func(
 	}
 
 	if *pgDSN == "" {
-		return errors.New("PostgreSQL is required: pass --pg or set MEMSTORE_PG " +
+		return errors.New("PostgreSQL is required: pass --pg or set MEMSTORE_PG_SECRET " +
 			"(for single-user local development, use memstore-mcp directly with no daemon)")
 	}
 

--- a/config.go
+++ b/config.go
@@ -3,10 +3,12 @@ package memstore
 import (
 	"bufio"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // AppConfig holds persistent defaults for the memstore CLI and MCP server.
@@ -24,8 +26,15 @@ type AppConfig struct {
 	APIKey    string // API key for memstored auth
 	LLMAPIKey string // API key for the chat LLM provider (LiteLLM, OpenAI, etc.)
 	Addr      string // listen address for memstored daemon
-	PG        string // PostgreSQL connection string; if set, use Postgres instead of SQLite
-	VecDim    int    // embedding vector dimension for Postgres (e.g. 768)
+	// PG is the PostgreSQL connection string; if set, use Postgres instead of
+	// SQLite. It is a SECRET: the DSN embeds the database password. It is named
+	// pg_secret / MEMSTORE_PG_SECRET so that the ordinary secret-filtering
+	// habit -- grep -v for pass|key|secret|token over an env dump -- catches it.
+	// The old name, plain "pg" / MEMSTORE_PG, matched none of those and so read
+	// as inert config; it leaked into a terminal that way. Both names still
+	// load (see LoadConfig), but only the new one is documented.
+	PG     string
+	VecDim int // embedding vector dimension for Postgres (e.g. 768)
 
 	// TLS configuration for memstored (server side). The daemon requires TLS
 	// by default; TLSDisabled is the explicit opt-out for proxy-fronted
@@ -81,7 +90,35 @@ type redactedAppConfig AppConfig
 func (c AppConfig) String() string {
 	c.APIKey = redactSecret(c.APIKey)
 	c.LLMAPIKey = redactSecret(c.LLMAPIKey)
+	c.PG = RedactDSN(c.PG)
 	return fmt.Sprintf("%+v", redactedAppConfig(c))
+}
+
+// RedactDSN masks the password in a PostgreSQL DSN while leaving the parts an
+// operator actually debugs -- scheme, user, host, database, options -- intact.
+// Blanket-redacting the whole string would hide "am I pointed at the right
+// host?", which is the usual question, and so would invite people to print the
+// raw DSN instead.
+//
+// It is exported because the DSN is passed around outside AppConfig (flags,
+// admin commands), and every one of those paths needs the same treatment.
+// A DSN that will not parse is redacted whole: an unparseable string is not
+// proof there is no password in it.
+func RedactDSN(dsn string) string {
+	if dsn == "" {
+		return ""
+	}
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "[redacted]"
+	}
+	if _, hasPassword := u.User.Password(); !hasPassword {
+		return dsn
+	}
+	u.User = url.UserPassword(u.User.Username(), "[redacted]")
+	// url.String re-encodes the masked password; undo that so the marker stays
+	// readable rather than appearing as %5Bredacted%5D.
+	return strings.Replace(u.String(), "%5Bredacted%5D", "[redacted]", 1)
 }
 
 // redactSecret masks a secret while preserving whether one was set at all, which
@@ -91,6 +128,22 @@ func redactSecret(s string) string {
 		return ""
 	}
 	return "[redacted]"
+}
+
+// pgEnvWarnOnce keeps the deprecation notice to one line per process. LoadConfig
+// is called from memstore-mcp, whose stderr is the MCP client's log: a warning
+// per load would be noise, and noisy warnings get filtered out wholesale, taking
+// this one with them.
+var pgEnvWarnOnce sync.Once
+
+// warnDeprecatedPGEnv notes that the deployment is still on the old env-var
+// name. Deliberately to stderr and never to stdout: stdout carries MCP JSON-RPC.
+func warnDeprecatedPGEnv() {
+	pgEnvWarnOnce.Do(func() {
+		fmt.Fprintln(os.Stderr,
+			"memstore: MEMSTORE_PG is deprecated, use MEMSTORE_PG_SECRET "+
+				"(the DSN holds a password; the name should say so)")
+	})
 }
 
 // DefaultConfig returns the built-in defaults used when no config file exists.
@@ -154,8 +207,16 @@ func LoadConfig() AppConfig {
 					cfg.LLMAPIKey = value
 				case "addr":
 					cfg.Addr = value
-				case "pg":
+				case "pg_secret":
 					cfg.PG = value
+				case "pg":
+					// Deprecated spelling, still honored. See AppConfig.PG.
+					// No warning here: unlike the env var, a config file key is
+					// not something a shell dump splatters into a transcript,
+					// and warning on every load would spam MCP stderr.
+					if cfg.PG == "" {
+						cfg.PG = value
+					}
 				case "tls_cert_file":
 					cfg.TLSCertFile = expandTilde(value)
 				case "tls_key_file":
@@ -207,8 +268,11 @@ func LoadConfig() AppConfig {
 	if v := os.Getenv("MEMSTORE_ADDR"); v != "" {
 		cfg.Addr = v
 	}
-	if v := os.Getenv("MEMSTORE_PG"); v != "" {
+	if v := os.Getenv("MEMSTORE_PG_SECRET"); v != "" {
 		cfg.PG = v
+	} else if v := os.Getenv("MEMSTORE_PG"); v != "" {
+		cfg.PG = v
+		warnDeprecatedPGEnv()
 	}
 	if v := os.Getenv("MEMSTORE_TLS_CERT_FILE"); v != "" {
 		cfg.TLSCertFile = expandTilde(v)

--- a/config_test.go
+++ b/config_test.go
@@ -411,3 +411,114 @@ func TestLoadIngestToken(t *testing.T) {
 		t.Errorf("env override = %q", got)
 	}
 }
+
+func TestLoadConfig_PGSecretEnv(t *testing.T) {
+	const dsn = "postgres://memstore:pw@db:5432/memstore?sslmode=disable"
+
+	t.Run("new name", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		clearMemstoreEnv(t)
+		t.Setenv("MEMSTORE_PG_SECRET", dsn)
+		if got := LoadConfig().PG; got != dsn {
+			t.Errorf("PG = %q, want %q", got, dsn)
+		}
+	})
+
+	t.Run("deprecated name still loads", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		clearMemstoreEnv(t)
+		t.Setenv("MEMSTORE_PG", dsn)
+		if got := LoadConfig().PG; got != dsn {
+			t.Errorf("PG = %q, want %q (old name must keep working)", got, dsn)
+		}
+	})
+
+	t.Run("new name wins over deprecated", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		clearMemstoreEnv(t)
+		t.Setenv("MEMSTORE_PG", "postgres://memstore:pw@old:5432/memstore")
+		t.Setenv("MEMSTORE_PG_SECRET", dsn)
+		if got := LoadConfig().PG; got != dsn {
+			t.Errorf("PG = %q, want %q", got, dsn)
+		}
+	})
+}
+
+func TestLoadConfig_PGSecretFileKey(t *testing.T) {
+	const dsn = "postgres://memstore:pw@db:5432/memstore"
+
+	// Both orderings: pg_secret must win regardless of which line comes first.
+	for name, content := range map[string]string{
+		"pg_secret only": "pg_secret = \"" + dsn + "\"\n",
+		"legacy pg only": "pg = \"" + dsn + "\"\n",
+		"secret first":   "pg_secret = \"" + dsn + "\"\npg = \"postgres://memstore:pw@old:5432/x\"\n",
+		"legacy first":   "pg = \"postgres://memstore:pw@old:5432/x\"\npg_secret = \"" + dsn + "\"\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", dir)
+			clearMemstoreEnv(t)
+			configDir := filepath.Join(dir, "memstore")
+			if err := os.MkdirAll(configDir, 0700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(content), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if got := LoadConfig().PG; got != dsn {
+				t.Errorf("PG = %q, want %q", got, dsn)
+			}
+		})
+	}
+}
+
+func TestRedactDSN(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{
+			"password masked, host and db preserved",
+			"postgres://memstore:hunter2@db:5432/memstore?sslmode=disable",
+			"postgres://memstore:[redacted]@db:5432/memstore?sslmode=disable",
+		},
+		{
+			// The live homelab password contains '+', so this is the shape that
+			// actually has to work, not a hypothetical.
+			"password with url-unsafe characters",
+			"postgres://memstore:aB+cD9=@db:5432/memstore?sslmode=disable",
+			"postgres://memstore:[redacted]@db:5432/memstore?sslmode=disable",
+		},
+		{
+			// A '/' in the password makes the DSN unparseable. Redacting the
+			// whole string is the safe answer: failing to parse is not evidence
+			// that there is no password in there.
+			"unparseable password is redacted whole",
+			"postgres://memstore:a+b/c=@db:5432/memstore",
+			"[redacted]",
+		},
+		{"no password, left alone", "postgres://memstore@db:5432/memstore", "postgres://memstore@db:5432/memstore"},
+		{"no credentials at all", "postgres://db:5432/memstore", "postgres://db:5432/memstore"},
+		{"unparseable is redacted whole", "postgres://memstore:pw@db:70000/x\x7f", "[redacted]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RedactDSN(tt.in); got != tt.want {
+				t.Errorf("RedactDSN(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppConfigString_RedactsPG(t *testing.T) {
+	c := AppConfig{PG: "postgres://memstore:hunter2@db:5432/memstore"}
+	s := c.String()
+	if strings.Contains(s, "hunter2") {
+		t.Errorf("AppConfig.String() leaked the DSN password: %s", s)
+	}
+	if !strings.Contains(s, "db:5432") {
+		t.Errorf("AppConfig.String() should keep the host for debugging: %s", s)
+	}
+}

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -58,7 +58,7 @@ memstore admin disable-user alice
 ```
 
 All `admin` commands connect directly to Postgres and are meant to run on the
-daemon host (set `--pg` or `MEMSTORE_PG`).
+daemon host (set `--pg` or `MEMSTORE_PG_SECRET`).
 
 ### What did not change
 
@@ -169,11 +169,11 @@ fact stalling the queue.
 If you were running `memstored` against SQLite:
 
 1. Stand up a Postgres instance with pgvector. The container image needs
-   a `MEMSTORE_PG` like
+   a `MEMSTORE_PG_SECRET` like
    `postgres://user:pass@host:5432/memstore?sslmode=disable` (or with
    `sslmode=require` for non-local hosts).
 2. Issue an API token (bound to a user; run on the daemon host, where
-   `MEMSTORE_PG` resolves):
+   `MEMSTORE_PG_SECRET` resolves):
    ```sh
    memstore admin issue-token --user <user> --scopes admin <user>@<host>
    # Prints the plaintext token once. Save it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -257,7 +257,7 @@ The daemon does its own TLS termination. TLS 1.2 minimum, 1.3 in practice. Optio
 
 ### Container
 
-Published to GHCR on every push to main. The Dockerfile builds a minimal image (`golang:1.25-alpine` builder → distroless-style runtime). The container expects `MEMSTORE_PG`, embedder env vars, and optionally `MEMSTORE_TLS_CERT_FILE` / `MEMSTORE_TLS_KEY_FILE` / `MEMSTORE_TLS_CLIENT_CA_FILE`.
+Published to GHCR on every push to main. The Dockerfile builds a minimal image (`golang:1.25-alpine` builder → distroless-style runtime). The container expects `MEMSTORE_PG_SECRET`, embedder env vars, and optionally `MEMSTORE_TLS_CERT_FILE` / `MEMSTORE_TLS_KEY_FILE` / `MEMSTORE_TLS_CLIENT_CA_FILE`.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,7 +80,7 @@ For multi-machine access, lower-latency context injection, and background proces
 go install github.com/matthewjhunter/memstore/cmd/memstored@latest
 
 # Postgres with pgvector is required
-export MEMSTORE_PG='postgres://memstore:secret@host:5432/memstore?sslmode=require'
+export MEMSTORE_PG_SECRET='postgres://memstore:secret@host:5432/memstore?sslmode=require'
 
 # Same embedder config as the CLI
 export MEMSTORE_EMBED_BACKEND=ollama
@@ -121,10 +121,10 @@ with constant-time comparison.
 
 Tokens are bound to a user, so the user has to exist first. Admin commands talk
 to PostgreSQL directly rather than through the API, so they run on the daemon
-host with `--pg` (or `MEMSTORE_PG`) pointing at the database:
+host with `--pg` (or `MEMSTORE_PG_SECRET`) pointing at the database:
 
 ```bash
-export MEMSTORE_PG=postgres://memstore:<password>@localhost:5432/memstore
+export MEMSTORE_PG_SECRET=postgres://memstore:<password>@localhost:5432/memstore
 
 # One-time: seed the identity schema and create the user
 memstore admin tier3-init --default-user matthew
@@ -222,7 +222,7 @@ hybrid order. The model can tune rerank behavior per session via the
 
 ```bash
 docker run -d \
-  -e MEMSTORE_PG='postgres://memstore@db:5432/memstore?sslmode=disable' \
+  -e MEMSTORE_PG_SECRET='postgres://memstore@db:5432/memstore?sslmode=disable' \
   -e MEMSTORE_API_KEY='<bootstrap-api-key>' \
   -e MEMSTORE_TLS_CERT_FILE=/certs/server.crt \
   -e MEMSTORE_TLS_KEY_FILE=/certs/server.key \
@@ -326,7 +326,7 @@ The database directory is created automatically on first run. The default path f
 | `MEMSTORE_NAMESPACE` | CLI, MCP, daemon | Namespace partition |
 | `MEMSTORE_REMOTE` | CLI, MCP | Daemon URL (enables daemon mode) |
 | `MEMSTORE_API_KEY` | CLI, MCP | Bearer token for daemon mode |
-| `MEMSTORE_PG` | daemon | Postgres connection string |
+| `MEMSTORE_PG_SECRET` | daemon | Postgres connection string. **Secret** -- the DSN embeds the database password. Formerly `MEMSTORE_PG`, which is still read (with a deprecation warning) but no longer documented: the old name matched none of the usual secret-filter patterns, so env dumps that correctly masked `*_KEY` and `*_PASSWORD` printed this DSN in full. The config-file key moved from `pg` to `pg_secret` on the same reasoning, and the old key is likewise still accepted. |
 | `MEMSTORE_TLS_CERT_FILE`, `MEMSTORE_TLS_KEY_FILE` | daemon | Server cert paths |
 | `MEMSTORE_TLS_CLIENT_CA_FILE` | daemon | mTLS client trust roots |
 | `MEMSTORE_API_KEY` | daemon | Single bootstrap API key; additional tokens live in the api_tokens table (issued via `memstore admin issue-token`) |


### PR DESCRIPTION
## Why

The Postgres DSN embeds the database password, but nothing about the name said so. The reflex for dumping a container's environment is to filter on `pass|key|secret|token` — which masks `MEMSTORE_API_KEY` and `POSTGRES_PASSWORD`, and sails straight past `MEMSTORE_PG`. So the DSN, password and all, printed in the clear. That is not hypothetical; it is how this was found.

## Changes

**Rename.** `MEMSTORE_PG` → `MEMSTORE_PG_SECRET`, config key `pg` → `pg_secret`. The name now trips the filter people already use.

Both old spellings still load. A deployment that renames the variable before the daemon image understands it will not start, so the compatibility window is what makes the rollout safe rather than a courtesy. The env var warns once per process on stderr (never stdout — that carries MCP JSON-RPC); the config-file key is accepted silently, since a file key does not get splattered into a transcript by a shell dump and a warning on every load would be MCP noise. The new name wins when both are set, in either file order.

**Redact the DSN in `AppConfig.String()`.** The same gap in a second place: `PG` sat next to `APIKey` and `LLMAPIKey`, which were already redacted, and was not — so any `%+v` of a config leaked it. `RedactDSN` masks only the password, leaving scheme, user, host, database and options intact. Blanket redaction would hide "am I pointed at the right host?", which is the question people actually have, and hiding it is what tempts someone to print the raw DSN instead. An unparseable DSN is redacted whole: failing to parse is not evidence there is no password in there.

## Naming

`_SECRET` because that substring is what the filter that failed already matches. No env-var secret-naming convention was recorded in the memstore facts, so this establishes one — happy to switch to `_DSN` or split the password into its own variable if you'd rather.

## Testing

`go vet ./...` clean; full suite passes. New coverage for both env spellings and their precedence, both config-file keys in both orders, `RedactDSN` (including a `+` in the password, the shape the live homelab credential actually has), and a regression test that `AppConfig.String()` cannot leak the password while keeping the host visible.

## Deploy ordering

Merging this builds the GHCR image that understands the new name. The homelab-side rename (matthewjhunter/homelab#173) must land only after that image is live, and is marked accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
