### PR TITLE
feat: adopt go-embedding v0.6.1

### DIFF
--- a/embedconfig.go
+++ b/embedconfig.go
@@ -2,7 +2,6 @@ package memstore
 
 import (
 	"log"
-	"os"
 
 	embedding "github.com/matthewjhunter/go-embedding"
 )
@@ -12,54 +11,20 @@ import (
 const EmbedEnvPrefix = "MEMSTORE_EMBED"
 
 // EmbedConfigFromEnv reads the embedder configuration every memstore binary
-// shares, defaulting StrictModel on.
+// shares, with StrictModel defaulted on.
 //
-// Model identity decides two things that fail silently when the registry lookup
-// misses: the task prefixes text is wrapped in, and the input budget. A miss
-// yields neither and no error, so the symptom is not a failure but quietly worse
-// recall -- or, against a backend that rejects oversize input hard rather than
-// truncating, a per-fact failure with nothing naming the cause.
-//
-// Serving runtimes rename models freely: Ollama appends a tag, Lemonade appends
-// -GGUF and takes a user. prefix. A rename on the backend is enough to turn a
-// resolved model into an unresolved one, which is why this is strict by default
-// rather than trusting the deployment to keep the name in registry form.
-//
-// Set MEMSTORE_EMBED_STRICT_MODEL=false (or EMBEDDING_STRICT_MODEL=false) to run
-// a model the registry does not know, accepting no prefixes and no budget.
-// Setting EMBEDDING_MODEL_ALIAS to map the served name onto a known one is
-// almost always the better answer.
+// The default matters because model identity decides the task prefixes and the
+// input budget, and both fail open: a registry miss yields a passthrough
+// prompter and a zero budget with no error, so the symptom is quietly worse
+// recall rather than a failure. Setting MEMSTORE_EMBED_STRICT_MODEL or the bare
+// EMBEDDING_STRICT_MODEL opts out, and is never overridden.
 func EmbedConfigFromEnv() (embedding.Config, error) {
-	cfg, err := embedding.ConfigFromEnvPrefix(EmbedEnvPrefix)
-	if err != nil {
-		return cfg, err
-	}
-	if !strictModelSetByOperator() {
-		cfg.StrictModel = true
-	}
-	return cfg, nil
-}
-
-// strictModelSetByOperator reports whether the strict-model choice was made
-// explicitly, so the default is applied only when nobody stated a preference.
-func strictModelSetByOperator() bool {
-	for _, k := range []string{EmbedEnvPrefix + "_STRICT_MODEL", "EMBEDDING_STRICT_MODEL"} {
-		if _, ok := os.LookupEnv(k); ok {
-			return true
-		}
-	}
-	return false
+	return embedding.ConfigFromEnvPrefixStrict(EmbedEnvPrefix)
 }
 
 // LogEmbedModel records what the configured model name actually resolved to, so
 // the prefixes and budget in force are visible at startup rather than inferred
 // from bad results later.
 func LogEmbedModel(cfg embedding.Config) {
-	info, known := embedding.LookupModel(cfg.Model)
-	if !known {
-		log.Printf("memstore: embedding model %q is unrecognised -- no task prefixes and no input budget", cfg.Model)
-		return
-	}
-	log.Printf("memstore: embedding model %q resolved as %q (task prefixes: %v, budget: %d bytes)",
-		cfg.Model, info.Canonical, info.HasPrompts, cfg.Limits().MaxBytes)
+	log.Printf("memstore: %s", embedding.Describe(cfg))
 }

--- a/factchunk.go
+++ b/factchunk.go
@@ -60,9 +60,14 @@ type FactVectors struct {
 // widens every chunk and quietly degrades retrieval, with nothing reporting it
 // (see matthewjhunter/herald#297).
 const (
-	// ChunkTargetBytes is the size chunks aim for: roughly 512 tokens at
-	// typical English byte/token ratios.
-	ChunkTargetBytes = 1024
+	// ChunkTargetTokens is the size chunks aim for, in tokens.
+	//
+	// Tokens rather than bytes because that is the unit chunk size is reasoned
+	// about in, and the bytes-per-token ratio varies by model and by corpus.
+	// go-embedding converts it through the ratio it has actually observed for
+	// the model (BudgetForTokens), falling back to a conservative figure until
+	// enough has been seen.
+	ChunkTargetTokens = 512
 	// ChunkOverlapBytes repeats the tail of each chunk at the head of the
 	// next, so a boundary landing mid-argument does not strand the two halves
 	// in vectors that each describe half a thought.
@@ -74,7 +79,7 @@ const (
 
 // ChunkFact splits a fact's content into the spans that will each become one
 // vector. Most facts are short and come back as a single chunk; only content
-// past ChunkTargetBytes is split.
+// past the chunk target is split.
 //
 // ceiling is a hard upper bound in bytes, normally the effective input budget
 // of the configured embedder (Config.Limits().MaxBytes). It only ever makes
@@ -86,21 +91,13 @@ const (
 // Chunk.Text is exactly content[Start:End], so a stored vector can be traced
 // back to the span of the fact it describes.
 func ChunkFact(model, content string, ceiling int) []embedding.Chunk {
-	target := ChunkTargetBytes
-	if ceiling > 0 && ceiling < target {
-		target = ceiling
-	}
-	overlap := ChunkOverlapBytes
-	minBytes := ChunkMinBytes
-	if target < ChunkTargetBytes {
-		// Scale the companion sizes with a clamped target, or a small ceiling
-		// leaves an overlap that swallows most of each chunk.
-		overlap = target * ChunkOverlapBytes / ChunkTargetBytes
-		minBytes = target * ChunkMinBytes / ChunkTargetBytes
-	}
 	return embedding.Split(model, content, embedding.SplitOptions{
-		MaxBytes: target,
-		Overlap:  overlap,
-		MinBytes: minBytes,
+		// The token target and the backend ceiling, whichever binds first. The
+		// ceiling can only ever make chunks smaller; a ceiling above the target
+		// is ignored rather than used to inflate them.
+		MaxTokens: ChunkTargetTokens,
+		MaxBytes:  ceiling,
+		Overlap:   ChunkOverlapBytes,
+		MinBytes:  ChunkMinBytes,
 	})
 }

--- a/factchunk_test.go
+++ b/factchunk_test.go
@@ -42,8 +42,8 @@ func TestChunkFact_TargetIsWellUnderTheModelBudget(t *testing.T) {
 			"which is exactly the sizing this is meant not to use", len(content), len(chunks), budget)
 	}
 	for i, c := range chunks {
-		if len(c.Text) > memstore.ChunkTargetBytes {
-			t.Errorf("chunk %d is %d bytes, over the %d-byte target", i, len(c.Text), memstore.ChunkTargetBytes)
+		if got := embedding.BudgetForTokens(chunkModel, memstore.ChunkTargetTokens); len(c.Text) > got {
+			t.Errorf("chunk %d is %d bytes, over the %d-byte target", i, len(c.Text), got)
 		}
 	}
 }
@@ -72,12 +72,12 @@ func TestChunkFact_CeilingClampsTheTarget(t *testing.T) {
 func TestChunkFact_GenerousCeilingDoesNotInflateChunks(t *testing.T) {
 	content := strings.Repeat("The retry budget needs careful tuning. ", 80)
 
-	tight := memstore.ChunkFact(chunkModel, content, memstore.ChunkTargetBytes*4)
+	tight := memstore.ChunkFact(chunkModel, content, embedding.BudgetForTokens(chunkModel, memstore.ChunkTargetTokens)*4)
 	none := memstore.ChunkFact(chunkModel, content, 0)
 
 	if len(tight) != len(none) {
 		t.Errorf("a ceiling of %d produced %d chunks but no ceiling produced %d; "+
-			"the ceiling is raising the target", memstore.ChunkTargetBytes*4, len(tight), len(none))
+			"the ceiling is raising the target", embedding.BudgetForTokens(chunkModel, memstore.ChunkTargetTokens)*4, len(tight), len(none))
 	}
 }
 

--- a/factembed.go
+++ b/factembed.go
@@ -8,13 +8,22 @@ import (
 	embedding "github.com/matthewjhunter/go-embedding"
 )
 
-// FactEmbedText renders what is actually sent to the model for one chunk: the
-// fact's subject, then the chunk body, under the model's document task prefix.
+// factFields is the metadata header applied to every chunk of a fact.
 //
-// The subject is re-applied to every chunk rather than only the first. Split
-// the rendered text instead and chunk 0 keeps the subject while chunks 1..N are
+// The subject is re-applied to each chunk rather than only the first. Split the
+// rendered text instead and chunk 0 keeps the subject while chunks 1..N are
 // anonymous prose with nothing saying which fact they belong to -- no error,
 // just worse retrieval on exactly the long facts chunking was meant to rescue.
+// SplitRecord enforces that; memstore only has to say what the header is.
+func factFields(subject string) []embedding.Field {
+	if subject == "" {
+		return nil
+	}
+	return []embedding.Field{{Key: "subject", Value: subject}}
+}
+
+// FactEmbedText renders what is sent to the model for one chunk of a fact: the
+// document task prefix, the subject header, then the chunk body.
 //
 // The task prefix is what the model was trained to key off. nomic-embed-text
 // expects "search_document:" on stored text and "search_query:" on the query;
@@ -22,21 +31,12 @@ import (
 // trained to distinguish, silently. See FactQueryText for the other side.
 //
 // TaskRetrievalDocument rather than TaskClustering because memstore's primary
-// vector use is query-to-fact search, which is asymmetric retrieval. herald
-// picks clustering for the same library because its primary use is
-// article-to-article grouping -- different primary use, different right answer.
-// Fact-to-fact comparison (deduplication, supersession) still works here
-// because both operands are document vectors, so they share a space.
-//
-// An unregistered model yields a passthrough prompter, so the text is returned
-// unprefixed rather than mangled; EmbedConfigFromEnv defaults StrictModel on so
-// that case is loud at startup instead of silent here.
+// vector use is query-to-fact search, which is asymmetric. Fact-to-fact
+// comparison still works, since both operands are document vectors and share a
+// space.
 func FactEmbedText(model, subject, chunk string) string {
-	text := chunk
-	if subject != "" {
-		text = subject + ": " + chunk
-	}
-	return embedding.FormatForTask(model, embedding.TaskRetrievalDocument, text)
+	return embedding.FormatRecordForTask(model, embedding.TaskRetrievalDocument,
+		factFields(subject), chunk)
 }
 
 // FactQueryText renders a search query under the model's query task, so it is
@@ -77,14 +77,14 @@ func FactQueryText(model, query string) string {
 // in the middle of it, so a failure returns nothing and the fact is retried
 // whole.
 func EmbedFact(ctx context.Context, e embedding.Embedder, model string, f Fact, ceiling int) (FactVectors, error) {
-	chunks, _ := factChunksFor(model, f, ceiling)
+	chunks := factChunksFor(model, f, ceiling)
 	if len(chunks) == 0 {
 		return FactVectors{}, nil
 	}
 
 	texts := make([]string, len(chunks))
 	for i, c := range chunks {
-		texts[i] = FactEmbedText(model, f.Subject, c.Text)
+		texts[i] = c.Text
 	}
 
 	vecs, err := embedding.EmbedWithRetry(ctx, e, texts)
@@ -148,23 +148,24 @@ func poolVectors(vecs [][]float32) []float32 {
 }
 
 // factChunksFor splits a fact's content into chunks whose *rendered* size fits
-// the ceiling. The task prefix and subject header are charged against it by
-// measuring the rendering of an empty body rather than assuming a size -- size
-// the body at the full ceiling and then prepend a header and every request goes
-// over it.
-func factChunksFor(model string, f Fact, ceiling int) ([]embedding.Chunk, int) {
-	overhead := len(FactEmbedText(model, f.Subject, ""))
-	bodyCeiling := ceiling
-	if bodyCeiling > 0 {
-		bodyCeiling -= overhead
-		if bodyCeiling < 1 {
-			// A subject long enough to leave no room for a body is
-			// pathological. Embed what fits rather than splitting into
-			// slivers; go-embedding still clips to the model's budget.
-			bodyCeiling = 1
-		}
-	}
-	return ChunkFact(model, f.Content, bodyCeiling), overhead
+// the budget, with the header re-applied to each.
+//
+// SplitRecord owns the parts that are easy to get wrong: it splits the body
+// rather than the rendered text (so late chunks keep their header and their
+// offsets stay inside the content), and it charges the header against the
+// budget by measuring it rather than assuming a size.
+//
+// MaxBytes is the ceiling the backend imposes and MaxTokens the retrieval
+// target; whichever binds first wins, so the ceiling can only ever make chunks
+// smaller.
+func factChunksFor(model string, f Fact, ceiling int) []embedding.RenderedChunk {
+	return embedding.SplitRecord(model, embedding.TaskRetrievalDocument,
+		factFields(f.Subject), f.Content, embedding.SplitOptions{
+			MaxBytes:  ceiling,
+			MaxTokens: ChunkTargetTokens,
+			Overlap:   ChunkOverlapBytes,
+			MinBytes:  ChunkMinBytes,
+		})
 }
 
 // FactVectorsResult is the outcome for one fact in a batched embed,
@@ -195,62 +196,36 @@ type FactVectorsResult struct {
 func EmbedFactsBatch(ctx context.Context, e embedding.Embedder, model string, facts []Fact, ceiling, batchSize int) []FactVectorsResult {
 	out := make([]FactVectorsResult, len(facts))
 
-	// Flatten every fact's chunks into one input slice, remembering which fact
-	// each came from so the vectors can be zipped back afterwards.
-	var texts []string
-	var spans []FactChunk
-	var owner []int
+	items := make([]embedding.BatchItem, len(facts))
+	spans := make([][]embedding.RenderedChunk, len(facts))
 	for i, f := range facts {
-		chunks, _ := factChunksFor(model, f, ceiling)
-		for _, c := range chunks {
-			texts = append(texts, FactEmbedText(model, f.Subject, c.Text))
-			spans = append(spans, FactChunk{Ordinal: c.Ordinal, ByteStart: c.Start, ByteEnd: c.End})
-			owner = append(owner, i)
+		chunks := factChunksFor(model, f, ceiling)
+		spans[i] = chunks
+		texts := make([]string, len(chunks))
+		for j, c := range chunks {
+			texts[j] = c.Text
 		}
-	}
-	if len(texts) == 0 {
-		return out
+		items[i] = embedding.BatchItem{Texts: texts}
 	}
 
-	res, err := embedding.BatchEmbedResults(ctx, e, texts, batchSize, nil)
-	if len(res) != len(texts) {
-		// Every input failed, or the helper broke its index-alignment contract.
-		// Either way there is nothing to zip; fail each fact with the cause.
-		if err == nil {
-			err = fmt.Errorf("memstore: embedding facts: got %d results for %d inputs", len(res), len(texts))
-		}
-		for _, i := range owner {
-			out[i].Err = err
-		}
-		return out
-	}
-
-	for j, r := range res {
-		i := owner[j]
-		if out[i].Err != nil {
-			continue
-		}
+	for i, r := range embedding.BatchEmbedItems(ctx, e, items, batchSize) {
 		if r.Err != nil {
-			// One failed chunk fails the whole fact: a half-embedded fact would
-			// look complete to the queue and leave a permanent hole in it.
-			out[i] = FactVectorsResult{Err: fmt.Errorf("memstore: embedding fact %d: %w", facts[i].ID, r.Err)}
+			out[i] = FactVectorsResult{Err: fmt.Errorf("memstore: fact %d: %w", facts[i].ID, r.Err)}
 			continue
 		}
-		c := spans[j]
-		c.Vector = r.Vector
-		out[i].Vectors.Chunks = append(out[i].Vectors.Chunks, c)
-	}
-
-	// Pool each fact's chunk vectors into its whole-fact vector.
-	for i := range out {
-		if out[i].Err != nil || len(out[i].Vectors.Chunks) == 0 {
-			continue
+		if len(r.Vectors) == 0 {
+			continue // nothing embeddable in the content
 		}
-		vecs := make([][]float32, len(out[i].Vectors.Chunks))
-		for k, c := range out[i].Vectors.Chunks {
-			vecs[k] = c.Vector
+		chunks := make([]FactChunk, len(r.Vectors))
+		for j, v := range r.Vectors {
+			chunks[j] = FactChunk{
+				Ordinal:   spans[i][j].Ordinal,
+				Vector:    v,
+				ByteStart: spans[i][j].Start,
+				ByteEnd:   spans[i][j].End,
+			}
 		}
-		out[i].Vectors.Whole = poolVectors(vecs)
+		out[i] = FactVectorsResult{Vectors: FactVectors{Whole: poolVectors(r.Vectors), Chunks: chunks}}
 	}
 	return out
 }

--- a/factprefix_test.go
+++ b/factprefix_test.go
@@ -62,8 +62,9 @@ func TestFactPrefixes_UnknownModelPassesThrough(t *testing.T) {
 	if got := memstore.FactQueryText(unknown, "hello"); got != "hello" {
 		t.Errorf("query = %q, want it unchanged on an unregistered model", got)
 	}
-	if got := memstore.FactEmbedText(unknown, "s", "body"); got != "s: body" {
-		t.Errorf("document = %q, want the bare rendering on an unregistered model", got)
+	// The record layout still applies; only the task prefix is absent.
+	if got := memstore.FactEmbedText(unknown, "s", "body"); got != "subject: s\n\nbody" {
+		t.Errorf("document = %q, want the unprefixed record rendering on an unregistered model", got)
 	}
 }
 

--- a/factrecipe.go
+++ b/factrecipe.go
@@ -1,0 +1,56 @@
+package memstore
+
+import (
+	embedding "github.com/matthewjhunter/go-embedding"
+)
+
+// headerLayoutVersion identifies how a chunk's header is assembled.
+// go-embedding sees the task and the chunk size but not which fields memstore
+// puts in the header, so memstore contributes this. Bump it whenever the header
+// changes, so stored vectors are recognised as stale.
+//
+// v2: moved from a hand-rolled "subject: content" single line to
+// FormatRecordForTask's record layout ("subject: <v>", blank line, body), which
+// is what SplitRecord renders.
+const headerLayoutVersion = "subject-record-v2"
+
+// EmbedRecipe identifies everything besides the model and vector dimension that
+// determines a stored fact vector: the task prefix, the chunk size, and the
+// header layout.
+//
+// It exists so a recipe change is *detected* rather than remembered. Every
+// previous one -- chunking, then task prefixes -- needed a hand-written
+// migration whose only content was "delete every vector so the backfill
+// re-runs", written from whoever changed the recipe recalling that they had.
+// That does not scale, and the symptom of forgetting is degraded ranking rather
+// than an error.
+//
+// The embed ceiling is deliberately NOT folded in, even though a ceiling below
+// the chunk target does lower the effective chunk size and so does change the
+// vectors.
+//
+// The reason is when each is knowable. The ceiling arrives through
+// SetEmbedCeiling after the store is constructed, so a recipe that depended on
+// it could not be checked at store-open -- the moment that matters, before a
+// stale vector is served. Computing it at open with the ceiling still unset and
+// again later with it set would make the recipe differ between the two, and a
+// deployment clamped below the target would clear its vectors on every single
+// startup. A check that cries wolf is one that gets routed around.
+//
+// The gap this leaves is narrow and worth stating: two deployments of the same
+// model that clamp to different ceilings below the chunk target are not
+// distinguished. Both known deployments run budgets well above it, where the
+// ceiling has no effect on chunk size at all.
+//
+// The *token* target is hashed rather than the byte budget it converts to. The
+// byte figure moves as calibration observations accumulate, so hashing it would
+// make the recipe drift during normal operation and clear the corpus on a
+// restart.
+func EmbedRecipe(model string) string {
+	return embedding.RecipeFingerprint(
+		model,
+		embedding.TaskRetrievalDocument,
+		embedding.SplitOptions{MaxTokens: ChunkTargetTokens},
+		headerLayoutVersion,
+	)
+}

--- a/factrecipe_test.go
+++ b/factrecipe_test.go
@@ -1,0 +1,113 @@
+package memstore_test
+
+import (
+	"database/sql"
+	"testing"
+
+	embedding "github.com/matthewjhunter/go-embedding"
+	"github.com/matthewjhunter/memstore"
+	_ "modernc.org/sqlite"
+)
+
+func TestEmbedRecipe_ModelMovesIt(t *testing.T) {
+	if memstore.EmbedRecipe("nomic-embed-text") == memstore.EmbedRecipe("embeddinggemma") {
+		t.Error("two models share a recipe")
+	}
+}
+
+// The recipe must not vary between two computations in the same deployment, or
+// the store would clear its vectors on every startup.
+func TestEmbedRecipe_IsStable(t *testing.T) {
+	if a, b := memstore.EmbedRecipe(chunkModel), memstore.EmbedRecipe(chunkModel); a != b {
+		t.Errorf("same model gave %q and %q", a, b)
+	}
+}
+
+// The payoff: a recipe change is detected and self-heals, instead of needing a
+// hand-written migration whose only content is "delete every vector". Chunking
+// and task prefixes each needed one of those, written from whoever changed the
+// recipe remembering that they had.
+func TestReopen_RecipeChangeClearsVectorsForReEmbedding(t *testing.T) {
+	db := openSharedTestDB(t)
+	ctx := t.Context()
+
+	first := newStoreOnDB(t, db, &mockEmbedder{dim: 4, model: "nomic-embed-text"})
+	id, err := first.Insert(ctx, memstore.Fact{Content: "a fact", Subject: "S", Category: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := first.EmbedFacts(ctx, 10); err != nil {
+		t.Fatal(err)
+	}
+	if chunks, _ := first.FactChunks(ctx, id); len(chunks) == 0 {
+		t.Fatal("nothing was embedded, so there is nothing for a recipe change to invalidate")
+	}
+
+	// Reopening under a different model changes the recipe -- but also the
+	// model, which must NOT self-heal. Rewrite just the recipe to isolate it.
+	if _, err := db.Exec(
+		`UPDATE memstore_meta SET value = 'stale-recipe' WHERE key = 'embedding_recipe'`); err != nil {
+		t.Fatal(err)
+	}
+
+	second := newStoreOnDB(t, db, &mockEmbedder{dim: 4, model: "nomic-embed-text"})
+
+	chunks, err := second.FactChunks(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chunks) != 0 {
+		t.Errorf("%d chunk rows survived a recipe change; they were produced by a different "+
+			"recipe and would be ranked against queries from the new one", len(chunks))
+	}
+	pending, err := second.NeedingEmbedding(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Errorf("%d facts queued for re-embedding, want 1 -- clearing without re-queueing "+
+			"leaves the fact permanently unembedded", len(pending))
+	}
+}
+
+// A model change must NOT self-heal: it usually means something moved
+// underneath the deployment, and clearing vectors would hide that.
+func TestReopen_ModelChangeIsRefusedNotCleared(t *testing.T) {
+	db := openSharedTestDB(t)
+	ctx := t.Context()
+
+	first := newStoreOnDB(t, db, &mockEmbedder{dim: 4, model: "nomic-embed-text"})
+	if _, err := first.Insert(ctx, memstore.Fact{Content: "a fact", Subject: "S", Category: "test"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := first.EmbedFacts(ctx, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := memstore.NewSQLiteStore(db, &mockEmbedder{dim: 4, model: "embeddinggemma"}, "test")
+	if err == nil {
+		t.Fatal("a model change was accepted; stored vectors from another model would be served")
+	}
+}
+
+// openSharedTestDB returns a database that survives being reopened by several
+// stores, so a fingerprint written by one is seen by the next.
+func openSharedTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+t.Name()+"?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func newStoreOnDB(t *testing.T, db *sql.DB, e embedding.Embedder) *memstore.SQLiteStore {
+	t.Helper()
+	s, err := memstore.NewSQLiteStore(db, e, "test")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	return s
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/infodancer/smoke v0.1.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/matthewjhunter/airlock v0.1.1
-	github.com/matthewjhunter/go-embedding v0.5.3
+	github.com/matthewjhunter/go-embedding v0.6.1
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/openai/openai-go v1.12.0
 	github.com/pgvector/pgvector-go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,10 @@ github.com/matthewjhunter/airlock v0.1.1 h1:l4Oh5vGf0t2gHxUvcdejbDweh47gxQE+rlPF
 github.com/matthewjhunter/airlock v0.1.1/go.mod h1:moFr55RDN0yuPfKlZbN1K9qQDNA4/SCZuMSGkQuUR9M=
 github.com/matthewjhunter/go-embedding v0.5.3 h1:nsM4IxX7QuXECU34mqvJ/ikYbjOq897Ij70STOUM4gg=
 github.com/matthewjhunter/go-embedding v0.5.3/go.mod h1:V1zB3ZIUOE9zL2WvnZqtgj5kP1IXPgbAFUROT1+a2+w=
+github.com/matthewjhunter/go-embedding v0.6.0 h1:R88ZA8kMESi4tcZbQ5hKBmM/TnVxwnQMwPhX8NHIjVo=
+github.com/matthewjhunter/go-embedding v0.6.0/go.mod h1:JC7e8n+h2p9O6EZkpJUDc9dRRAYPM4mHhDRzWvAxnIQ=
+github.com/matthewjhunter/go-embedding v0.6.1 h1:SblIEfHjlB7fI1WeWajXZPtqW47XTVITpyjzx8jx8Wc=
+github.com/matthewjhunter/go-embedding v0.6.1/go.mod h1:JC7e8n+h2p9O6EZkpJUDc9dRRAYPM4mHhDRzWvAxnIQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -760,51 +761,123 @@ func migrateV4As(ctx context.Context, tx pgx.Tx, namespace, defaultUser string) 
 	return nil
 }
 
-func (s *PostgresStore) validateEmbedder(ctx context.Context) error {
-	var stored string
-	err := s.pool.QueryRow(ctx, `SELECT value FROM memstore_meta WHERE key = 'embedding_model'`).Scan(&stored)
-	if err == pgx.ErrNoRows {
-		return nil
-	}
+// storedFingerprint reads the persisted fingerprint. Absent fields come back as
+// their zero value, which Reconcile reads as "not known yet".
+func (s *PostgresStore) storedFingerprint(ctx context.Context) (embedding.Fingerprint, error) {
+	var fp embedding.Fingerprint
+	rows, err := s.pool.Query(ctx,
+		`SELECT key, value FROM memstore_meta
+		 WHERE key IN ('embedding_model', 'embedding_dim', 'embedding_recipe')`)
 	if err != nil {
-		return fmt.Errorf("pgstore: reading embedding model: %w", err)
+		return fp, fmt.Errorf("pgstore: reading embedder fingerprint: %w", err)
 	}
-	if got := s.embedder.Model(); got != stored {
-		return &embedding.MismatchError{
-			Stored:  embedding.Fingerprint{Model: stored},
-			Current: embedding.Fingerprint{Model: got},
+	defer rows.Close()
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return fp, fmt.Errorf("pgstore: scanning embedder fingerprint: %w", err)
+		}
+		switch k {
+		case "embedding_model":
+			fp.Model = v
+		case "embedding_dim":
+			fmt.Sscanf(v, "%d", &fp.Dim)
+		case "embedding_recipe":
+			fp.Recipe = v
+		}
+	}
+	return fp, rows.Err()
+}
+
+// persistFingerprint writes the fingerprint back, replacing whatever was there.
+func (s *PostgresStore) persistFingerprint(ctx context.Context, fp embedding.Fingerprint) error {
+	vals := map[string]string{"embedding_model": fp.Model, "embedding_recipe": fp.Recipe}
+	if fp.Dim > 0 {
+		vals["embedding_dim"] = fmt.Sprintf("%d", fp.Dim)
+	}
+	for k, v := range vals {
+		if v == "" {
+			continue
+		}
+		if _, err := s.pool.Exec(ctx,
+			`INSERT INTO memstore_meta (key, value) VALUES ($1, $2)
+			 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`, k, v); err != nil {
+			return fmt.Errorf("pgstore: recording %s: %w", k, err)
 		}
 	}
 	return nil
 }
 
-func (s *PostgresStore) recordEmbedder(ctx context.Context, dim int) error {
-	var storedDim string
-	err := s.pool.QueryRow(ctx, `SELECT value FROM memstore_meta WHERE key = 'embedding_dim'`).Scan(&storedDim)
-	if err != nil && err != pgx.ErrNoRows {
-		return fmt.Errorf("pgstore: checking meta: %w", err)
+// reconcileEmbedder compares what is currently known against what is stored,
+// and persists the result.
+//
+// A model or dimension change is returned as an error: those mean something
+// moved underneath the deployment -- a tag advanced, a backend swapped a model
+// -- and clearing vectors automatically would hide it.
+//
+// A recipe-only change is handled here instead. It follows a deliberate edit,
+// the stored vectors are merely in the wrong region rather than incomparable,
+// and clearing them lets the existing backfill rebuild. Doing that here is what
+// removes the hand-written-migration-per-recipe-change pattern.
+func (s *PostgresStore) reconcileEmbedder(ctx context.Context, current embedding.Fingerprint) error {
+	stored, err := s.storedFingerprint(ctx)
+	if err != nil {
+		return err
 	}
-	if err == nil {
-		var existing int
-		fmt.Sscanf(storedDim, "%d", &existing)
-		if existing != dim {
-			return &embedding.MismatchError{
-				Stored:  embedding.Fingerprint{Model: s.embedder.Model(), Dim: existing},
-				Current: embedding.Fingerprint{Model: s.embedder.Model(), Dim: dim},
-			}
+
+	merged, err := embedding.Reconcile(stored, current)
+	if err != nil {
+		if !embedding.RecipeOnly(err) {
+			return err
 		}
+		log.Printf("pgstore: embedding recipe changed (%s -> %s); clearing vectors for re-embedding",
+			stored.Recipe, current.Recipe)
+		if err := s.clearVectors(ctx); err != nil {
+			return err
+		}
+		// The dimension is re-learned on the next embed; keeping the old one
+		// would assert something about vectors that no longer exist.
+		merged = current
+	}
+	return s.persistFingerprint(ctx, merged)
+}
+
+// clearVectors drops every stored vector so the backfill repopulates them.
+func (s *PostgresStore) clearVectors(ctx context.Context) error {
+	for _, q := range []string{
+		`DELETE FROM memstore_fact_chunks`,
+		`UPDATE memstore_facts SET embedding = NULL, embed_failed_at = NULL, embed_error = NULL`,
+		`DELETE FROM memstore_meta WHERE key = 'embedding_dim'`,
+	} {
+		if _, err := s.pool.Exec(ctx, q); err != nil {
+			return fmt.Errorf("pgstore: clearing vectors: %w", err)
+		}
+	}
+	return nil
+}
+
+// validateEmbedder checks, at store-open, everything knowable from
+// configuration alone: the model and the recipe. Only the dimension has to
+// wait, since it is not known until a vector comes back.
+func (s *PostgresStore) validateEmbedder(ctx context.Context) error {
+	if s.embedder == nil {
 		return nil
 	}
-	if _, err := s.pool.Exec(ctx, `INSERT INTO memstore_meta (key, value) VALUES ('embedding_model', $1)`, s.embedder.Model()); err != nil {
-		return fmt.Errorf("pgstore: recording embedding model: %w", err)
-	}
-	if _, err := s.pool.Exec(ctx, `INSERT INTO memstore_meta (key, value) VALUES ('embedding_dim', $1)`, fmt.Sprintf("%d", dim)); err != nil {
-		return fmt.Errorf("pgstore: recording embedding dim: %w", err)
-	}
-	return nil
+	return s.reconcileEmbedder(ctx, embedding.Fingerprint{
+		Model:  s.embedder.Model(),
+		Recipe: memstore.EmbedRecipe(s.embedder.Model()),
+	})
 }
 
-// Insert adds a single fact and returns its ID.
+// recordEmbedder reconciles everything now knowable -- model, dimension and
+// recipe -- on the first embedding operation.
+func (s *PostgresStore) recordEmbedder(ctx context.Context, dim int) error {
+	return s.reconcileEmbedder(ctx, embedding.Fingerprint{
+		Model:  s.embedder.Model(),
+		Dim:    dim,
+		Recipe: memstore.EmbedRecipe(s.embedder.Model()),
+	})
+}
 func (s *PostgresStore) Insert(ctx context.Context, f memstore.Fact) (int64, error) {
 	if f.CreatedAt.IsZero() {
 		f.CreatedAt = time.Now().UTC()

--- a/sqlite.go
+++ b/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os/user"
 	"slices"
 	"strings"
@@ -564,55 +565,125 @@ func (s *SQLiteStore) migrateV2() error {
 	return nil
 }
 
-// validateEmbedder checks that the configured embedder's model matches
-// the model recorded in the database (if any). Dim cannot be validated here
-// because embedder.Fingerprint().Dim is only populated after the first
-// successful Embed call; recordEmbedder validates dim at first embed.
-func (s *SQLiteStore) validateEmbedder() error {
-	var stored string
-	err := s.db.QueryRow(`SELECT value FROM memstore_meta WHERE key = 'embedding_model'`).Scan(&stored)
-	if err == sql.ErrNoRows {
-		return nil // no model recorded yet; will be recorded on first embed
-	}
+// storedFingerprint reads the persisted fingerprint. Absent fields come back
+// as their zero value, which Reconcile reads as "not known yet".
+func (s *SQLiteStore) storedFingerprint() (embedding.Fingerprint, error) {
+	var fp embedding.Fingerprint
+	rows, err := s.db.Query(
+		`SELECT key, value FROM memstore_meta
+		 WHERE key IN ('embedding_model', 'embedding_dim', 'embedding_recipe')`)
 	if err != nil {
-		return fmt.Errorf("memstore: reading embedding model: %w", err)
+		return fp, fmt.Errorf("memstore: reading embedder fingerprint: %w", err)
 	}
-	if got := s.embedder.Model(); got != stored {
-		return &embedding.MismatchError{
-			Stored:  embedding.Fingerprint{Model: stored},
-			Current: embedding.Fingerprint{Model: got},
+	defer rows.Close()
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return fp, fmt.Errorf("memstore: scanning embedder fingerprint: %w", err)
+		}
+		switch k {
+		case "embedding_model":
+			fp.Model = v
+		case "embedding_dim":
+			fmt.Sscanf(v, "%d", &fp.Dim)
+		case "embedding_recipe":
+			fp.Recipe = v
+		}
+	}
+	return fp, rows.Err()
+}
+
+// persistFingerprint writes the fingerprint back, replacing whatever was there.
+func (s *SQLiteStore) persistFingerprint(fp embedding.Fingerprint) error {
+	vals := map[string]string{"embedding_model": fp.Model, "embedding_recipe": fp.Recipe}
+	if fp.Dim > 0 {
+		vals["embedding_dim"] = fmt.Sprintf("%d", fp.Dim)
+	}
+	for k, v := range vals {
+		if v == "" {
+			continue
+		}
+		if _, err := s.db.Exec(
+			`INSERT INTO memstore_meta (key, value) VALUES (?, ?)
+			 ON CONFLICT(key) DO UPDATE SET value = excluded.value`, k, v); err != nil {
+			return fmt.Errorf("memstore: recording %s: %w", k, err)
 		}
 	}
 	return nil
 }
 
-// recordEmbedder writes the embedding model and dimension to the meta table
-// if not already recorded; if a dim is already recorded, it must match the
-// observed dim or recordEmbedder returns *embedding.MismatchError. Called on
-// first embedding operation.
-func (s *SQLiteStore) recordEmbedder(dim int) error {
-	var storedDim sql.NullString
-	if err := s.db.QueryRow(`SELECT value FROM memstore_meta WHERE key = 'embedding_dim'`).Scan(&storedDim); err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("memstore: checking meta: %w", err)
+// reconcileEmbedder compares what is currently known against what is stored,
+// and persists the result.
+//
+// A model or dimension change is returned as an error: those mean something
+// moved underneath the deployment -- a tag advanced, a backend swapped a model
+// -- and clearing vectors automatically would hide it.
+//
+// A recipe-only change is handled here instead. It follows a deliberate edit,
+// the stored vectors are merely in the wrong region rather than incomparable,
+// and clearing them lets the existing backfill rebuild. Doing that here is what
+// removes the hand-written-migration-per-recipe-change pattern: chunking and
+// task prefixes each needed one, written from whoever changed the recipe
+// remembering that they had.
+func (s *SQLiteStore) reconcileEmbedder(current embedding.Fingerprint) error {
+	stored, err := s.storedFingerprint()
+	if err != nil {
+		return err
 	}
-	if storedDim.Valid {
-		var existing int
-		fmt.Sscanf(storedDim.String, "%d", &existing)
-		if existing != dim {
-			return &embedding.MismatchError{
-				Stored:  embedding.Fingerprint{Model: s.embedder.Model(), Dim: existing},
-				Current: embedding.Fingerprint{Model: s.embedder.Model(), Dim: dim},
-			}
+
+	merged, err := embedding.Reconcile(stored, current)
+	if err != nil {
+		if !embedding.RecipeOnly(err) {
+			return err
 		}
-		return nil
+		log.Printf("memstore: embedding recipe changed (%s -> %s); clearing vectors for re-embedding",
+			stored.Recipe, current.Recipe)
+		if err := s.clearVectorsLocked(); err != nil {
+			return err
+		}
+		// The dimension is re-learned on the next embed; keeping the old one
+		// would assert something about vectors that no longer exist.
+		merged = current
 	}
-	if _, err := s.db.Exec(`INSERT INTO memstore_meta (key, value) VALUES ('embedding_model', ?)`, s.embedder.Model()); err != nil {
-		return fmt.Errorf("memstore: recording embedding model: %w", err)
-	}
-	if _, err := s.db.Exec(`INSERT INTO memstore_meta (key, value) VALUES ('embedding_dim', ?)`, fmt.Sprintf("%d", dim)); err != nil {
-		return fmt.Errorf("memstore: recording embedding dim: %w", err)
+	return s.persistFingerprint(merged)
+}
+
+// clearVectorsLocked drops every stored vector so the backfill repopulates
+// them. The caller holds the write lock.
+func (s *SQLiteStore) clearVectorsLocked() error {
+	for _, q := range []string{
+		`DELETE FROM memstore_fact_chunks`,
+		`UPDATE memstore_facts SET embedding = NULL, embed_failed_at = NULL, embed_error = NULL`,
+		`DELETE FROM memstore_meta WHERE key = 'embedding_dim'`,
+	} {
+		if _, err := s.db.Exec(q); err != nil {
+			return fmt.Errorf("memstore: clearing vectors: %w", err)
+		}
 	}
 	return nil
+}
+
+// validateEmbedder checks, at store-open, everything knowable from
+// configuration alone: the model and the recipe. Only the dimension has to
+// wait, since it is not known until a vector comes back.
+func (s *SQLiteStore) validateEmbedder() error {
+	if s.embedder == nil {
+		return nil
+	}
+	return s.reconcileEmbedder(embedding.Fingerprint{
+		Model:  s.embedder.Model(),
+		Recipe: EmbedRecipe(s.embedder.Model()),
+	})
+}
+
+// recordEmbedder reconciles everything now knowable -- model, dimension and
+// recipe -- on the first embedding operation.
+func (s *SQLiteStore) recordEmbedder(dim int) error {
+	return s.reconcileEmbedder(embedding.Fingerprint{
+		Model:  s.embedder.Model(),
+		Dim:    dim,
+		Recipe: EmbedRecipe(s.embedder.Model()),
+	})
 }
 
 func (s *SQLiteStore) migrateV1() error {


### PR DESCRIPTION
Adopts go-embedding v0.6.1, deleting what the library now owns and picking up the fingerprint work from the #32 design discussion.

## What the library absorbed

| memstore had | now |
|---|---|
| 65-line `embedconfig.go` copied verbatim from herald | 30 lines wrapping `ConfigFromEnvPrefixStrict` + `Describe` |
| hand-rolled chunk rendering and budget arithmetic | `SplitRecord` |
| `EmbedFactsBatch` flatten-and-regroup | `BatchEmbedItems` |
| `validateEmbedder` + `recordEmbedder` | `Reconcile`, called at each of the two moments |
| `ChunkTargetBytes = 1024` | `ChunkTargetTokens = 512`, converted through observed calibration |

`SplitRecord` also fixes a bug memstore had: `len(format(""))` undercounted the real header by two bytes, because `FormatRecord` trims its trailing newline for an empty body but emits a blank-line separator for a real one. Two bytes is enough to put a tightly-budgeted chunk over a backend limit that rejects rather than truncates.

The chunk target moves to tokens because that is the unit chunk size is reasoned about in, and `BudgetForTokens` converts through the ratio observed for the model rather than the single corpus density that `1024` baked in.

## No migration, which is the point

Adopting `SplitRecord` changes the header layout -- from a hand-rolled `"subject: content"` line to the record layout -- so the vectors move.

Under the old scheme that needed a **third** hand-written migration whose entire content is "delete every vector so the backfill re-runs", and whose correctness depended on whoever changed the recipe remembering that they had. Chunking (#136) needed one. Task prefixes (#137) needed another. This one needs none: `validateEmbedder` reconciles a recipe fingerprint at store-open and clears the vectors itself.

```
memstore: embedding recipe changed (stale-recipe -> 31122fd9663af656); clearing vectors for re-embedding
```

A model or dimension change still refuses to open. Those usually mean something moved *underneath* the deployment -- a tag advanced, a backend swapped a model -- and clearing vectors automatically would hide the mistake. `RecipeOnly` is what separates the two.

## Two judgement calls

**The recipe excludes the embed ceiling.** The ceiling arrives through `SetEmbedCeiling` after construction, so a recipe depending on it could not be checked at store-open -- the moment that matters. Computing it with the ceiling unset at open and set at first embed would make the two differ, and a deployment clamped below the chunk target would clear its vectors on *every startup*. A check that cries wolf is one that gets routed around, which is exactly how the old `CheckFingerprint` ended up unused.

The gap: two deployments of the same model clamping to different ceilings *below* the chunk target are not distinguished. Both known deployments run budgets well above it, where the ceiling has no effect on chunk size at all.

**It hashes the token target, not the byte budget it converts to.** The byte figure moves as calibration observations accumulate, so hashing it would drift the recipe during normal operation and clear the corpus on a restart.

## Verification

Each behaviour checked by breaking it and confirming the test fails:

- treat a recipe change like a model change -> the self-heal test fails, store refuses to open
- clear vectors without re-queueing the facts -> `0 facts queued for re-embedding, want 1`
- (in go-embedding, #34) drop the exclusions from `RecipeOnly` -> it returns true for a combined model+recipe change

Ordering was checked rather than assumed: `clearVectors` touches the chunk table, so `validateEmbedder` must run after `migrate`. It does in both backends (sqlite.go:89/100, pgstore/store.go:86/98).

All 12 packages pass `go test -race -count=1 ./...` against a live pgvector container, plus `go build`, `go vet`, `golangci-lint` (0 issues) and `govulncheck`.

## Deploying

No new migration, and no extra re-embed. Production is still at schema version 5 with no chunk table, so the #136/#137 migrations have not run yet -- this rides the re-embed that was already pending rather than adding one. On the next `memstored` start the corpus rebuilds once, under the final recipe.

Refs #136, #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
