### PR TITLE
fix: create the chunk table without a dimension when none is configured

### DIFF
--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -537,11 +537,7 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 }
 
 func (s *PostgresStore) migrateV1(ctx context.Context) error {
-	// Build vector column type. If vecDim is set, use vector(N) for HNSW index support.
-	vecType := "vector"
-	if s.vecDim > 0 {
-		vecType = fmt.Sprintf("vector(%d)", s.vecDim)
-	}
+	vecType := s.vectorColumnType()
 
 	stmts := []string{
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS memstore_facts (
@@ -640,6 +636,21 @@ func (s *PostgresStore) migrateV3(ctx context.Context) error {
 		return fmt.Errorf("pgstore V3 migration: %w", err)
 	}
 	return nil
+}
+
+// vectorColumnType is the pgvector column type for this store's configured
+// dimension, and is the single place the vecDim==0 rule lives.
+//
+// An unset dimension yields an unconstrained "vector" rather than "vector(0)",
+// which Postgres rejects outright. That is not a corner case: no deployment here
+// sets vec-dim, so the live store's columns are all unconstrained, and a migration
+// that interpolated the dimension unconditionally failed on the real database while
+// passing every test -- the test harness passes a dimension, production does not.
+func (s *PostgresStore) vectorColumnType() string {
+	if s.vecDim > 0 {
+		return fmt.Sprintf("vector(%d)", s.vecDim)
+	}
+	return "vector"
 }
 
 // migrateV9 records each fact's regex detect score, so the read filter can be a
@@ -1509,11 +1520,11 @@ func (s *PostgresStore) migrateV6(ctx context.Context) error {
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS memstore_fact_chunks (
 			fact_id    BIGINT NOT NULL REFERENCES memstore_facts(id) ON DELETE CASCADE,
 			ordinal    INTEGER NOT NULL,
-			embedding  vector(%d) NOT NULL,
+			embedding  %s NOT NULL,
 			byte_start INTEGER NOT NULL,
 			byte_end   INTEGER NOT NULL,
 			PRIMARY KEY (fact_id, ordinal)
-		)`, s.vecDim),
+		)`, s.vectorColumnType()),
 		`DELETE FROM memstore_fact_chunks`,
 		// Re-queue every fact for the backfill. embed_failed_at is cleared too:
 		// a fact quarantined for overrunning the old whole-fact budget is

--- a/pgstore/store_test.go
+++ b/pgstore/store_test.go
@@ -1610,3 +1610,63 @@ func TestInitIdentity(t *testing.T) {
 		t.Fatalf("InitIdentity idempotent call: %v", err)
 	}
 }
+
+// Every test above constructs a store with an explicit dimension. No deployment
+// does: the live store passes no --vec-dim, so its vector columns are unconstrained,
+// and migrateV1 has always documented that vecDim==0 means an unconstrained column.
+//
+// migrateV6 interpolated the dimension unconditionally and so emitted "vector(0)",
+// which Postgres rejects. It passed every test and failed on the real database --
+// the harness supplied a dimension that production never had.
+func TestMigrationsWithoutAConfiguredDimension(t *testing.T) {
+	ctx := context.Background()
+	dsn := testDSN(t)
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting to postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	for _, tbl := range []string{"api_tokens", "memstore_links", "memstore_fact_chunks",
+		"memstore_screen_findings", "memstore_facts", "memstore_meta", "memstore_version",
+		"memstore_document_chunks", "memstore_documents", "memstore_users"} {
+		pool.Exec(ctx, "DROP TABLE IF EXISTS "+tbl+" CASCADE")
+	}
+
+	if _, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 0, 512); err != nil &&
+		!strings.Contains(err.Error(), "tier3-init") {
+		t.Fatalf("migrations failed with no configured dimension: %v", err)
+	}
+	if err := pgstore.InitIdentity(ctx, pool, "test", "testuser"); err != nil {
+		t.Fatal(err)
+	}
+	store, err := pgstore.New(ctx, pool, &mockEmbedder{dim: 4}, "test", 0, 512)
+	if err != nil {
+		t.Fatalf("reopen with no configured dimension: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, tbl := range []string{"memstore_fact_chunks", "memstore_screen_findings",
+			"memstore_facts", "memstore_meta", "memstore_version", "memstore_users"} {
+			pool.Exec(context.Background(), "DROP TABLE IF EXISTS "+tbl+" CASCADE")
+		}
+	})
+
+	// And the chunk table it created has to actually accept vectors.
+	id, err := store.Insert(ctx, memstore.Fact{Content: "a fact", Subject: "S", Category: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetFactVectors(ctx, id, memstore.FactVectors{
+		Whole:  []float32{1, 0, 0, 0},
+		Chunks: []memstore.FactChunk{{Ordinal: 0, Vector: []float32{1, 0, 0, 0}, ByteEnd: 6}},
+	}); err != nil {
+		t.Fatalf("storing chunk vectors in an unconstrained column: %v", err)
+	}
+	chunks, err := store.FactChunks(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chunks) != 1 {
+		t.Errorf("got %d chunks, want 1", len(chunks))
+	}
+}


### PR DESCRIPTION
`migrateV6` emitted `vector(0)` against the live database, Postgres rejected it, and memstored crash-looped on deploy.

```
init postgres store: pgstore: migration: pgstore: migrateV6:
ERROR: dimensions for type vector must be at least 1 (SQLSTATE 22023)
```

## What went wrong

pgstore has documented since `migrateV1` that a `vecDim` of 0 means an **unconstrained** column, and `migrateV1` implements exactly that:

```go
vecType := "vector"
if s.vecDim > 0 {
    vecType = fmt.Sprintf("vector(%d)", s.vecDim)
}
```

`migrateV6` (added in #140) interpolated the dimension unconditionally instead.

## Why no test caught it

Because every test supplies a dimension and no deployment does.

The daemon takes `--vec-dim` from config; `Config.VecDim` has no default; the live compose file and `.env` set nothing. So production runs with `vecDim = 0`, and **every vector column in the live store is unconstrained** -- and has been since `migrateV1`. `migrateV6` was simply the first migration to interpolate the value, so the mismatch had never been exercised.

Confirmed on the live database: `format_type` on `memstore_facts.embedding` returns a bare `vector`.

## The fix

The rule now lives in one place, `vectorColumnType()`, used by both `migrateV1` and `migrateV6`, so a future migration cannot miss it by writing its own DDL.

`TestMigrationsWithoutAConfiguredDimension` constructs a store the way production does -- no dimension -- runs the full migration chain, and then stores and reads back chunk vectors to prove the resulting column actually works. Reverting to the shipped DDL reproduces the exact production error:

```
migrations failed with no configured dimension: pgstore: migration: pgstore: migrateV6:
ERROR: dimensions for type vector must be at least 1 (SQLSTATE 22023)
```

## Nothing was damaged

The migration failed atomically before altering anything: the schema stayed at version 5 and `memstore_fact_chunks` was never created. After deploying a locally built image carrying this fix, the store migrated cleanly to version 9 and is re-embedding and detect-scoring normally.

14 packages pass `go test -race -count=1 ./...` against a live pgvector container; build, vet, `golangci-lint` (0 issues) and `govulncheck` clean.

## Please merge promptly

Production is currently running a **locally built** image tagged `:latest`. Watchtower on that host runs at 04:00 daily and will pull the registry's `:latest`, which still carries this bug until this merges and the image workflow republishes. If that happens before the fix lands, memstored crash-loops overnight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
