### PR TITLE
feat: chunk fact embeddings for retrieval

### DIFF
--- a/cmd/memstore-mcp/main.go
+++ b/cmd/memstore-mcp/main.go
@@ -86,6 +86,9 @@ func main() {
 
 	var store memstore.Store
 	var embedder embedding.Embedder
+	// Hard byte bound on a single embed request, from the configured budget.
+	// Only set in local mode; in daemon mode the server owns embedding.
+	var embedCeiling int
 
 	if *remote != "" {
 		// Daemon mode: talk to memstored over HTTP.
@@ -123,6 +126,7 @@ func main() {
 				log.Fatalf("memstore-mcp: create embedder: %v", err)
 			}
 			memstore.LogEmbedModel(embCfg)
+			embedCeiling = embCfg.Limits().MaxBytes
 			embedDesc = embCfg.Model
 		}
 
@@ -177,6 +181,10 @@ func main() {
 	}
 
 	memorySrv := mcpserver.NewMemoryServerWithConfig(store, embedder, srvCfg)
+	// The configured budget, not the model's registered one: sizing chunks
+	// against the registry while requests are clipped to a lower configured
+	// budget truncates every chunk's tail silently.
+	memorySrv.SetEmbedCeiling(embedCeiling)
 
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "memstore",

--- a/cmd/memstored/main.go
+++ b/cmd/memstored/main.go
@@ -241,6 +241,10 @@ func run(ctx context.Context, args []string, stderr io.Writer, onListening func(
 	// Use service scope so NeedingEmbedding/SetEmbedding/MarkEmbedFailed span
 	// all users. ServiceScope() is concrete (only reachable via pgStore here).
 	eq := httpapi.NewEmbedQueue(pgStore.ServiceScope(), embedder, *embedInterval, *embedBatch)
+	// The configured budget, not the model's registered one: sizing chunks
+	// against the registry while requests are clipped to a lower configured
+	// budget truncates every chunk's tail silently.
+	eq.SetCeiling(embCfg.Limits().MaxBytes)
 	eq.Start()
 	defer eq.Stop()
 

--- a/extract.go
+++ b/extract.go
@@ -43,10 +43,11 @@ type PromptFunc func(text string, hints ExtractHints) string
 
 // FactExtractor distills unstructured text into structured facts using an LLM.
 type FactExtractor struct {
-	store     Store
-	embedder  embedding.Embedder
-	generator Generator
-	promptFn  PromptFunc // nil = defaultPrompt
+	store        Store
+	embedder     embedding.Embedder
+	generator    Generator
+	promptFn     PromptFunc // nil = defaultPrompt
+	embedCeiling int
 }
 
 // NewFactExtractor creates an extractor that uses the given store, embedder,
@@ -58,6 +59,12 @@ func NewFactExtractor(store Store, embedder embedding.Embedder, generator Genera
 		generator: generator,
 	}
 }
+
+// SetEmbedCeiling sets the hard byte bound on any single embed request,
+// normally the configured embedder's effective budget
+// (embedding.Config.Limits().MaxBytes). Zero leaves chunk sizing to the
+// retrieval target alone.
+func (e *FactExtractor) SetEmbedCeiling(n int) { e.embedCeiling = n }
 
 // SetPromptFunc overrides the default prompt builder.
 func (e *FactExtractor) SetPromptFunc(fn PromptFunc) {
@@ -205,10 +212,22 @@ func (e *FactExtractor) Extract(ctx context.Context, text string, opts ExtractOp
 	}
 
 	// --- Phase B: batch embed ---
+	//
+	// This vector serves two purposes: it is the fact's dedup vector in Phase D
+	// (fact-to-fact similarity, where a single whole-fact point is the right
+	// unit) and, via Insert, its chunk 0. It is rendered through FactEmbedText
+	// so it matches what the embed queue and the MCP store path produce -- this
+	// path used to embed the bare content while the queue embedded
+	// "subject: content", leaving a fact's vector dependent on which path
+	// created it.
+	//
+	// Facts long enough to split are re-embedded as proper chunks after insert
+	// (Phase C). Short facts -- the large majority -- are a single chunk, so
+	// this one call is all they need.
 	if e.embedder != nil {
 		contents := make([]string, len(candidates))
 		for i, c := range candidates {
-			contents[i] = c.Content
+			contents[i] = FactEmbedText(c.Subject, c.Content)
 		}
 		embs, err := embedding.EmbedWithRetry(ctx, e.embedder, contents)
 		if err != nil {
@@ -238,6 +257,27 @@ func (e *FactExtractor) Extract(ctx context.Context, text string, opts ExtractOp
 		candidates[i].ID = id
 		batchIndexByID[id] = i
 		result.Inserted = append(result.Inserted, candidates[i].Fact)
+
+		// A fact long enough to split needs one vector per chunk; Insert only
+		// recorded the whole-fact vector as chunk 0. Re-embed those properly.
+		// The whole-fact vector stays on the candidate for Phase D's dedup.
+		if e.embedder == nil {
+			continue
+		}
+		if len(ChunkFact(e.embedder.Model(), c.Content, e.embedCeiling)) <= 1 {
+			continue
+		}
+		chunks, err := EmbedFact(ctx, e.embedder, e.embedder.Model(), c.Fact, e.embedCeiling)
+		if err != nil {
+			// The fact is stored and searchable on its chunk-0 vector; only the
+			// finer-grained chunks are missing. Report it rather than failing
+			// the extraction.
+			result.Errors = append(result.Errors, fmt.Errorf("chunking %q: %w", c.Content, err))
+			continue
+		}
+		if err := e.store.SetFactChunks(ctx, id, chunks); err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("storing chunks for %q: %w", c.Content, err))
+		}
 	}
 
 	// --- Phase D: supersession ---

--- a/extract.go
+++ b/extract.go
@@ -267,17 +267,24 @@ func (e *FactExtractor) Extract(ctx context.Context, text string, opts ExtractOp
 		if len(ChunkFact(e.embedder.Model(), c.Content, e.embedCeiling)) <= 1 {
 			continue
 		}
-		chunks, err := EmbedFact(ctx, e.embedder, e.embedder.Model(), c.Fact, e.embedCeiling)
+		vecs, err := EmbedFact(ctx, e.embedder, e.embedder.Model(), c.Fact, e.embedCeiling)
 		if err != nil {
-			// The fact is stored and searchable on its chunk-0 vector; only the
-			// finer-grained chunks are missing. Report it rather than failing
-			// the extraction.
+			// The fact is stored and searchable on the whole-fact vector Insert
+			// already recorded; only the finer-grained chunks are missing.
+			// Report it rather than failing the extraction.
 			result.Errors = append(result.Errors, fmt.Errorf("chunking %q: %w", c.Content, err))
 			continue
 		}
-		if err := e.store.SetFactChunks(ctx, id, chunks); err != nil {
+		if err := e.store.SetFactVectors(ctx, id, vecs); err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("storing chunks for %q: %w", c.Content, err))
+			continue
 		}
+		// Phase D compares this against other facts' stored markers, which are
+		// pooled. Carry the pooled vector across so both sides of the
+		// comparison mean the same thing; the Phase B vector was a single embed
+		// of the whole content, which for a fact this long was clipped.
+		candidates[i].Embedding = vecs.Whole
+		result.Inserted[len(result.Inserted)-1].Embedding = vecs.Whole
 	}
 
 	// --- Phase D: supersession ---

--- a/factchunk.go
+++ b/factchunk.go
@@ -1,0 +1,86 @@
+package memstore
+
+import (
+	embedding "github.com/matthewjhunter/go-embedding"
+)
+
+// FactChunk is one embeddable span of a fact's content, and the unit a vector
+// is actually stored against.
+//
+// A fact is a set of vectors rather than a point. Most facts are short enough
+// to be a single chunk, but a long one is split so that each vector describes
+// one passage: a vector has fixed capacity, and averaging a whole document
+// into it dilutes exactly the specificity retrieval depends on. See ChunkFact.
+type FactChunk struct {
+	// Ordinal is the chunk's position within the fact, from 0.
+	Ordinal int
+	// Vector is the embedding of this chunk.
+	Vector []float32
+	// ByteStart and ByteEnd address the span of Fact.Content this chunk was
+	// produced from, so a chunk hit resolves back to a passage of the fact
+	// rather than only to the fact. Overlap makes these impossible to
+	// recompute after the fact, so they are stored rather than derived.
+	ByteStart int
+	ByteEnd   int
+}
+
+// Chunk sizing for fact embeddings.
+//
+// These are retrieval targets, deliberately far below the models' registered
+// budgets (nomic-embed-text and embeddinggemma are both 6000 bytes). A vector
+// has fixed capacity, so filling the whole context window averages away the
+// specificity retrieval depends on; 256-512 tokens per chunk is the usual
+// working range. go-embedding's Split defaults to the model budget because
+// that is the only figure it knows, and documents that the caller should pass
+// something smaller -- this is memstore passing it.
+//
+// Keeping the target separate from the backend ceiling matters: the ceiling
+// exists so a request is not rejected, and the two answer different questions.
+// Deriving chunk size from the ceiling means raising the ceiling silently
+// widens every chunk and quietly degrades retrieval, with nothing reporting it
+// (see matthewjhunter/herald#297).
+const (
+	// ChunkTargetBytes is the size chunks aim for: roughly 512 tokens at
+	// typical English byte/token ratios.
+	ChunkTargetBytes = 1024
+	// ChunkOverlapBytes repeats the tail of each chunk at the head of the
+	// next, so a boundary landing mid-argument does not strand the two halves
+	// in vectors that each describe half a thought.
+	ChunkOverlapBytes = 128
+	// ChunkMinBytes absorbs a trailing sliver into its predecessor. A few
+	// words on their own embed to a vector that matches almost nothing.
+	ChunkMinBytes = 200
+)
+
+// ChunkFact splits a fact's content into the spans that will each become one
+// vector. Most facts are short and come back as a single chunk; only content
+// past ChunkTargetBytes is split.
+//
+// ceiling is a hard upper bound in bytes, normally the effective input budget
+// of the configured embedder (Config.Limits().MaxBytes). It only ever makes
+// chunks smaller: a ceiling below the target clamps it, so a backend stricter
+// than the target still gets requests it will accept, while a ceiling above
+// the target is ignored rather than used to inflate chunks. Pass 0 for no
+// ceiling.
+//
+// Chunk.Text is exactly content[Start:End], so a stored vector can be traced
+// back to the span of the fact it describes.
+func ChunkFact(model, content string, ceiling int) []embedding.Chunk {
+	target := ChunkTargetBytes
+	if ceiling > 0 && ceiling < target {
+		target = ceiling
+	}
+	overlap := ChunkOverlapBytes
+	minBytes := ChunkMinBytes
+	if target < ChunkTargetBytes {
+		// Scale the companion sizes with a clamped target, or a small ceiling
+		// leaves an overlap that swallows most of each chunk.
+		overlap = target * ChunkOverlapBytes / ChunkTargetBytes
+		minBytes = target * ChunkMinBytes / ChunkTargetBytes
+	}
+	return embedding.Split(model, content, embedding.SplitOptions{
+		MaxBytes: target,
+		Overlap:  overlap,
+		MinBytes: minBytes,
+	})
+}

--- a/factchunk.go
+++ b/factchunk.go
@@ -24,6 +24,26 @@ type FactChunk struct {
 	ByteEnd   int
 }
 
+// FactVectors is everything embedding a fact produces: the retrieval vectors,
+// one per chunk, and the single whole-fact vector used for comparing facts to
+// each other.
+//
+// The two are separate because they answer different questions. Retrieval wants
+// the nearest passage, so it needs a vector per chunk. Deduplication asks
+// whether two facts say the same thing, which is a property of the whole fact;
+// comparing a whole-fact vector against a chunk would compare an average with
+// an opening passage, score systematically low, and silently stop deduplicating
+// long facts. Auto-supersession is destructive, so that asymmetry is not one to
+// leave in place.
+type FactVectors struct {
+	// Whole is the vector over the fact's entire content, and the one stored
+	// as the fact row's marker. For a fact short enough to be a single chunk
+	// it is that chunk's vector -- they are the same text.
+	Whole []float32
+	// Chunks holds one vector per chunk, in ordinal order.
+	Chunks []FactChunk
+}
+
 // Chunk sizing for fact embeddings.
 //
 // These are retrieval targets, deliberately far below the models' registered

--- a/factchunk_store_test.go
+++ b/factchunk_store_test.go
@@ -1,0 +1,175 @@
+package memstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matthewjhunter/memstore"
+)
+
+// The multi-chunk semantics of chunked fact embeddings: a fact is a set of
+// vectors, and every fact-level comparison has to say what it means over that
+// set.
+//
+// mockEmbedder maps a single query text to [0.1, 0.2, 0.3, 0.4], so chunk
+// vectors here are chosen relative to that: a multiple of it scores 1.0, and
+// [4,-3,2,-1] is orthogonal to it and scores 0.
+
+func chunkAt(ordinal int, vec []float32) memstore.FactChunk {
+	return memstore.FactChunk{
+		Ordinal:   ordinal,
+		Vector:    vec,
+		ByteStart: ordinal * 100,
+		ByteEnd:   (ordinal + 1) * 100,
+	}
+}
+
+func TestSetFactChunks_RoundTripsEveryChunk(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	id, err := store.Insert(ctx, memstore.Fact{Content: "multi", Subject: "S", Category: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []memstore.FactChunk{
+		chunkAt(0, []float32{1, 0, 0, 0}),
+		chunkAt(1, []float32{0, 1, 0, 0}),
+		chunkAt(2, []float32{0, 0, 1, 0}),
+	}
+	if err := store.SetFactChunks(ctx, id, want); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.FactChunks(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d chunks, want 3", len(got))
+	}
+	for i, c := range got {
+		if c.Ordinal != i {
+			t.Errorf("row %d has ordinal %d -- chunks must come back in ordinal order", i, c.Ordinal)
+		}
+		if c.ByteStart != i*100 || c.ByteEnd != (i+1)*100 {
+			t.Errorf("chunk %d span [%d,%d) did not round-trip", i, c.ByteStart, c.ByteEnd)
+		}
+	}
+}
+
+// A re-embed producing fewer chunks must not leave the old high-ordinal
+// vectors behind, or they keep answering searches for text the fact no
+// longer has.
+func TestSetFactChunks_ReplacesRatherThanMerges(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	id, err := store.Insert(ctx, memstore.Fact{Content: "shrinks", Subject: "S", Category: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetFactChunks(ctx, id, []memstore.FactChunk{
+		chunkAt(0, []float32{1, 0, 0, 0}),
+		chunkAt(1, []float32{0, 1, 0, 0}),
+		chunkAt(2, []float32{0, 0, 1, 0}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetFactChunks(ctx, id, []memstore.FactChunk{
+		chunkAt(0, []float32{1, 0, 0, 0}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := store.FactChunks(ctx, id)
+	if len(got) != 1 {
+		t.Fatalf("got %d chunks after re-embedding to one, want 1", len(got))
+	}
+}
+
+// The payoff. A fact whose *second* chunk matches the query must be found, and
+// found once. Ranking on chunk 0 alone would miss it entirely; returning it per
+// matching chunk would let one long fact fill the result set.
+func TestSearch_RanksFactsByTheirBestChunk(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	longID, err := store.Insert(ctx, memstore.Fact{
+		Content: "zzz unrelated wording", Subject: "S", Category: "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	shortID, err := store.Insert(ctx, memstore.Fact{
+		Content: "yyy other wording", Subject: "S", Category: "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Chunk 0 is orthogonal to the query; chunk 1 is exactly on it.
+	if err := store.SetFactChunks(ctx, longID, []memstore.FactChunk{
+		chunkAt(0, []float32{4, -3, 2, -1}),
+		chunkAt(1, []float32{1, 2, 3, 4}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// A single chunk that matches, but less well than the long fact's chunk 1.
+	if err := store.SetFactChunks(ctx, shortID, []memstore.FactChunk{
+		chunkAt(0, []float32{1, 1, 1, 1}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.Search(ctx, "qqq", memstore.SearchOpts{
+		MaxResults: 10,
+		OnlyActive: true,
+		FTSWeight:  0.0001,
+		VecWeight:  1,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	seen := map[int64]int{}
+	var order []int64
+	for _, r := range results {
+		seen[r.Fact.ID]++
+		order = append(order, r.Fact.ID)
+	}
+	if seen[longID] == 0 {
+		t.Fatalf("the long fact was not found; its matching chunk is ordinal 1, "+
+			"so ranking on chunk 0 alone misses it (results: %v)", order)
+	}
+	if seen[longID] > 1 {
+		t.Errorf("the long fact appeared %d times; chunks must collapse to one hit per fact", seen[longID])
+	}
+	if order[0] != longID {
+		t.Errorf("ranked %v; the long fact's best chunk (1.0) beats the short fact's (0.91)", order)
+	}
+}
+
+// A fact inserted with a precomputed whole-fact vector must be findable: the
+// marker on the fact row is not what vector search reads.
+func TestInsert_PrecomputedEmbeddingIsSearchable(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	id, err := store.Insert(ctx, memstore.Fact{
+		Content: "zzz unrelated wording", Subject: "S", Category: "test",
+		Embedding: []float32{1, 2, 3, 4},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chunks, err := store.FactChunks(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("got %d chunk rows for a precomputed vector, want 1 -- "+
+			"vector search reads chunks, so the fact would be invisible", len(chunks))
+	}
+}

--- a/factchunk_store_test.go
+++ b/factchunk_store_test.go
@@ -15,6 +15,10 @@ import (
 // vectors here are chosen relative to that: a multiple of it scores 1.0, and
 // [4,-3,2,-1] is orthogonal to it and scores 0.
 
+func vecsOf(chunks ...memstore.FactChunk) memstore.FactVectors {
+	return memstore.FactVectors{Whole: chunks[0].Vector, Chunks: chunks}
+}
+
 func chunkAt(ordinal int, vec []float32) memstore.FactChunk {
 	return memstore.FactChunk{
 		Ordinal:   ordinal,
@@ -24,7 +28,7 @@ func chunkAt(ordinal int, vec []float32) memstore.FactChunk {
 	}
 }
 
-func TestSetFactChunks_RoundTripsEveryChunk(t *testing.T) {
+func TestSetFactVectors_RoundTripsEveryChunk(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()
 
@@ -37,7 +41,7 @@ func TestSetFactChunks_RoundTripsEveryChunk(t *testing.T) {
 		chunkAt(1, []float32{0, 1, 0, 0}),
 		chunkAt(2, []float32{0, 0, 1, 0}),
 	}
-	if err := store.SetFactChunks(ctx, id, want); err != nil {
+	if err := store.SetFactVectors(ctx, id, vecsOf(want...)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -61,7 +65,7 @@ func TestSetFactChunks_RoundTripsEveryChunk(t *testing.T) {
 // A re-embed producing fewer chunks must not leave the old high-ordinal
 // vectors behind, or they keep answering searches for text the fact no
 // longer has.
-func TestSetFactChunks_ReplacesRatherThanMerges(t *testing.T) {
+func TestSetFactVectors_ReplacesRatherThanMerges(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()
 
@@ -69,16 +73,16 @@ func TestSetFactChunks_ReplacesRatherThanMerges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetFactChunks(ctx, id, []memstore.FactChunk{
+	if err := store.SetFactVectors(ctx, id, vecsOf(
 		chunkAt(0, []float32{1, 0, 0, 0}),
 		chunkAt(1, []float32{0, 1, 0, 0}),
 		chunkAt(2, []float32{0, 0, 1, 0}),
-	}); err != nil {
+	)); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetFactChunks(ctx, id, []memstore.FactChunk{
+	if err := store.SetFactVectors(ctx, id, vecsOf(
 		chunkAt(0, []float32{1, 0, 0, 0}),
-	}); err != nil {
+	)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -109,16 +113,16 @@ func TestSearch_RanksFactsByTheirBestChunk(t *testing.T) {
 	}
 
 	// Chunk 0 is orthogonal to the query; chunk 1 is exactly on it.
-	if err := store.SetFactChunks(ctx, longID, []memstore.FactChunk{
+	if err := store.SetFactVectors(ctx, longID, vecsOf(
 		chunkAt(0, []float32{4, -3, 2, -1}),
 		chunkAt(1, []float32{1, 2, 3, 4}),
-	}); err != nil {
+	)); err != nil {
 		t.Fatal(err)
 	}
 	// A single chunk that matches, but less well than the long fact's chunk 1.
-	if err := store.SetFactChunks(ctx, shortID, []memstore.FactChunk{
+	if err := store.SetFactVectors(ctx, shortID, vecsOf(
 		chunkAt(0, []float32{1, 1, 1, 1}),
-	}); err != nil {
+	)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/factchunk_test.go
+++ b/factchunk_test.go
@@ -1,0 +1,106 @@
+package memstore_test
+
+import (
+	"strings"
+	"testing"
+
+	embedding "github.com/matthewjhunter/go-embedding"
+	"github.com/matthewjhunter/memstore"
+)
+
+const chunkModel = "nomic-embed-text"
+
+// Most facts are short. They must stay one vector, or chunking would multiply
+// the corpus for no retrieval gain.
+func TestChunkFact_ShortFactStaysWhole(t *testing.T) {
+	content := "Matthew prefers ASCII punctuation in everything Claude writes."
+
+	chunks := memstore.ChunkFact(chunkModel, content, 0)
+
+	if len(chunks) != 1 {
+		t.Fatalf("got %d chunks for a %d-byte fact, want 1", len(chunks), len(content))
+	}
+	if chunks[0].Text != content {
+		t.Errorf("chunk text %q != content", chunks[0].Text)
+	}
+}
+
+// The point of the change: chunks are sized for retrieval, not to fill the
+// model's context window. nomic-embed-text is registered at 6000 bytes, so a
+// 3000-byte fact would be a single vector if the budget drove sizing.
+func TestChunkFact_TargetIsWellUnderTheModelBudget(t *testing.T) {
+	budget := embedding.LookupLimits(chunkModel).MaxBytes
+	if budget < 3000 {
+		t.Fatalf("test assumes a model budget over 3000 bytes, got %d", budget)
+	}
+	content := strings.Repeat("The retry budget needs careful tuning. ", 80) // ~3000 bytes
+
+	chunks := memstore.ChunkFact(chunkModel, content, 0)
+
+	if len(chunks) < 2 {
+		t.Fatalf("a %d-byte fact produced %d chunk(s); it fits the %d-byte model budget, "+
+			"which is exactly the sizing this is meant not to use", len(content), len(chunks), budget)
+	}
+	for i, c := range chunks {
+		if len(c.Text) > memstore.ChunkTargetBytes {
+			t.Errorf("chunk %d is %d bytes, over the %d-byte target", i, len(c.Text), memstore.ChunkTargetBytes)
+		}
+	}
+}
+
+// The target is a retrieval choice; the ceiling is a backend constraint. When
+// the backend is stricter than the target, the backend has to win or requests
+// get rejected.
+func TestChunkFact_CeilingClampsTheTarget(t *testing.T) {
+	content := strings.Repeat("The retry budget needs careful tuning. ", 80)
+	const ceiling = 400
+
+	chunks := memstore.ChunkFact(chunkModel, content, ceiling)
+
+	if len(chunks) < 2 {
+		t.Fatalf("got %d chunks, want several", len(chunks))
+	}
+	for i, c := range chunks {
+		if len(c.Text) > ceiling {
+			t.Errorf("chunk %d is %d bytes, over the %d-byte ceiling", i, len(c.Text), ceiling)
+		}
+	}
+}
+
+// A ceiling above the target must not inflate chunks: that is the herald
+// failure mode (raising the backend limit silently widens chunks).
+func TestChunkFact_GenerousCeilingDoesNotInflateChunks(t *testing.T) {
+	content := strings.Repeat("The retry budget needs careful tuning. ", 80)
+
+	tight := memstore.ChunkFact(chunkModel, content, memstore.ChunkTargetBytes*4)
+	none := memstore.ChunkFact(chunkModel, content, 0)
+
+	if len(tight) != len(none) {
+		t.Errorf("a ceiling of %d produced %d chunks but no ceiling produced %d; "+
+			"the ceiling is raising the target", memstore.ChunkTargetBytes*4, len(tight), len(none))
+	}
+}
+
+// Offsets are provenance: a chunk hit has to resolve back to a span of the
+// fact. Overlap makes them impossible to recompute, so they must be exact.
+func TestChunkFact_OffsetsAddressTheSourceExactly(t *testing.T) {
+	content := strings.Repeat("The retry budget needs careful tuning. ", 80)
+
+	for i, c := range memstore.ChunkFact(chunkModel, content, 0) {
+		if c.Start < 0 || c.End > len(content) || c.Start > c.End {
+			t.Fatalf("chunk %d has out-of-range span [%d,%d) for %d bytes", i, c.Start, c.End, len(content))
+		}
+		if got := content[c.Start:c.End]; got != c.Text {
+			t.Errorf("chunk %d: content[%d:%d] != Text", i, c.Start, c.End)
+		}
+		if c.Ordinal != i {
+			t.Errorf("chunk %d has ordinal %d", i, c.Ordinal)
+		}
+	}
+}
+
+func TestChunkFact_EmptyContentYieldsNothing(t *testing.T) {
+	if got := memstore.ChunkFact(chunkModel, "   \n ", 0); len(got) != 0 {
+		t.Errorf("got %d chunks for whitespace-only content", len(got))
+	}
+}

--- a/factembed.go
+++ b/factembed.go
@@ -3,6 +3,7 @@ package memstore
 import (
 	"context"
 	"fmt"
+	"math"
 
 	embedding "github.com/matthewjhunter/go-embedding"
 )
@@ -22,7 +23,7 @@ func FactEmbedText(subject, chunk string) string {
 }
 
 // EmbedFact splits a fact's content into retrieval-sized chunks and embeds
-// each one, returning a FactChunk per chunk in ordinal order.
+// each one, plus the whole-fact vector deduplication compares against.
 //
 // ceiling is a hard byte bound on the rendered text of any single chunk,
 // normally the effective input budget of the configured embedder. The subject
@@ -30,11 +31,25 @@ func FactEmbedText(subject, chunk string) string {
 // body at the full ceiling and then prepending a header would push every
 // request over it.
 //
-// Either every chunk embeds or none do. A partially embedded fact would look
+// The whole-fact vector is pooled from the chunk vectors rather than embedded
+// from the whole text. Embedding the whole text is not available here: a fact
+// that splits is by definition longer than the ceiling, so that request is the
+// one a strict backend rejects, and clipping it back under the ceiling would
+// discard the tail -- reintroducing the loss chunking removed. Pooling covers
+// every chunk, costs no extra request, and is the standard answer for a
+// whole-document vector.
+//
+// Pooling is the right tool here precisely because the question is different
+// from retrieval's. Averaging dilutes the specificity a passage lookup needs,
+// which is why chunks are stored separately; but "do these two facts say the
+// same thing" is a property of the whole fact, and a pooled vector is what
+// represents it.
+//
+// Either every vector embeds or none do. A partially embedded fact would look
 // complete to the queue (its marker vector is set) and leave a permanent hole
-// in the middle of it, so a failure returns no chunks and the fact is retried
+// in the middle of it, so a failure returns nothing and the fact is retried
 // whole.
-func EmbedFact(ctx context.Context, e embedding.Embedder, model string, f Fact, ceiling int) ([]FactChunk, error) {
+func EmbedFact(ctx context.Context, e embedding.Embedder, model string, f Fact, ceiling int) (FactVectors, error) {
 	// Charge the header to the budget by measuring it rather than assuming it.
 	overhead := len(FactEmbedText(f.Subject, ""))
 	bodyCeiling := ceiling
@@ -50,7 +65,7 @@ func EmbedFact(ctx context.Context, e embedding.Embedder, model string, f Fact, 
 
 	chunks := ChunkFact(model, f.Content, bodyCeiling)
 	if len(chunks) == 0 {
-		return nil, nil
+		return FactVectors{}, nil
 	}
 
 	texts := make([]string, len(chunks))
@@ -60,21 +75,60 @@ func EmbedFact(ctx context.Context, e embedding.Embedder, model string, f Fact, 
 
 	vecs, err := embedding.EmbedWithRetry(ctx, e, texts)
 	if err != nil {
-		return nil, fmt.Errorf("memstore: embedding fact %d: %w", f.ID, err)
+		return FactVectors{}, fmt.Errorf("memstore: embedding fact %d: %w", f.ID, err)
 	}
-	if len(vecs) != len(chunks) {
-		return nil, fmt.Errorf("memstore: embedding fact %d: got %d vectors for %d chunks",
-			f.ID, len(vecs), len(chunks))
+	if len(vecs) != len(texts) {
+		return FactVectors{}, fmt.Errorf("memstore: embedding fact %d: got %d vectors for %d inputs",
+			f.ID, len(vecs), len(texts))
 	}
 
-	out := make([]FactChunk, len(chunks))
+	out := FactVectors{Chunks: make([]FactChunk, len(chunks))}
 	for i, c := range chunks {
-		out[i] = FactChunk{
+		out.Chunks[i] = FactChunk{
 			Ordinal:   c.Ordinal,
 			Vector:    vecs[i],
 			ByteStart: c.Start,
 			ByteEnd:   c.End,
 		}
 	}
+	out.Whole = poolVectors(vecs)
 	return out, nil
+}
+
+// poolVectors averages unit-normalised vectors into a centroid.
+//
+// Normalising first stops a chunk with a larger magnitude from dominating the
+// result, so the centroid reflects direction -- which is all cosine similarity
+// reads -- rather than length. A single vector pools to itself, so a fact that
+// did not split keeps exactly its own chunk vector.
+func poolVectors(vecs [][]float32) []float32 {
+	if len(vecs) == 0 {
+		return nil
+	}
+	if len(vecs) == 1 {
+		return vecs[0]
+	}
+	out := make([]float32, len(vecs[0]))
+	for _, v := range vecs {
+		if len(v) != len(out) {
+			// Ragged dimensions mean the backend changed model mid-batch;
+			// there is no meaningful centroid to take.
+			return nil
+		}
+		var norm float64
+		for _, x := range v {
+			norm += float64(x) * float64(x)
+		}
+		norm = math.Sqrt(norm)
+		if norm == 0 {
+			continue
+		}
+		for i, x := range v {
+			out[i] += float32(float64(x) / norm)
+		}
+	}
+	for i := range out {
+		out[i] /= float32(len(vecs))
+	}
+	return out
 }

--- a/factembed.go
+++ b/factembed.go
@@ -1,0 +1,80 @@
+package memstore
+
+import (
+	"context"
+	"fmt"
+
+	embedding "github.com/matthewjhunter/go-embedding"
+)
+
+// FactEmbedText renders what is actually sent to the model for one chunk: the
+// fact's subject, then the chunk body.
+//
+// The subject is re-applied to every chunk rather than only the first. Split
+// the rendered text instead and chunk 0 keeps the subject while chunks 1..N are
+// anonymous prose with nothing saying which fact they belong to -- no error,
+// just worse retrieval on exactly the long facts chunking was meant to rescue.
+func FactEmbedText(subject, chunk string) string {
+	if subject == "" {
+		return chunk
+	}
+	return subject + ": " + chunk
+}
+
+// EmbedFact splits a fact's content into retrieval-sized chunks and embeds
+// each one, returning a FactChunk per chunk in ordinal order.
+//
+// ceiling is a hard byte bound on the rendered text of any single chunk,
+// normally the effective input budget of the configured embedder. The subject
+// header is charged against it, so the body gets the remainder -- sizing the
+// body at the full ceiling and then prepending a header would push every
+// request over it.
+//
+// Either every chunk embeds or none do. A partially embedded fact would look
+// complete to the queue (its marker vector is set) and leave a permanent hole
+// in the middle of it, so a failure returns no chunks and the fact is retried
+// whole.
+func EmbedFact(ctx context.Context, e embedding.Embedder, model string, f Fact, ceiling int) ([]FactChunk, error) {
+	// Charge the header to the budget by measuring it rather than assuming it.
+	overhead := len(FactEmbedText(f.Subject, ""))
+	bodyCeiling := ceiling
+	if bodyCeiling > 0 {
+		bodyCeiling -= overhead
+		if bodyCeiling < 1 {
+			// A subject long enough to leave no room for a body is
+			// pathological. Embed what fits rather than splitting into
+			// slivers; go-embedding still clips to the model's budget.
+			bodyCeiling = 1
+		}
+	}
+
+	chunks := ChunkFact(model, f.Content, bodyCeiling)
+	if len(chunks) == 0 {
+		return nil, nil
+	}
+
+	texts := make([]string, len(chunks))
+	for i, c := range chunks {
+		texts[i] = FactEmbedText(f.Subject, c.Text)
+	}
+
+	vecs, err := embedding.EmbedWithRetry(ctx, e, texts)
+	if err != nil {
+		return nil, fmt.Errorf("memstore: embedding fact %d: %w", f.ID, err)
+	}
+	if len(vecs) != len(chunks) {
+		return nil, fmt.Errorf("memstore: embedding fact %d: got %d vectors for %d chunks",
+			f.ID, len(vecs), len(chunks))
+	}
+
+	out := make([]FactChunk, len(chunks))
+	for i, c := range chunks {
+		out[i] = FactChunk{
+			Ordinal:   c.Ordinal,
+			Vector:    vecs[i],
+			ByteStart: c.Start,
+			ByteEnd:   c.End,
+		}
+	}
+	return out, nil
+}

--- a/factembed_internal_test.go
+++ b/factembed_internal_test.go
@@ -1,0 +1,55 @@
+package memstore
+
+import "testing"
+
+// poolVectors is what deduplication compares facts on, so its properties
+// matter: every chunk has to count, and magnitude must not decide the outcome.
+
+func TestPoolVectors_SingleVectorPoolsToItself(t *testing.T) {
+	v := []float32{1, 2, 3}
+	if got := poolVectors([][]float32{v}); !sameVec(got, v) {
+		t.Errorf("poolVectors(one) = %v, want %v -- an unsplit fact keeps its own vector", got, v)
+	}
+}
+
+// Dropping a chunk must change the result. If it does not, the tail of a long
+// fact is invisible to deduplication -- the loss chunking removed, reintroduced.
+func TestPoolVectors_EveryVectorCounts(t *testing.T) {
+	all := [][]float32{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}
+
+	if sameVec(poolVectors(all), poolVectors(all[:2])) {
+		t.Error("dropping the last vector did not change the centroid")
+	}
+}
+
+// A chunk with a larger magnitude must not dominate: cosine reads direction,
+// so the centroid is over unit vectors.
+func TestPoolVectors_MagnitudeDoesNotDominate(t *testing.T) {
+	balanced := poolVectors([][]float32{{1, 0}, {0, 1}})
+	lopsided := poolVectors([][]float32{{100, 0}, {0, 1}})
+
+	if !sameVec(balanced, lopsided) {
+		t.Errorf("centroid moved from %v to %v when one vector was scaled up; "+
+			"vectors must be normalised before averaging", balanced, lopsided)
+	}
+}
+
+func TestPoolVectors_RaggedDimensionsYieldNothing(t *testing.T) {
+	if got := poolVectors([][]float32{{1, 0}, {0, 1, 0}}); got != nil {
+		t.Errorf("got %v for mismatched dimensions, want nil", got)
+	}
+}
+
+func sameVec(a, b []float32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	const eps = 1e-6
+	for i := range a {
+		d := a[i] - b[i]
+		if d > eps || d < -eps {
+			return false
+		}
+	}
+	return true
+}

--- a/factembed_test.go
+++ b/factembed_test.go
@@ -12,18 +12,20 @@ import (
 
 // recordingEmbedder captures the exact texts sent to the backend.
 type recordingEmbedder struct {
-	seen []string
-	err  error
+	seen  []string
+	calls int
+	err   error
 }
 
 func (r *recordingEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	r.calls++
 	if r.err != nil {
 		return nil, r.err
 	}
 	r.seen = append(r.seen, texts...)
 	out := make([][]float32, len(texts))
-	for i := range out {
-		out[i] = []float32{float32(i), 1}
+	for i, t := range texts {
+		out[i] = []float32{float32(i + 1), float32(len(t))}
 	}
 	return out, nil
 }
@@ -43,12 +45,12 @@ func TestEmbedFact_ShortFactSendsSubjectAndContent(t *testing.T) {
 	e := &recordingEmbedder{}
 	f := memstore.Fact{Subject: "matthew", Content: "Prefers ASCII punctuation everywhere."}
 
-	chunks, err := memstore.EmbedFact(context.Background(), e, chunkModel, f, 0)
+	vecs, err := memstore.EmbedFact(context.Background(), e, chunkModel, f, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) != 1 {
-		t.Fatalf("got %d chunks, want 1", len(chunks))
+	if len(vecs.Chunks) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(vecs.Chunks))
 	}
 	if len(e.seen) != 1 || !strings.Contains(e.seen[0], "matthew") || !strings.Contains(e.seen[0], "ASCII") {
 		t.Errorf("embedded text %q does not carry both subject and content", e.seen)
@@ -62,12 +64,12 @@ func TestEmbedFact_EveryChunkCarriesTheSubject(t *testing.T) {
 	e := &recordingEmbedder{}
 	f := longFact()
 
-	chunks, err := memstore.EmbedFact(context.Background(), e, chunkModel, f, 0)
+	vecs, err := memstore.EmbedFact(context.Background(), e, chunkModel, f, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(chunks) < 2 {
-		t.Fatalf("got %d chunks, want several", len(chunks))
+	if len(vecs.Chunks) < 2 {
+		t.Fatalf("got %d chunks, want several", len(vecs.Chunks))
 	}
 	for i, text := range e.seen {
 		if !strings.Contains(text, f.Subject) {
@@ -83,17 +85,17 @@ func TestEmbedFact_OffsetsAddressContentNotRenderedText(t *testing.T) {
 	e := &recordingEmbedder{}
 	f := longFact()
 
-	chunks, err := memstore.EmbedFact(context.Background(), e, chunkModel, f, 0)
+	vecs, err := memstore.EmbedFact(context.Background(), e, chunkModel, f, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, c := range chunks {
+	for _, c := range vecs.Chunks {
 		if c.ByteStart < 0 || c.ByteEnd > len(f.Content) || c.ByteStart >= c.ByteEnd {
 			t.Errorf("chunk %d span [%d,%d) is not inside the %d-byte content",
 				c.Ordinal, c.ByteStart, c.ByteEnd, len(f.Content))
 		}
 	}
-	if last := chunks[len(chunks)-1]; last.ByteEnd < len(f.Content)-ChunkSlack {
+	if last := vecs.Chunks[len(vecs.Chunks)-1]; last.ByteEnd < len(f.Content)-ChunkSlack {
 		t.Errorf("last chunk ends at %d, leaving %d bytes of a %d-byte fact unindexed",
 			last.ByteEnd, len(f.Content)-last.ByteEnd, len(f.Content))
 	}
@@ -104,12 +106,12 @@ func TestEmbedFact_OffsetsAddressContentNotRenderedText(t *testing.T) {
 func TestEmbedFact_FailureIsAllOrNothing(t *testing.T) {
 	e := &recordingEmbedder{err: errors.New("backend down")}
 
-	chunks, err := memstore.EmbedFact(context.Background(), e, chunkModel, longFact(), 0)
+	vecs, err := memstore.EmbedFact(context.Background(), e, chunkModel, longFact(), 0)
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if len(chunks) != 0 {
-		t.Errorf("got %d chunks alongside an error; a partial set must never be stored", len(chunks))
+	if len(vecs.Chunks) != 0 {
+		t.Errorf("got %d chunks alongside an error; a partial set must never be stored", len(vecs.Chunks))
 	}
 }
 
@@ -132,3 +134,80 @@ func TestEmbedFact_CeilingBoundsTheRenderedText(t *testing.T) {
 // ChunkSlack tolerates the trailing-sliver merge and whitespace trimming when
 // asserting coverage.
 const ChunkSlack = 300
+
+// --- The dedup vector ---
+//
+// Auto-supersession compares a new fact's vector against an existing fact's
+// stored marker, and acts destructively at 0.85. Both sides therefore have to
+// mean the same thing: a whole-fact vector. Letting the marker be chunk 0 makes
+// it an opening-passage vector for anything that splits, which compares low
+// against a whole-fact average and silently stops deduping long facts.
+
+func TestEmbedFact_SingleChunkReusesItsVectorAsTheWhole(t *testing.T) {
+	e := &recordingEmbedder{}
+	f := memstore.Fact{Subject: "matthew", Content: "Prefers ASCII punctuation everywhere."}
+
+	v, err := memstore.EmbedFact(context.Background(), e, chunkModel, f, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v.Chunks) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(v.Chunks))
+	}
+	if len(e.seen) != 1 {
+		t.Errorf("sent %d texts for a single-chunk fact, want 1 -- "+
+			"chunk 0 already is the whole fact, so no separate embed is needed", len(e.seen))
+	}
+	if !vecEq(v.Whole, v.Chunks[0].Vector) {
+		t.Error("Whole differs from the only chunk's vector")
+	}
+}
+
+func TestEmbedFact_MultiChunkPoolsAWholeFactVector(t *testing.T) {
+	e := &recordingEmbedder{}
+
+	v, err := memstore.EmbedFact(context.Background(), e, chunkModel, longFact(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v.Chunks) < 2 {
+		t.Fatalf("got %d chunks, want several", len(v.Chunks))
+	}
+	if len(v.Whole) == 0 {
+		t.Fatal("no whole-fact vector; supersession would have nothing to compare")
+	}
+	if vecEq(v.Whole, v.Chunks[0].Vector) {
+		t.Error("Whole is chunk 0's vector -- for a fact that splits, that is the " +
+			"opening passage, not the fact")
+	}
+}
+
+// Pooling comes from the chunk vectors already in hand, so a fact costs one
+// request whether or not it splits.
+func TestEmbedFact_WholeFactCostsNoExtraInput(t *testing.T) {
+	e := &recordingEmbedder{}
+
+	v, err := memstore.EmbedFact(context.Background(), e, chunkModel, longFact(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.calls != 1 {
+		t.Errorf("made %d embed calls, want 1", e.calls)
+	}
+	if len(e.seen) != len(v.Chunks) {
+		t.Errorf("sent %d texts for %d chunks; the whole-fact vector must be pooled, not embedded",
+			len(e.seen), len(v.Chunks))
+	}
+}
+
+func vecEq(a, b []float32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/factembed_test.go
+++ b/factembed_test.go
@@ -1,0 +1,134 @@
+package memstore_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	embedding "github.com/matthewjhunter/go-embedding"
+	"github.com/matthewjhunter/memstore"
+)
+
+// recordingEmbedder captures the exact texts sent to the backend.
+type recordingEmbedder struct {
+	seen []string
+	err  error
+}
+
+func (r *recordingEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	r.seen = append(r.seen, texts...)
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = []float32{float32(i), 1}
+	}
+	return out, nil
+}
+func (r *recordingEmbedder) Model() string { return chunkModel }
+func (r *recordingEmbedder) Fingerprint() embedding.Fingerprint {
+	return embedding.Fingerprint{Model: chunkModel}
+}
+
+func longFact() memstore.Fact {
+	return memstore.Fact{
+		Subject: "deployment",
+		Content: strings.Repeat("The retry budget needs careful tuning. ", 80),
+	}
+}
+
+func TestEmbedFact_ShortFactSendsSubjectAndContent(t *testing.T) {
+	e := &recordingEmbedder{}
+	f := memstore.Fact{Subject: "matthew", Content: "Prefers ASCII punctuation everywhere."}
+
+	chunks, err := memstore.EmbedFact(context.Background(), e, chunkModel, f, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(chunks))
+	}
+	if len(e.seen) != 1 || !strings.Contains(e.seen[0], "matthew") || !strings.Contains(e.seen[0], "ASCII") {
+		t.Errorf("embedded text %q does not carry both subject and content", e.seen)
+	}
+}
+
+// The lesson chunking usually gets wrong: split the rendered text and chunk 0
+// keeps the subject while chunks 1..N are anonymous prose. Every chunk must
+// carry it.
+func TestEmbedFact_EveryChunkCarriesTheSubject(t *testing.T) {
+	e := &recordingEmbedder{}
+	f := longFact()
+
+	chunks, err := memstore.EmbedFact(context.Background(), e, chunkModel, f, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("got %d chunks, want several", len(chunks))
+	}
+	for i, text := range e.seen {
+		if !strings.Contains(text, f.Subject) {
+			t.Errorf("chunk %d was embedded without its subject: %q", i, text[:min(60, len(text))])
+		}
+	}
+}
+
+// Offsets address Fact.Content, not the rendered text. Rendering adds a header
+// per chunk, so offsets taken from the rendered string would drift further out
+// with every chunk.
+func TestEmbedFact_OffsetsAddressContentNotRenderedText(t *testing.T) {
+	e := &recordingEmbedder{}
+	f := longFact()
+
+	chunks, err := memstore.EmbedFact(context.Background(), e, chunkModel, f, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range chunks {
+		if c.ByteStart < 0 || c.ByteEnd > len(f.Content) || c.ByteStart >= c.ByteEnd {
+			t.Errorf("chunk %d span [%d,%d) is not inside the %d-byte content",
+				c.Ordinal, c.ByteStart, c.ByteEnd, len(f.Content))
+		}
+	}
+	if last := chunks[len(chunks)-1]; last.ByteEnd < len(f.Content)-ChunkSlack {
+		t.Errorf("last chunk ends at %d, leaving %d bytes of a %d-byte fact unindexed",
+			last.ByteEnd, len(f.Content)-last.ByteEnd, len(f.Content))
+	}
+}
+
+// A half-embedded fact would look complete to the queue and leave a permanent
+// hole in the middle of it.
+func TestEmbedFact_FailureIsAllOrNothing(t *testing.T) {
+	e := &recordingEmbedder{err: errors.New("backend down")}
+
+	chunks, err := memstore.EmbedFact(context.Background(), e, chunkModel, longFact(), 0)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if len(chunks) != 0 {
+		t.Errorf("got %d chunks alongside an error; a partial set must never be stored", len(chunks))
+	}
+}
+
+// The header is charged against the budget, so a ceiling must bound the
+// rendered text, not just the body.
+func TestEmbedFact_CeilingBoundsTheRenderedText(t *testing.T) {
+	e := &recordingEmbedder{}
+	const ceiling = 400
+
+	if _, err := memstore.EmbedFact(context.Background(), e, chunkModel, longFact(), ceiling); err != nil {
+		t.Fatal(err)
+	}
+	for i, text := range e.seen {
+		if len(text) > ceiling {
+			t.Errorf("chunk %d rendered to %d bytes, over the %d-byte ceiling", i, len(text), ceiling)
+		}
+	}
+}
+
+// ChunkSlack tolerates the trailing-sliver merge and whitespace trimming when
+// asserting coverage.
+const ChunkSlack = 300

--- a/httpapi/embedqueue.go
+++ b/httpapi/embedqueue.go
@@ -100,7 +100,7 @@ func (eq *EmbedQueue) ProcessOnce() {
 	// together inside EmbedFact -- they succeed or fail as a unit anyway.
 	embedded := 0
 	for _, f := range facts {
-		chunks, err := memstore.EmbedFact(ctx, eq.embedder, eq.embedder.Model(), f, eq.ceiling)
+		vecs, err := memstore.EmbedFact(ctx, eq.embedder, eq.embedder.Model(), f, eq.ceiling)
 		if err != nil {
 			// A transient failure (timeout, 5xx) keeps its NULL embedding and
 			// is retried next tick. A permanent failure would otherwise loop
@@ -118,7 +118,7 @@ func (eq *EmbedQueue) ProcessOnce() {
 			log.Printf("embed queue: EmbedFact id=%d: %v", f.ID, err)
 			continue
 		}
-		if len(chunks) == 0 {
+		if len(vecs.Chunks) == 0 {
 			// Content with nothing embeddable in it (empty or whitespace).
 			// Quarantine rather than re-queue it forever.
 			log.Printf("embed queue: quarantining id=%d (no embeddable content)", f.ID)
@@ -127,8 +127,8 @@ func (eq *EmbedQueue) ProcessOnce() {
 			}
 			continue
 		}
-		if err := eq.store.SetFactChunks(ctx, f.ID, chunks); err != nil {
-			log.Printf("embed queue: SetFactChunks id=%d: %v", f.ID, err)
+		if err := eq.store.SetFactVectors(ctx, f.ID, vecs); err != nil {
+			log.Printf("embed queue: SetFactVectors id=%d: %v", f.ID, err)
 			continue
 		}
 		embedded++

--- a/httpapi/embedqueue.go
+++ b/httpapi/embedqueue.go
@@ -16,6 +16,7 @@ type EmbedQueue struct {
 	embedder embedding.Embedder
 	interval time.Duration
 	batch    int
+	ceiling  int
 
 	done chan struct{}
 	wg   sync.WaitGroup
@@ -38,6 +39,18 @@ func NewEmbedQueue(store memstore.Store, embedder embedding.Embedder, interval t
 		done:     make(chan struct{}),
 	}
 }
+
+// SetCeiling sets the hard byte bound on any single embed request, normally
+// the configured embedder's effective budget (embedding.Config.Limits().MaxBytes).
+//
+// It has to be passed in because the Embedder interface does not expose it, and
+// it must be the *configured* budget rather than the model's registered one: a
+// deployment lowers it when the backend serving the model is stricter than the
+// model itself, and sizing against the registered figure while the request is
+// clipped to a lower configured one truncates every chunk's tail silently.
+//
+// Zero leaves chunk sizing to the retrieval target alone.
+func (eq *EmbedQueue) SetCeiling(n int) { eq.ceiling = n }
 
 // Start begins the background embedding loop.
 func (eq *EmbedQueue) Start() {
@@ -83,18 +96,18 @@ func (eq *EmbedQueue) ProcessOnce() {
 	// poisoned input (e.g. context-length error) fail the whole batch and
 	// stall the queue forever, since NeedingEmbedding would keep returning
 	// the same head-of-queue rows. Per-fact lets us isolate the bad fact and
-	// keep the rest of the queue moving.
+	// keep the rest of the queue moving. A fact's own chunks are still batched
+	// together inside EmbedFact -- they succeed or fail as a unit anyway.
 	embedded := 0
 	for _, f := range facts {
-		text := f.Subject + ": " + f.Content
-		embs, err := eq.embedder.Embed(ctx, []string{text})
+		chunks, err := memstore.EmbedFact(ctx, eq.embedder, eq.embedder.Model(), f, eq.ceiling)
 		if err != nil {
 			// A transient failure (timeout, 5xx) keeps its NULL embedding and
 			// is retried next tick. A permanent failure would otherwise loop
 			// forever — NeedingEmbedding hands the same row back every poll —
-			// so quarantine it. The embedder already truncates/adaptively
-			// shrinks over-length input, so a permanent failure here means a
-			// genuinely unembeddable fact, not merely a long one.
+			// so quarantine it. Chunking already keeps each request inside the
+			// budget, so a permanent failure here means a genuinely
+			// unembeddable fact, not merely a long one.
 			if !embedding.IsRetryable(err) {
 				log.Printf("embed queue: quarantining id=%d (permanent embed failure): %v", f.ID, err)
 				if mErr := eq.store.MarkEmbedFailed(ctx, f.ID, err.Error()); mErr != nil {
@@ -102,15 +115,20 @@ func (eq *EmbedQueue) ProcessOnce() {
 				}
 				continue
 			}
-			log.Printf("embed queue: Embed id=%d: %v", f.ID, err)
+			log.Printf("embed queue: EmbedFact id=%d: %v", f.ID, err)
 			continue
 		}
-		if len(embs) != 1 {
-			log.Printf("embed queue: Embed id=%d: got %d embeddings, want 1", f.ID, len(embs))
+		if len(chunks) == 0 {
+			// Content with nothing embeddable in it (empty or whitespace).
+			// Quarantine rather than re-queue it forever.
+			log.Printf("embed queue: quarantining id=%d (no embeddable content)", f.ID)
+			if mErr := eq.store.MarkEmbedFailed(ctx, f.ID, "no embeddable content"); mErr != nil {
+				log.Printf("embed queue: MarkEmbedFailed id=%d: %v", f.ID, mErr)
+			}
 			continue
 		}
-		if err := eq.store.SetEmbedding(ctx, f.ID, embs[0]); err != nil {
-			log.Printf("embed queue: SetEmbedding id=%d: %v", f.ID, err)
+		if err := eq.store.SetFactChunks(ctx, f.ID, chunks); err != nil {
+			log.Printf("embed queue: SetFactChunks id=%d: %v", f.ID, err)
 			continue
 		}
 		embedded++

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -259,6 +259,14 @@ func (c *Client) SetEmbedding(_ context.Context, _ int64, _ []float32) error {
 	return nil
 }
 
+func (c *Client) SetFactChunks(_ context.Context, _ int64, _ []memstore.FactChunk) error {
+	return nil
+}
+
+func (c *Client) FactChunks(_ context.Context, _ int64) ([]memstore.FactChunk, error) {
+	return nil, nil
+}
+
 func (c *Client) MarkEmbedFailed(_ context.Context, _ int64, _ string) error {
 	return nil
 }

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -259,7 +259,7 @@ func (c *Client) SetEmbedding(_ context.Context, _ int64, _ []float32) error {
 	return nil
 }
 
-func (c *Client) SetFactChunks(_ context.Context, _ int64, _ []memstore.FactChunk) error {
+func (c *Client) SetFactVectors(_ context.Context, _ int64, _ memstore.FactVectors) error {
 	return nil
 }
 

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -100,6 +100,9 @@ func Run(t *testing.T, opts Options) {
 	t.Run("SearchRanksFactsByBestChunk", func(t *testing.T) {
 		testSearchRanksFactsByBestChunk(t, opts.NewStore(t))
 	})
+	t.Run("FactMarkerIsTheWholeFactVector", func(t *testing.T) {
+		testFactMarkerIsTheWholeFactVector(t, opts.NewStore(t))
+	})
 	t.Run("NamespaceIsolation", func(t *testing.T) {
 		if opts.NewStoreNS == nil {
 			t.Skip("NewStoreNS not provided; skipping namespace isolation test")
@@ -1298,6 +1301,16 @@ func testSessionFeedbackIsolated(t *testing.T, a, b memstore.SessionStore) {
 // to it and scores 1.0, {4,-3,2,-1} is orthogonal and scores 0, and {1,1,1,1}
 // lands between them at about 0.91.
 
+// vectorsOf bundles chunks with a whole-fact vector. Where a test does not
+// care what the whole-fact vector is, chunk 0's stands in -- which is what a
+// single-chunk fact produces anyway.
+func vectorsOf(whole []float32, chunks ...memstore.FactChunk) memstore.FactVectors {
+	if whole == nil && len(chunks) > 0 {
+		whole = chunks[0].Vector
+	}
+	return memstore.FactVectors{Whole: whole, Chunks: chunks}
+}
+
 func chunkAt(ordinal int, vec []float32) memstore.FactChunk {
 	return memstore.FactChunk{
 		Ordinal:   ordinal,
@@ -1314,12 +1327,12 @@ func testFactChunkRoundTrip(t *testing.T, s memstore.Store) {
 	if err != nil {
 		t.Fatalf("Insert: %v", err)
 	}
-	if err := s.SetFactChunks(ctx, id, []memstore.FactChunk{
+	if err := s.SetFactVectors(ctx, id, vectorsOf(nil,
 		chunkAt(0, []float32{1, 0, 0, 0}),
 		chunkAt(1, []float32{0, 1, 0, 0}),
 		chunkAt(2, []float32{0, 0, 1, 0}),
-	}); err != nil {
-		t.Fatalf("SetFactChunks: %v", err)
+	)); err != nil {
+		t.Fatalf("SetFactVectors: %v", err)
 	}
 
 	got, err := s.FactChunks(ctx, id)
@@ -1349,15 +1362,15 @@ func testFactChunksReplaceRatherThanMerge(t *testing.T, s memstore.Store) {
 	if err != nil {
 		t.Fatalf("Insert: %v", err)
 	}
-	if err := s.SetFactChunks(ctx, id, []memstore.FactChunk{
+	if err := s.SetFactVectors(ctx, id, vectorsOf(nil,
 		chunkAt(0, []float32{1, 0, 0, 0}),
 		chunkAt(1, []float32{0, 1, 0, 0}),
 		chunkAt(2, []float32{0, 0, 1, 0}),
-	}); err != nil {
-		t.Fatalf("SetFactChunks: %v", err)
+	)); err != nil {
+		t.Fatalf("SetFactVectors: %v", err)
 	}
-	if err := s.SetFactChunks(ctx, id, []memstore.FactChunk{chunkAt(0, []float32{1, 0, 0, 0})}); err != nil {
-		t.Fatalf("SetFactChunks shrink: %v", err)
+	if err := s.SetFactVectors(ctx, id, vectorsOf(nil, chunkAt(0, []float32{1, 0, 0, 0}))); err != nil {
+		t.Fatalf("SetFactVectors shrink: %v", err)
 	}
 
 	got, err := s.FactChunks(ctx, id)
@@ -1384,16 +1397,16 @@ func testSearchRanksFactsByBestChunk(t *testing.T, s memstore.Store) {
 		t.Fatalf("Insert short: %v", err)
 	}
 
-	if err := s.SetFactChunks(ctx, longID, []memstore.FactChunk{
+	if err := s.SetFactVectors(ctx, longID, vectorsOf(nil,
 		chunkAt(0, []float32{4, -3, 2, -1}), // orthogonal to the query
 		chunkAt(1, []float32{1, 2, 3, 4}),   // exactly on it
-	}); err != nil {
-		t.Fatalf("SetFactChunks long: %v", err)
+	)); err != nil {
+		t.Fatalf("SetFactVectors long: %v", err)
 	}
-	if err := s.SetFactChunks(ctx, shortID, []memstore.FactChunk{
+	if err := s.SetFactVectors(ctx, shortID, vectorsOf(nil,
 		chunkAt(0, []float32{1, 1, 1, 1}),
-	}); err != nil {
-		t.Fatalf("SetFactChunks short: %v", err)
+	)); err != nil {
+		t.Fatalf("SetFactVectors short: %v", err)
 	}
 
 	results, err := s.Search(ctx, "qqq", memstore.SearchOpts{
@@ -1421,5 +1434,45 @@ func testSearchRanksFactsByBestChunk(t *testing.T, s memstore.Store) {
 	}
 	if len(order) > 0 && order[0] != longID {
 		t.Errorf("ranked %v; the long fact best chunk (1.0) beats the short fact (0.91)", order)
+	}
+}
+
+// Deduplication compares a new fact against an existing fact's stored marker
+// and supersedes destructively at 0.85. The marker therefore has to be the
+// whole-fact vector: chunk 0 is the opening passage of anything that splits,
+// which scores systematically low against a whole-fact vector and would
+// silently stop deduplicating long facts.
+func testFactMarkerIsTheWholeFactVector(t *testing.T, s memstore.Store) {
+	ctx := context.Background()
+
+	id, err := s.Insert(ctx, memstore.Fact{Content: "a fact that splits", Subject: "S", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	whole := []float32{9, 9, 9, 9}
+	if err := s.SetFactVectors(ctx, id, memstore.FactVectors{
+		Whole: whole,
+		Chunks: []memstore.FactChunk{
+			chunkAt(0, []float32{1, 0, 0, 0}),
+			chunkAt(1, []float32{0, 1, 0, 0}),
+		},
+	}); err != nil {
+		t.Fatalf("SetFactVectors: %v", err)
+	}
+
+	got, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.Embedding) != len(whole) {
+		t.Fatalf("marker has %d dims, want %d", len(got.Embedding), len(whole))
+	}
+	for i := range whole {
+		if got.Embedding[i] != whole[i] {
+			t.Fatalf("marker = %v, want the whole-fact vector %v -- storing chunk 0 here "+
+				"compares an opening passage against a whole fact during supersession",
+				got.Embedding, whole)
+		}
 	}
 }

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -91,6 +91,15 @@ func Run(t *testing.T, opts Options) {
 	t.Run("EmbedQuarantine", func(t *testing.T) {
 		testEmbedQuarantine(t, opts.NewStore(t))
 	})
+	t.Run("FactChunkRoundTrip", func(t *testing.T) {
+		testFactChunkRoundTrip(t, opts.NewStore(t))
+	})
+	t.Run("FactChunksReplaceRatherThanMerge", func(t *testing.T) {
+		testFactChunksReplaceRatherThanMerge(t, opts.NewStore(t))
+	})
+	t.Run("SearchRanksFactsByBestChunk", func(t *testing.T) {
+		testSearchRanksFactsByBestChunk(t, opts.NewStore(t))
+	})
 	t.Run("NamespaceIsolation", func(t *testing.T) {
 		if opts.NewStoreNS == nil {
 			t.Skip("NewStoreNS not provided; skipping namespace isolation test")
@@ -1275,5 +1284,142 @@ func testSessionFeedbackIsolated(t *testing.T, a, b memstore.SessionStore) {
 	}
 	if len(stats) != 0 {
 		t.Errorf("B.FeedbackScores returned %d entries from A (expected 0): %v", len(stats), stats)
+	}
+}
+
+// --- Chunked fact embeddings ---
+//
+// A fact is a set of vectors rather than a point, so every fact-level
+// comparison has to say what it means over that set. These pin the semantics
+// for every backend.
+//
+// The vectors below are chosen against the mock embedder both backends use,
+// which maps a single query text to [0.1, 0.2, 0.3, 0.4]: {1,2,3,4} is parallel
+// to it and scores 1.0, {4,-3,2,-1} is orthogonal and scores 0, and {1,1,1,1}
+// lands between them at about 0.91.
+
+func chunkAt(ordinal int, vec []float32) memstore.FactChunk {
+	return memstore.FactChunk{
+		Ordinal:   ordinal,
+		Vector:    vec,
+		ByteStart: ordinal * 100,
+		ByteEnd:   (ordinal + 1) * 100,
+	}
+}
+
+func testFactChunkRoundTrip(t *testing.T, s memstore.Store) {
+	ctx := context.Background()
+
+	id, err := s.Insert(ctx, memstore.Fact{Content: "multi chunk fact", Subject: "S", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := s.SetFactChunks(ctx, id, []memstore.FactChunk{
+		chunkAt(0, []float32{1, 0, 0, 0}),
+		chunkAt(1, []float32{0, 1, 0, 0}),
+		chunkAt(2, []float32{0, 0, 1, 0}),
+	}); err != nil {
+		t.Fatalf("SetFactChunks: %v", err)
+	}
+
+	got, err := s.FactChunks(ctx, id)
+	if err != nil {
+		t.Fatalf("FactChunks: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d chunks, want 3", len(got))
+	}
+	for i, c := range got {
+		if c.Ordinal != i {
+			t.Errorf("row %d has ordinal %d -- chunks must come back in ordinal order", i, c.Ordinal)
+		}
+		if c.ByteStart != i*100 || c.ByteEnd != (i+1)*100 {
+			t.Errorf("chunk %d span [%d,%d) did not round-trip", i, c.ByteStart, c.ByteEnd)
+		}
+	}
+}
+
+// A re-embed producing fewer chunks must not leave the old high-ordinal
+// vectors behind, or they keep answering searches for text the fact no longer
+// has.
+func testFactChunksReplaceRatherThanMerge(t *testing.T, s memstore.Store) {
+	ctx := context.Background()
+
+	id, err := s.Insert(ctx, memstore.Fact{Content: "shrinking fact", Subject: "S", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := s.SetFactChunks(ctx, id, []memstore.FactChunk{
+		chunkAt(0, []float32{1, 0, 0, 0}),
+		chunkAt(1, []float32{0, 1, 0, 0}),
+		chunkAt(2, []float32{0, 0, 1, 0}),
+	}); err != nil {
+		t.Fatalf("SetFactChunks: %v", err)
+	}
+	if err := s.SetFactChunks(ctx, id, []memstore.FactChunk{chunkAt(0, []float32{1, 0, 0, 0})}); err != nil {
+		t.Fatalf("SetFactChunks shrink: %v", err)
+	}
+
+	got, err := s.FactChunks(ctx, id)
+	if err != nil {
+		t.Fatalf("FactChunks: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d chunks after re-embedding to one, want 1", len(got))
+	}
+}
+
+// A fact whose *second* chunk matches the query must be found, and found once.
+// Ranking on chunk 0 alone misses it entirely; returning it per matching chunk
+// lets one long fact fill the result set and double-counts it in the fusion.
+func testSearchRanksFactsByBestChunk(t *testing.T, s memstore.Store) {
+	ctx := context.Background()
+
+	longID, err := s.Insert(ctx, memstore.Fact{Content: "zzz unrelated wording", Subject: "S", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert long: %v", err)
+	}
+	shortID, err := s.Insert(ctx, memstore.Fact{Content: "yyy other wording", Subject: "S", Category: "test"})
+	if err != nil {
+		t.Fatalf("Insert short: %v", err)
+	}
+
+	if err := s.SetFactChunks(ctx, longID, []memstore.FactChunk{
+		chunkAt(0, []float32{4, -3, 2, -1}), // orthogonal to the query
+		chunkAt(1, []float32{1, 2, 3, 4}),   // exactly on it
+	}); err != nil {
+		t.Fatalf("SetFactChunks long: %v", err)
+	}
+	if err := s.SetFactChunks(ctx, shortID, []memstore.FactChunk{
+		chunkAt(0, []float32{1, 1, 1, 1}),
+	}); err != nil {
+		t.Fatalf("SetFactChunks short: %v", err)
+	}
+
+	results, err := s.Search(ctx, "qqq", memstore.SearchOpts{
+		MaxResults: 10,
+		OnlyActive: true,
+		FTSWeight:  0.0001,
+		VecWeight:  1,
+	})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	seen := map[int64]int{}
+	var order []int64
+	for _, r := range results {
+		seen[r.Fact.ID]++
+		order = append(order, r.Fact.ID)
+	}
+	if seen[longID] == 0 {
+		t.Fatalf("the long fact was not found; its matching chunk is ordinal 1, "+
+			"so ranking on chunk 0 alone misses it (results: %v)", order)
+	}
+	if seen[longID] > 1 {
+		t.Errorf("the long fact appeared %d times; chunks must collapse to one hit per fact", seen[longID])
+	}
+	if len(order) > 0 && order[0] != longID {
+		t.Errorf("ranked %v; the long fact best chunk (1.0) beats the short fact (0.91)", order)
 	}
 }

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -56,6 +56,7 @@ type Config struct {
 type MemoryServer struct {
 	store        memstore.Store
 	embedder     embedding.Embedder
+	embedCeiling int
 	config       Config
 	curator      memstore.Curator
 	generator    memstore.Generator
@@ -885,23 +886,12 @@ func (ms *MemoryServer) HandleStore(ctx context.Context, _ *mcp.CallToolRequest,
 		return textResult("Already stored (duplicate).", false), StoreResult{}, nil
 	}
 
-	// Compute embedding (skip in daemon mode — the server handles embeddings).
-	var emb []float32
-	if ms.embedder != nil {
-		var err error
-		emb, err = embedding.Single(ctx, ms.embedder, input.Content)
-		if err != nil {
-			return textResult(fmt.Sprintf("Error computing embedding: %v", err), true), StoreResult{}, nil
-		}
-	}
-
 	fact := memstore.Fact{
 		Content:   input.Content,
 		Subject:   input.Subject,
 		Category:  category,
 		Kind:      strings.TrimSpace(input.Kind),
 		Subsystem: strings.TrimSpace(input.Subsystem),
-		Embedding: emb,
 	}
 	if len(input.Metadata) > 0 {
 		metaJSON, err := json.Marshal(input.Metadata)
@@ -914,6 +904,10 @@ func (ms *MemoryServer) HandleStore(ctx context.Context, _ *mcp.CallToolRequest,
 	id, err := ms.store.Insert(ctx, fact)
 	if err != nil {
 		return textResult(fmt.Sprintf("Error storing fact: %v", err), true), StoreResult{}, nil
+	}
+
+	if err := ms.embedFact(ctx, id, fact); err != nil {
+		return textResult(fmt.Sprintf("Error computing embedding: %v", err), true), StoreResult{}, nil
 	}
 
 	msg := fmt.Sprintf("Stored (id=%d, subject=%q, category=%q).", id, input.Subject, category)
@@ -931,6 +925,41 @@ func (ms *MemoryServer) HandleStore(ctx context.Context, _ *mcp.CallToolRequest,
 
 	out := StoreResult{Status: "stored", ID: id, Superseded: supersededBy}
 	return textResult(msg, false), out, nil
+}
+
+// SetEmbedCeiling sets the hard byte bound on any single embed request,
+// normally the configured embedder's effective budget
+// (embedding.Config.Limits().MaxBytes). Zero leaves chunk sizing to the
+// retrieval target alone.
+func (ms *MemoryServer) SetEmbedCeiling(n int) { ms.embedCeiling = n }
+
+// embedFact computes and stores a freshly inserted fact's chunk vectors.
+//
+// It runs after the insert rather than supplying Fact.Embedding before it,
+// because a fact is a set of vectors: chunk offsets and ordinals need the
+// fact's ID to be stored against, and a long fact is several vectors rather
+// than one.
+//
+// Routing every inline embed through memstore.EmbedFact also settles a recipe
+// split that predates chunking. This path embedded the bare content while the
+// daemon's embed queue embedded "subject: content", so a fact's vector depended
+// on which path happened to produce it, and the two sat in different regions of
+// the space. EmbedFact is now the single renderer for both.
+//
+// A nil embedder means daemon mode, where the queue owns embedding; the fact is
+// left unembedded and NeedingEmbedding picks it up.
+func (ms *MemoryServer) embedFact(ctx context.Context, id int64, f memstore.Fact) error {
+	if ms.embedder == nil {
+		return nil
+	}
+	chunks, err := memstore.EmbedFact(ctx, ms.embedder, ms.embedder.Model(), f, ms.embedCeiling)
+	if err != nil {
+		return err
+	}
+	if len(chunks) == 0 {
+		return nil
+	}
+	return ms.store.SetFactChunks(ctx, id, chunks)
 }
 
 func (ms *MemoryServer) HandleStoreBatch(ctx context.Context, _ *mcp.CallToolRequest, input StoreBatchInput) (*mcp.CallToolResult, StoreBatchResult, error) {
@@ -968,22 +997,12 @@ func (ms *MemoryServer) HandleStoreBatch(ctx context.Context, _ *mcp.CallToolReq
 			continue
 		}
 
-		var emb []float32
-		if ms.embedder != nil {
-			emb, err = embedding.Single(ctx, ms.embedder, f.Content)
-			if err != nil {
-				results = append(results, BatchResult{Index: i + 1, Status: "error", Error: fmt.Sprintf("embedding error: %v", err)})
-				continue
-			}
-		}
-
 		fact := memstore.Fact{
 			Content:   f.Content,
 			Subject:   f.Subject,
 			Category:  category,
 			Kind:      strings.TrimSpace(f.Kind),
 			Subsystem: strings.TrimSpace(f.Subsystem),
-			Embedding: emb,
 		}
 		if len(f.Metadata) > 0 {
 			metaJSON, err := json.Marshal(f.Metadata)
@@ -997,6 +1016,11 @@ func (ms *MemoryServer) HandleStoreBatch(ctx context.Context, _ *mcp.CallToolReq
 		id, err := ms.store.Insert(ctx, fact)
 		if err != nil {
 			results = append(results, BatchResult{Index: i + 1, Status: "error", Error: err.Error()})
+			continue
+		}
+
+		if err := ms.embedFact(ctx, id, fact); err != nil {
+			results = append(results, BatchResult{Index: i + 1, Status: "error", Error: fmt.Sprintf("embedding error: %v", err)})
 			continue
 		}
 
@@ -1603,25 +1627,19 @@ func (ms *MemoryServer) HandleTaskCreate(ctx context.Context, _ *mcp.CallToolReq
 		return textResult(fmt.Sprintf("Error encoding metadata: %v", err), true), TaskCreateResult{}, nil
 	}
 
-	// Compute embedding for searchability (skip in daemon mode).
-	var emb []float32
-	if ms.embedder != nil {
-		emb, err = embedding.Single(ctx, ms.embedder, input.Content)
-		if err != nil {
-			return textResult(fmt.Sprintf("Error computing embedding: %v", err), true), TaskCreateResult{}, nil
-		}
+	task := memstore.Fact{
+		Content:  input.Content,
+		Subject:  "todo",
+		Category: "note",
+		Kind:     "task",
+		Metadata: metaJSON,
 	}
-
-	id, err := ms.store.Insert(ctx, memstore.Fact{
-		Content:   input.Content,
-		Subject:   "todo",
-		Category:  "note",
-		Kind:      "task",
-		Metadata:  metaJSON,
-		Embedding: emb,
-	})
+	id, err := ms.store.Insert(ctx, task)
 	if err != nil {
 		return textResult(fmt.Sprintf("Error creating task: %v", err), true), TaskCreateResult{}, nil
+	}
+	if err := ms.embedFact(ctx, id, task); err != nil {
+		return textResult(fmt.Sprintf("Error computing embedding: %v", err), true), TaskCreateResult{}, nil
 	}
 
 	out := TaskCreateResult{Status: "created", ID: id, Scope: input.Scope, Priority: priority}

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -952,14 +952,14 @@ func (ms *MemoryServer) embedFact(ctx context.Context, id int64, f memstore.Fact
 	if ms.embedder == nil {
 		return nil
 	}
-	chunks, err := memstore.EmbedFact(ctx, ms.embedder, ms.embedder.Model(), f, ms.embedCeiling)
+	vecs, err := memstore.EmbedFact(ctx, ms.embedder, ms.embedder.Model(), f, ms.embedCeiling)
 	if err != nil {
 		return err
 	}
-	if len(chunks) == 0 {
+	if len(vecs.Chunks) == 0 {
 		return nil
 	}
-	return ms.store.SetFactChunks(ctx, id, chunks)
+	return ms.store.SetFactVectors(ctx, id, vecs)
 }
 
 func (ms *MemoryServer) HandleStoreBatch(ctx context.Context, _ *mcp.CallToolRequest, input StoreBatchInput) (*mcp.CallToolResult, StoreBatchResult, error) {

--- a/pgstore/search.go
+++ b/pgstore/search.go
@@ -208,38 +208,51 @@ func (s *PostgresStore) searchFTS(ctx context.Context, query string, opts memsto
 }
 
 // searchVector performs cosine similarity search using pgvector's <=> operator.
+//
+// A fact is a set of chunk vectors, so its distance to the query is the
+// distance of its *nearest* chunk -- a match on one passage is a match on the
+// fact. DISTINCT ON collapses each fact to that best chunk before ranking, so
+// a fact appears once however many chunks it has; without it one long fact
+// could fill the result set and would be double-counted in the fusion
+// downstream. Averaging its chunks instead would reintroduce exactly the
+// dilution chunking exists to remove.
 func (s *PostgresStore) searchVector(ctx context.Context, queryEmb []float32, opts memstore.SearchOpts) ([]memstore.SearchResult, error) {
 	qv := pgvector.NewVector(queryEmb)
 
 	var b queryBuilder
-	b.write(`SELECT `+factColumns+`, 1 - (embedding <=> `, qv)
+	b.write(`SELECT DISTINCT ON (f.id) `+prefixedFactColumns("f.")+`, 1 - (c.embedding <=> `, qv)
 	b.q += `) AS similarity
-	         FROM memstore_facts
-	         WHERE embedding IS NOT NULL`
+	         FROM memstore_facts f
+	         JOIN memstore_fact_chunks c ON c.fact_id = f.id
+	         WHERE 1 = 1`
 
-	s.appendNamespaceFilter(&b, "namespace", opts.AllNamespaces, opts.Namespaces)
-	s.appendUserFilter(&b, "user_id")
+	s.appendNamespaceFilter(&b, "f.namespace", opts.AllNamespaces, opts.Namespaces)
+	s.appendUserFilter(&b, "f.user_id")
 	if opts.OnlyActive {
-		b.q += ` AND superseded_by IS NULL`
+		b.q += ` AND f.superseded_by IS NULL`
 	}
 	if opts.Subject != "" {
-		b.write(` AND subject = `, opts.Subject)
+		b.write(` AND f.subject = `, opts.Subject)
 	}
 	if opts.Category != "" {
-		b.write(` AND category = `, opts.Category)
+		b.write(` AND f.category = `, opts.Category)
 	}
 	if opts.Kind != "" {
-		b.write(` AND kind = `, opts.Kind)
+		b.write(` AND f.kind = `, opts.Kind)
 	}
 	if opts.Subsystem != "" {
-		b.write(` AND subsystem = `, opts.Subsystem)
+		b.write(` AND f.subsystem = `, opts.Subsystem)
 	}
-	if err := appendMetadataFilters(&b, "", opts.MetadataFilters); err != nil {
+	if err := appendMetadataFilters(&b, "f.", opts.MetadataFilters); err != nil {
 		return nil, err
 	}
-	appendTemporalFilters(&b, "", opts.CreatedAfter, opts.CreatedBefore)
+	appendTemporalFilters(&b, "f.", opts.CreatedAfter, opts.CreatedBefore)
 
-	b.write(` ORDER BY embedding <=> `, qv)
+	// DISTINCT ON requires its expression to lead ORDER BY, so the per-fact
+	// pick and the global ranking cannot be the same sort. Pick the nearest
+	// chunk per fact inside, then rank facts by that distance outside.
+	b.write(` ORDER BY f.id, c.embedding <=> `, qv)
+	b.q = `SELECT * FROM (` + b.q + `) t ORDER BY similarity DESC`
 	b.write(` LIMIT `, memstore.FetchLimit(opts))
 
 	rows, err := s.pool.Query(ctx, b.q, b.args...)

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -1216,14 +1216,15 @@ func (s *PostgresStore) migrateV6(ctx context.Context) error {
 	return nil
 }
 
-// SetFactChunks replaces a fact's chunk vectors in one transaction.
+// SetFactVectors replaces a fact's vectors in one transaction.
 //
 // The fact row's embedding column is written in the same transaction, holding
-// chunk 0's vector. It is the marker the embed queue keys off (NeedingEmbedding
-// selects embedding IS NULL), so writing chunks without it would leave the fact
-// queued forever, re-embedding on every pass. Writing both together is what
-// keeps them from diverging.
-func (s *PostgresStore) SetFactChunks(ctx context.Context, id int64, chunks []memstore.FactChunk) error {
+// the whole-fact vector. It serves two purposes: it is the marker the embed
+// queue keys off (NeedingEmbedding selects embedding IS NULL), so writing
+// chunks without it would leave the fact queued forever; and it is the vector
+// deduplication compares facts on, which is why it is the whole fact rather
+// than chunk 0. Writing both together is what keeps them from diverging.
+func (s *PostgresStore) SetFactVectors(ctx context.Context, id int64, v memstore.FactVectors) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("pgstore: setting chunks for fact %d: %w", id, err)
@@ -1234,19 +1235,21 @@ func (s *PostgresStore) SetFactChunks(ctx context.Context, id int64, chunks []me
 		return fmt.Errorf("pgstore: clearing chunks for fact %d: %w", id, err)
 	}
 
-	var marker *pgvector.Vector
-	for _, c := range chunks {
-		v := pgvector.NewVector(c.Vector)
+	for _, c := range v.Chunks {
+		cv := pgvector.NewVector(c.Vector)
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO memstore_fact_chunks (fact_id, ordinal, embedding, byte_start, byte_end)
 			 VALUES ($1, $2, $3, $4, $5)`,
-			id, c.Ordinal, v, c.ByteStart, c.ByteEnd,
+			id, c.Ordinal, cv, c.ByteStart, c.ByteEnd,
 		); err != nil {
 			return fmt.Errorf("pgstore: inserting chunk %d for fact %d: %w", c.Ordinal, id, err)
 		}
-		if c.Ordinal == 0 {
-			marker = &v
-		}
+	}
+
+	var marker *pgvector.Vector
+	if len(v.Whole) > 0 {
+		wv := pgvector.NewVector(v.Whole)
+		marker = &wv
 	}
 
 	q, args := s.userPredicate(

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -11,17 +11,29 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/matthewjhunter/go-embedding"
 	"github.com/matthewjhunter/memstore"
 	pgvector "github.com/pgvector/pgvector-go"
 )
 
-const schemaVersion = 5
+const schemaVersion = 6
 
 // factColumns is the canonical SELECT list for fact queries.
 // searchFTS has its own column list because it joins and adds ts_rank.
 const factColumns = `id, namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, embedding, created_at`
+
+// prefixedFactColumns renders factColumns with a table alias applied to each
+// column, for queries that join memstore_facts to another table and would
+// otherwise leave shared names (id, embedding) ambiguous.
+func prefixedFactColumns(prefix string) string {
+	cols := strings.Split(factColumns, ", ")
+	for i, c := range cols {
+		cols[i] = prefix + c
+	}
+	return strings.Join(cols, ", ")
+}
 
 // PostgresStore implements memstore.Store backed by PostgreSQL.
 // It uses pgvector for vector similarity search and tsvector with GIN
@@ -380,6 +392,12 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 
 	if version < 5 {
 		if err := s.migrateV5(ctx); err != nil {
+			return err
+		}
+	}
+
+	if version < 6 {
+		if err := s.migrateV6(ctx); err != nil {
 			return err
 		}
 	}
@@ -798,7 +816,42 @@ func (s *PostgresStore) Insert(ctx context.Context, f memstore.Fact) (int64, err
 	if err != nil {
 		return 0, fmt.Errorf("pgstore: inserting fact: %w", err)
 	}
+	// A caller that supplies a precomputed vector gets a matching chunk row.
+	// Vector search reads chunks, so a fact carrying only the marker would be
+	// invisible to it -- embedded as far as the queue is concerned, and
+	// unfindable in practice.
+	if len(f.Embedding) > 0 {
+		if err := insertWholeFactChunk(ctx, s.pool, id, f); err != nil {
+			return 0, err
+		}
+	}
 	return id, nil
+}
+
+// pgExecer is the subset of the pool / transaction API the chunk insert needs,
+// so it can run inside a batch transaction or on its own.
+type pgExecer interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// insertWholeFactChunk records a precomputed whole-fact vector as chunk 0
+// spanning the entire content. It is the single-chunk case of what
+// SetFactChunks writes, for callers that embedded the fact themselves rather
+// than going through memstore.EmbedFact.
+func insertWholeFactChunk(ctx context.Context, db pgExecer, id int64, f memstore.Fact) error {
+	_, err := db.Exec(ctx,
+		`INSERT INTO memstore_fact_chunks (fact_id, ordinal, embedding, byte_start, byte_end)
+		 VALUES ($1, 0, $2, 0, $3)
+		 ON CONFLICT (fact_id, ordinal) DO UPDATE
+		   SET embedding = EXCLUDED.embedding,
+		       byte_start = EXCLUDED.byte_start,
+		       byte_end = EXCLUDED.byte_end`,
+		id, pgvector.NewVector(f.Embedding), len(f.Content),
+	)
+	if err != nil {
+		return fmt.Errorf("pgstore: inserting chunk for fact %d: %w", id, err)
+	}
+	return nil
 }
 
 // InsertBatch inserts multiple facts in a single transaction.
@@ -844,6 +897,12 @@ func (s *PostgresStore) InsertBatch(ctx context.Context, facts []memstore.Fact) 
 		).Scan(&facts[i].ID)
 		if err != nil {
 			return fmt.Errorf("pgstore: inserting fact %q: %w", facts[i].Content, err)
+		}
+
+		if len(facts[i].Embedding) > 0 {
+			if err := insertWholeFactChunk(ctx, tx, facts[i].ID, facts[i]); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1116,6 +1175,114 @@ func (s *PostgresStore) MarkEmbedFailed(ctx context.Context, id int64, reason st
 		return fmt.Errorf("pgstore: marking embed failed for fact %d: %w", id, err)
 	}
 	return nil
+}
+
+// migrateV6 gives a fact a set of chunk vectors rather than a single point.
+//
+// A fact was previously one vector over its whole content, clipped to the
+// model's byte budget. That is the wrong target for retrieval: a vector has
+// fixed capacity, so filling the model's context window averages away the
+// specificity retrieval depends on, and the longest facts -- the substantive
+// ones -- lost the most. It also silently discarded the tail of anything over
+// the budget. Chunking answers both (see memstore.ChunkFact).
+//
+// Existing vectors are cleared rather than carried forward. They were produced
+// from whole-fact text against a different budget, so they sit in a different
+// region of the space than anything produced after this; mixing the two would
+// quietly degrade ranking rather than loudly fail. Clearing makes every fact
+// look unembedded, and the existing backfill (NeedingEmbedding, which keys off
+// embedding IS NULL) repopulates them through its normal path.
+func (s *PostgresStore) migrateV6(ctx context.Context) error {
+	stmts := []string{
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS memstore_fact_chunks (
+			fact_id    BIGINT NOT NULL REFERENCES memstore_facts(id) ON DELETE CASCADE,
+			ordinal    INTEGER NOT NULL,
+			embedding  vector(%d) NOT NULL,
+			byte_start INTEGER NOT NULL,
+			byte_end   INTEGER NOT NULL,
+			PRIMARY KEY (fact_id, ordinal)
+		)`, s.vecDim),
+		`DELETE FROM memstore_fact_chunks`,
+		// Re-queue every fact for the backfill. embed_failed_at is cleared too:
+		// a fact quarantined for overrunning the old whole-fact budget is
+		// exactly the fact chunking fixes, so it deserves a fresh attempt.
+		`UPDATE memstore_facts SET embedding = NULL, embed_failed_at = NULL, embed_error = NULL`,
+	}
+	for _, q := range stmts {
+		if _, err := s.pool.Exec(ctx, q); err != nil {
+			return fmt.Errorf("pgstore: migrateV6: %w", err)
+		}
+	}
+	return nil
+}
+
+// SetFactChunks replaces a fact's chunk vectors in one transaction.
+//
+// The fact row's embedding column is written in the same transaction, holding
+// chunk 0's vector. It is the marker the embed queue keys off (NeedingEmbedding
+// selects embedding IS NULL), so writing chunks without it would leave the fact
+// queued forever, re-embedding on every pass. Writing both together is what
+// keeps them from diverging.
+func (s *PostgresStore) SetFactChunks(ctx context.Context, id int64, chunks []memstore.FactChunk) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("pgstore: setting chunks for fact %d: %w", id, err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `DELETE FROM memstore_fact_chunks WHERE fact_id = $1`, id); err != nil {
+		return fmt.Errorf("pgstore: clearing chunks for fact %d: %w", id, err)
+	}
+
+	var marker *pgvector.Vector
+	for _, c := range chunks {
+		v := pgvector.NewVector(c.Vector)
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO memstore_fact_chunks (fact_id, ordinal, embedding, byte_start, byte_end)
+			 VALUES ($1, $2, $3, $4, $5)`,
+			id, c.Ordinal, v, c.ByteStart, c.ByteEnd,
+		); err != nil {
+			return fmt.Errorf("pgstore: inserting chunk %d for fact %d: %w", c.Ordinal, id, err)
+		}
+		if c.Ordinal == 0 {
+			marker = &v
+		}
+	}
+
+	q, args := s.userPredicate(
+		`UPDATE memstore_facts SET embedding = $1 WHERE id = $2 AND namespace = $3`,
+		[]any{marker, id, s.namespace})
+	if _, err := tx.Exec(ctx, q, args...); err != nil {
+		return fmt.Errorf("pgstore: setting embedding marker for fact %d: %w", id, err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("pgstore: committing chunks for fact %d: %w", id, err)
+	}
+	return nil
+}
+
+// FactChunks returns a fact's chunk vectors in ordinal order.
+func (s *PostgresStore) FactChunks(ctx context.Context, id int64) ([]memstore.FactChunk, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT ordinal, embedding, byte_start, byte_end
+		 FROM memstore_fact_chunks WHERE fact_id = $1 ORDER BY ordinal`, id)
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: reading chunks for fact %d: %w", id, err)
+	}
+	defer rows.Close()
+
+	var out []memstore.FactChunk
+	for rows.Next() {
+		var c memstore.FactChunk
+		var v pgvector.Vector
+		if err := rows.Scan(&c.Ordinal, &v, &c.ByteStart, &c.ByteEnd); err != nil {
+			return nil, fmt.Errorf("pgstore: scanning chunk for fact %d: %w", id, err)
+		}
+		c.Vector = v.Slice()
+		out = append(out, c)
+	}
+	return out, rows.Err()
 }
 
 // SetEmbedding stores a computed embedding for a fact.

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -1584,8 +1584,8 @@ func TestInitIdentity(t *testing.T) {
 	if err := pool.QueryRow(ctx, `SELECT version FROM memstore_version`).Scan(&version); err != nil {
 		t.Fatalf("reading schema version: %v", err)
 	}
-	if version != 5 {
-		t.Errorf("schema version = %d, want 5 after InitIdentity", version)
+	if version != 6 {
+		t.Errorf("schema version = %d, want 6 after InitIdentity", version)
 	}
 
 	// Insert must succeed (non-zero userID bound to the store).

--- a/search.go
+++ b/search.go
@@ -183,37 +183,60 @@ func (s *SQLiteStore) searchFTS(ctx context.Context, query string, opts SearchOp
 	return results, rows.Err()
 }
 
-// searchVector performs cosine similarity search against stored embeddings.
+// scanWithExtra lets scanFact read a row that carries extra trailing columns:
+// scanFact supplies its own destinations and the extras are appended, so the
+// joined chunk vector rides along without duplicating the fact scan.
+type scanWithExtra struct {
+	rows  *sql.Rows
+	extra []any
+}
+
+func (p scanWithExtra) Scan(dest ...any) error {
+	return p.rows.Scan(append(dest, p.extra...)...)
+}
+
+// searchVector performs cosine similarity search against stored chunk vectors.
+//
+// A fact is a set of vectors, so its distance to the query is the distance of
+// its *nearest* chunk -- a match on one passage is a match on the fact. The
+// alternative, averaging a fact's chunks, would reintroduce exactly the
+// dilution chunking exists to remove.
+//
+// Each fact appears once in the result. Returning it per matching chunk would
+// let one long fact fill the whole result set, and would double-count it in
+// the fusion downstream.
 func (s *SQLiteStore) searchVector(ctx context.Context, queryEmb []float32, opts SearchOpts) ([]SearchResult, error) {
-	q := `SELECT ` + factColumns + `
-	      FROM memstore_facts WHERE embedding IS NOT NULL`
+	q := `SELECT ` + prefixedFactColumns("f.") + `, c.embedding
+	      FROM memstore_facts f
+	      JOIN memstore_fact_chunks c ON c.fact_id = f.id
+	      WHERE 1=1`
 
 	var args []any
 
-	s.appendNamespaceFilter(&q, &args, "namespace", opts.AllNamespaces, opts.Namespaces)
+	s.appendNamespaceFilter(&q, &args, "f.namespace", opts.AllNamespaces, opts.Namespaces)
 	if opts.OnlyActive {
-		q += ` AND superseded_by IS NULL`
+		q += ` AND f.superseded_by IS NULL`
 	}
 	if opts.Subject != "" {
-		q += ` AND subject = ?`
+		q += ` AND f.subject = ?`
 		args = append(args, opts.Subject)
 	}
 	if opts.Category != "" {
-		q += ` AND category = ?`
+		q += ` AND f.category = ?`
 		args = append(args, opts.Category)
 	}
 	if opts.Kind != "" {
-		q += ` AND kind = ?`
+		q += ` AND f.kind = ?`
 		args = append(args, opts.Kind)
 	}
 	if opts.Subsystem != "" {
-		q += ` AND subsystem = ?`
+		q += ` AND f.subsystem = ?`
 		args = append(args, opts.Subsystem)
 	}
-	if err := appendMetadataFilters(&q, &args, "", opts.MetadataFilters); err != nil {
+	if err := appendMetadataFilters(&q, &args, "f.", opts.MetadataFilters); err != nil {
 		return nil, err
 	}
-	appendTemporalFilters(&q, &args, "", opts.CreatedAfter, opts.CreatedBefore)
+	appendTemporalFilters(&q, &args, "f.", opts.CreatedAfter, opts.CreatedBefore)
 
 	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
@@ -225,23 +248,41 @@ func (s *SQLiteStore) searchVector(ctx context.Context, queryEmb []float32, opts
 		fact  Fact
 		score float64
 	}
-	var candidates []scored
+	// Collapse to the best chunk per fact as rows arrive, so a fact with many
+	// chunks costs one entry rather than one per chunk.
+	best := make(map[int64]*scored)
+	var order []int64
 
 	for rows.Next() {
-		f, err := scanFact(rows)
+		var chunkBlob []byte
+		f, err := scanFact(scanWithExtra{rows: rows, extra: []any{&chunkBlob}})
 		if err != nil {
 			return nil, fmt.Errorf("memstore: scanning vector result: %w", err)
 		}
-		if len(f.Embedding) == 0 {
+		vec := embedding.DecodeFloat32s(chunkBlob)
+		if len(vec) == 0 {
 			continue
 		}
-		sim := embedding.CosineSimilarity(queryEmb, f.Embedding)
-		if sim > 0 {
-			candidates = append(candidates, scored{fact: *f, score: sim})
+		sim := embedding.CosineSimilarity(queryEmb, vec)
+		if sim <= 0 {
+			continue
 		}
+		if cur, ok := best[f.ID]; ok {
+			if sim > cur.score {
+				cur.score = sim
+			}
+			continue
+		}
+		best[f.ID] = &scored{fact: *f, score: sim}
+		order = append(order, f.ID)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("memstore: vector search scan: %w", err)
+	}
+
+	candidates := make([]scored, 0, len(best))
+	for _, id := range order {
+		candidates = append(candidates, *best[id])
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {

--- a/sqlite.go
+++ b/sqlite.go
@@ -1131,14 +1131,15 @@ func (s *SQLiteStore) migrateV13() error {
 	return nil
 }
 
-// SetFactChunks replaces a fact's chunk vectors in one transaction.
+// SetFactVectors replaces a fact's vectors in one transaction.
 //
 // The fact row's embedding column is written in the same transaction, holding
-// chunk 0's vector. It is the marker the embed queue keys off (NeedingEmbedding
-// selects embedding IS NULL), so writing chunks without it would leave the fact
-// queued forever, re-embedding on every pass. Writing both together is what
-// keeps them from diverging.
-func (s *SQLiteStore) SetFactChunks(ctx context.Context, id int64, chunks []FactChunk) error {
+// the whole-fact vector. It serves two purposes: it is the marker the embed
+// queue keys off (NeedingEmbedding selects embedding IS NULL), so writing
+// chunks without it would leave the fact queued forever; and it is the vector
+// deduplication compares facts on, which is why it is the whole fact rather
+// than chunk 0. Writing both together is what keeps them from diverging.
+func (s *SQLiteStore) SetFactVectors(ctx context.Context, id int64, v FactVectors) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -1152,8 +1153,7 @@ func (s *SQLiteStore) SetFactChunks(ctx context.Context, id int64, chunks []Fact
 		return fmt.Errorf("memstore: clearing chunks for fact %d: %w", id, err)
 	}
 
-	var marker []byte
-	for _, c := range chunks {
+	for _, c := range v.Chunks {
 		if _, err := tx.ExecContext(ctx,
 			`INSERT INTO memstore_fact_chunks (fact_id, ordinal, embedding, byte_start, byte_end)
 			 VALUES (?, ?, ?, ?, ?)`,
@@ -1161,9 +1161,11 @@ func (s *SQLiteStore) SetFactChunks(ctx context.Context, id int64, chunks []Fact
 		); err != nil {
 			return fmt.Errorf("memstore: inserting chunk %d for fact %d: %w", c.Ordinal, id, err)
 		}
-		if c.Ordinal == 0 {
-			marker = embedding.EncodeFloat32s(c.Vector)
-		}
+	}
+
+	var marker []byte
+	if len(v.Whole) > 0 {
+		marker = embedding.EncodeFloat32s(v.Whole)
 	}
 
 	if _, err := tx.ExecContext(ctx,

--- a/sqlite.go
+++ b/sqlite.go
@@ -14,11 +14,22 @@ import (
 	"github.com/matthewjhunter/go-embedding"
 )
 
-const schemaVersion = 12
+const schemaVersion = 13
 
 // factColumns is the canonical SELECT list for fact queries.
 // searchFTS has its own column list because it joins and adds rank.
 const factColumns = `id, namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, embedding, created_at`
+
+// prefixedFactColumns renders factColumns with a table alias applied to each
+// column, for queries that join memstore_facts to another table and would
+// otherwise leave shared names (id, embedding) ambiguous.
+func prefixedFactColumns(prefix string) string {
+	cols := strings.Split(factColumns, ", ")
+	for i, c := range cols {
+		cols[i] = prefix + c
+	}
+	return strings.Join(cols, ", ")
+}
 
 // SQLiteStore implements Store backed by a caller-provided SQLite database.
 // It creates memstore_* tables and uses its own version tracking table so it
@@ -207,6 +218,12 @@ func (s *SQLiteStore) migrate() error {
 
 	if version < 12 {
 		if err := s.migrateV12(); err != nil {
+			return err
+		}
+	}
+
+	if version < 13 {
+		if err := s.migrateV13(); err != nil {
 			return err
 		}
 	}
@@ -664,7 +681,42 @@ func (s *SQLiteStore) Insert(ctx context.Context, f Fact) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("memstore: inserting fact: %w", err)
 	}
-	return result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	// A caller that supplies a precomputed vector gets a matching chunk row.
+	// Vector search reads chunks, so a fact carrying only the marker would be
+	// invisible to it -- embedded as far as the queue is concerned, and
+	// unfindable in practice.
+	if len(f.Embedding) > 0 {
+		if err := insertWholeFactChunk(ctx, s.db, id, f); err != nil {
+			return 0, err
+		}
+	}
+	return id, nil
+}
+
+// insertWholeFactChunk records a precomputed whole-fact vector as chunk 0
+// spanning the entire content. It is the single-chunk case of what
+// SetFactChunks writes, for callers that embedded the fact themselves rather
+// than going through EmbedFact.
+func insertWholeFactChunk(ctx context.Context, db execer, id int64, f Fact) error {
+	_, err := db.ExecContext(ctx,
+		`INSERT OR REPLACE INTO memstore_fact_chunks (fact_id, ordinal, embedding, byte_start, byte_end)
+		 VALUES (?, 0, ?, 0, ?)`,
+		id, embedding.EncodeFloat32s(f.Embedding), len(f.Content),
+	)
+	if err != nil {
+		return fmt.Errorf("memstore: inserting chunk for fact %d: %w", id, err)
+	}
+	return nil
+}
+
+// execer is the subset of *sql.DB / *sql.Tx the chunk insert needs, so it can
+// run inside a batch transaction or on its own.
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
 // InsertBatch inserts multiple facts in a single transaction.
@@ -723,6 +775,12 @@ func (s *SQLiteStore) InsertBatch(ctx context.Context, facts []Fact) error {
 			return fmt.Errorf("memstore: getting insert id: %w", err)
 		}
 		facts[i].ID = id
+
+		if len(facts[i].Embedding) > 0 {
+			if err := insertWholeFactChunk(ctx, tx, id, facts[i]); err != nil {
+				return err
+			}
+		}
 	}
 
 	return tx.Commit()
@@ -1031,6 +1089,120 @@ func (s *SQLiteStore) NeedingEmbedding(ctx context.Context, limit int) ([]Fact, 
 	defer rows.Close()
 
 	return scanFacts(rows)
+}
+
+// migrateV13 gives a fact a set of chunk vectors rather than a single point.
+//
+// A fact was previously one vector over its whole content, clipped to the
+// model's byte budget. That is the wrong target for retrieval: a vector has
+// fixed capacity, so filling the model's context window averages away the
+// specificity retrieval depends on, and the longest facts -- the substantive
+// ones -- lost the most. It also silently discarded the tail of anything over
+// the budget. Chunking answers both (see ChunkFact).
+//
+// Existing vectors are cleared rather than carried forward. They were produced
+// from whole-fact text against a different budget, so they sit in a different
+// region of the space than anything produced after this; mixing the two would
+// quietly degrade ranking rather than loudly fail. Clearing makes every fact
+// look unembedded, and the existing backfill (NeedingEmbedding, which keys off
+// embedding IS NULL) repopulates them through its normal path.
+func (s *SQLiteStore) migrateV13() error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS memstore_fact_chunks (
+			fact_id    INTEGER NOT NULL,
+			ordinal    INTEGER NOT NULL,
+			embedding  BLOB NOT NULL,
+			byte_start INTEGER NOT NULL,
+			byte_end   INTEGER NOT NULL,
+			PRIMARY KEY (fact_id, ordinal),
+			FOREIGN KEY (fact_id) REFERENCES memstore_facts(id) ON DELETE CASCADE
+		)`,
+		`DELETE FROM memstore_fact_chunks`,
+		// Re-queue every fact for the backfill. embed_failed_at is cleared too:
+		// a fact quarantined for overrunning the old whole-fact budget is
+		// exactly the fact chunking fixes, so it deserves a fresh attempt.
+		`UPDATE memstore_facts SET embedding = NULL, embed_failed_at = NULL, embed_error = NULL`,
+	}
+	for _, q := range stmts {
+		if _, err := s.db.Exec(q); err != nil {
+			return fmt.Errorf("memstore: migrateV13: %w", err)
+		}
+	}
+	return nil
+}
+
+// SetFactChunks replaces a fact's chunk vectors in one transaction.
+//
+// The fact row's embedding column is written in the same transaction, holding
+// chunk 0's vector. It is the marker the embed queue keys off (NeedingEmbedding
+// selects embedding IS NULL), so writing chunks without it would leave the fact
+// queued forever, re-embedding on every pass. Writing both together is what
+// keeps them from diverging.
+func (s *SQLiteStore) SetFactChunks(ctx context.Context, id int64, chunks []FactChunk) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("memstore: setting chunks for fact %d: %w", id, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM memstore_fact_chunks WHERE fact_id = ?`, id); err != nil {
+		return fmt.Errorf("memstore: clearing chunks for fact %d: %w", id, err)
+	}
+
+	var marker []byte
+	for _, c := range chunks {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO memstore_fact_chunks (fact_id, ordinal, embedding, byte_start, byte_end)
+			 VALUES (?, ?, ?, ?, ?)`,
+			id, c.Ordinal, embedding.EncodeFloat32s(c.Vector), c.ByteStart, c.ByteEnd,
+		); err != nil {
+			return fmt.Errorf("memstore: inserting chunk %d for fact %d: %w", c.Ordinal, id, err)
+		}
+		if c.Ordinal == 0 {
+			marker = embedding.EncodeFloat32s(c.Vector)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE memstore_facts SET embedding = ? WHERE id = ? AND namespace = ?`,
+		marker, id, s.namespace,
+	); err != nil {
+		return fmt.Errorf("memstore: setting embedding marker for fact %d: %w", id, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("memstore: committing chunks for fact %d: %w", id, err)
+	}
+	return nil
+}
+
+// FactChunks returns a fact's chunk vectors in ordinal order.
+func (s *SQLiteStore) FactChunks(ctx context.Context, id int64) ([]FactChunk, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT ordinal, embedding, byte_start, byte_end
+		 FROM memstore_fact_chunks WHERE fact_id = ? ORDER BY ordinal`, id)
+	if err != nil {
+		return nil, fmt.Errorf("memstore: reading chunks for fact %d: %w", id, err)
+	}
+	defer rows.Close()
+
+	var out []FactChunk
+	for rows.Next() {
+		var c FactChunk
+		var blob []byte
+		if err := rows.Scan(&c.Ordinal, &blob, &c.ByteStart, &c.ByteEnd); err != nil {
+			return nil, fmt.Errorf("memstore: scanning chunk for fact %d: %w", id, err)
+		}
+		c.Vector = embedding.DecodeFloat32s(blob)
+		out = append(out, c)
+	}
+	return out, rows.Err()
 }
 
 // SetEmbedding stores a computed embedding for a fact.

--- a/store.go
+++ b/store.go
@@ -8,10 +8,15 @@ import (
 	"time"
 )
 
-// MaxContentLength bounds Fact.Content. Sized to fit comfortably inside the
-// 2048-token context window of the embedding models we use (nomic-embed-text,
-// embeddinggemma) at typical English byte/token ratios. Enforced at the DB
-// level by both pgstore and sqlite stores.
+// MaxContentLength bounds Fact.Content. Enforced at the DB level by both
+// pgstore and sqlite stores.
+//
+// It used to be sized against the embedding model's context window, because a
+// fact was one vector over its whole content and anything longer was silently
+// truncated. Chunking removed that constraint: content past the chunk target is
+// split rather than clipped, so length no longer costs coverage. What remains
+// is an ordinary sanity bound on a single fact -- a fact this long is usually a
+// document that wants the document corpus instead.
 const MaxContentLength = 8000
 
 // Fact represents a single factual claim in the knowledge store.
@@ -240,6 +245,13 @@ type Store interface {
 	// Embedding pipeline
 	NeedingEmbedding(ctx context.Context, limit int) ([]Fact, error)
 	SetEmbedding(ctx context.Context, id int64, emb []float32) error
+	// SetFactChunks replaces a fact's chunk vectors, and is the write path
+	// for a chunked embedding. It is atomic: the chunk rows and the fact
+	// row's marker vector are written together, so the two cannot diverge.
+	// Passing no chunks clears the fact's vectors entirely.
+	SetFactChunks(ctx context.Context, id int64, chunks []FactChunk) error
+	// FactChunks returns a fact's chunk vectors in ordinal order.
+	FactChunks(ctx context.Context, id int64) ([]FactChunk, error)
 	// MarkEmbedFailed quarantines a fact whose embedding failed permanently
 	// so NeedingEmbedding stops returning it. reason is stored for diagnostics.
 	MarkEmbedFailed(ctx context.Context, id int64, reason string) error

--- a/store.go
+++ b/store.go
@@ -245,11 +245,11 @@ type Store interface {
 	// Embedding pipeline
 	NeedingEmbedding(ctx context.Context, limit int) ([]Fact, error)
 	SetEmbedding(ctx context.Context, id int64, emb []float32) error
-	// SetFactChunks replaces a fact's chunk vectors, and is the write path
-	// for a chunked embedding. It is atomic: the chunk rows and the fact
-	// row's marker vector are written together, so the two cannot diverge.
+	// SetFactVectors replaces a fact's vectors, and is the write path for a
+	// chunked embedding. It is atomic: the chunk rows and the fact row's
+	// whole-fact marker are written together, so the two cannot diverge.
 	// Passing no chunks clears the fact's vectors entirely.
-	SetFactChunks(ctx context.Context, id int64, chunks []FactChunk) error
+	SetFactVectors(ctx context.Context, id int64, v FactVectors) error
 	// FactChunks returns a fact's chunk vectors in ordinal order.
 	FactChunks(ctx context.Context, id int64) ([]FactChunk, error)
 	// MarkEmbedFailed quarantines a fact whose embedding failed permanently


### PR DESCRIPTION
Chunks a fact's content into retrieval-sized pieces and stores one vector per chunk, instead of one vector over the whole fact clipped to the model's byte budget.

Builds on #138 (the go-embedding v0.5.3 bump), which should merge first.

## Why chunk at all

Two separate problems, and the second is the bigger one.

The old scheme lost content: anything past the model's budget was silently discarded, and 17 facts in the live store are over nomic-embed-text's 6000 bytes today.

It also lost precision even where the content fit. A vector has fixed capacity, so filling the model's context window averages away the specificity retrieval depends on. go-embedding's `Split` says so outright -- 256-512 tokens per chunk is the working range, and it defaults to the model budget only because that is the one figure the library knows, with its doc comment telling callers to pass their own. This is memstore passing it: `ChunkTargetBytes` is 1024, roughly 512 tokens, against a 6000-byte budget.

## Target and ceiling are two numbers

Deliberately. The ceiling exists so a strict backend does not reject the request; the target is a retrieval choice. Deriving one from the other means raising the ceiling silently widens every chunk and quietly degrades retrieval, with nothing reporting it. That coupling is live in herald (matthewjhunter/herald#297) and is not reproduced here: a ceiling above the target is ignored, never used to inflate chunks.

## Retrieval: nearest chunk wins

A fact's distance to a query is the distance of its *nearest* chunk -- a match on one passage is a match on the fact. Each fact still appears once (SQLite collapses as rows arrive, Postgres uses `DISTINCT ON`), because returning it per matching chunk would let one long fact fill the result set and double-count it in the fusion.

## Deduplication: the whole fact, pooled

Auto-supersession is destructive -- it compares a new fact against an existing fact's stored marker and at 0.85 supersedes the loser. Both sides therefore have to mean the same thing.

Storing chunk 0 as the marker would have made it an *opening passage* vector for anything that splits, scoring systematically low against a whole-fact vector and silently ending deduplication for long facts, with the 0.85 threshold no longer describing the comparison being made. 16% of the corpus (1,018 of 6,211 facts) is over the chunk target.

So the marker is a whole-fact vector, pooled from the chunk vectors. Embedding the whole text is not available: a fact that splits is by definition longer than the ceiling, so that request is exactly the one a strict backend rejects, and clipping it back would discard the tail -- the loss chunking removes. A test asserting the ceiling bounds every request is what caught that. Pooling covers every chunk and costs no extra request.

Pooling is right here for the same reason it is wrong for retrieval: averaging dilutes the specificity a passage lookup needs, but "do these two facts say the same thing" is a property of the whole fact. Vectors are unit-normalised before averaging so magnitude cannot decide the outcome.

## One recipe

Three paths embedded facts and two disagreed about the text. The embed queue sent `"subject: content"`; the MCP store path and the extractor sent bare content. A fact's vector depended on which path created it, and the two sat in different regions of the space. A quiet split that predates chunking and would have survived it. All three now go through `EmbedFact`.

The subject is re-applied to every chunk rather than splitting the rendered text -- otherwise chunk 0 keeps the subject while chunks 1..N are anonymous prose, which is worse retrieval on exactly the long facts chunking was meant to rescue.

## Testing

The chunk contract lives in the conformance suite, so both backends are held to the same semantics rather than SQLite's being checked and Postgres's assumed. Postgres tests skip silently without `MEMSTORE_TEST_PG`, so these were run against a live pgvector container -- otherwise the Postgres path would be asserted, not verified.

Each central claim was checked by breaking it and confirming the test fails:

- sizing from the model budget instead of the target -> the 3000-byte fact comes back as one chunk
- splitting the rendered text instead of re-applying the subject -> chunks 1..N lose the subject, and offsets drift past the end of the content
- joining `AND c.ordinal = 0` -> best-chunk ranking fails, on both backends
- marker set from chunk 0 -> the dedup-vector test fails, on both backends

`go build`, `go vet`, `golangci-lint` (0 issues), `go test -race -count=1 ./...` across all 12 packages with Postgres live, and `govulncheck` all pass.

## Deploying

Migration 13 (SQLite) / 6 (Postgres) creates the chunk table, clears every existing vector, and releases quarantined facts. Old vectors were produced from whole-fact text against a different budget, so they sit in a different region of the space; mixing them with new ones would quietly degrade ranking rather than loudly fail. Clearing makes every fact look unembedded and the existing backfill repopulates them -- 6,211 facts to roughly 7,790 chunks on first start after deploy. Quarantined facts are released because a fact that failed for overrunning the old whole-fact budget is precisely what chunking fixes.

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
