### PR TITLE
fix: stop writing session-activity breadcrumb facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ automatically. They are embedded in the `memstore` binary and installed by
 | `memstore-edit.mjs` | PreToolUse:Edit | Inject file/symbol constraints before edits |
 | `store-nudge.mjs` | PostToolUse:Write/Bash | Nudge to store decisions after key actions |
 | `stop-hook.mjs` | Stop | Track sessions, upload transcripts |
-| `memstore-session-end.mjs` | SessionEnd | Record activity, remind about open tasks |
+| `memstore-session-end.mjs` | SessionEnd | Remind about open tasks |
 
 Hooks that communicate with `memstored` (prompt recall, context touch, stop
 hook) silently no-op when the daemon is unavailable, so they are safe to

--- a/cmd/memstore/hooks/memstore-session-end.mjs
+++ b/cmd/memstore/hooks/memstore-session-end.mjs
@@ -2,11 +2,15 @@
 /**
  * memstore-session-end: Claude Code SessionEnd hook
  *
- * At session close this hook does two things:
- *   1. Records a "last active" timestamp fact in memstore for the working
- *      directory, giving a lightweight history of which projects were active.
- *   2. Prints any still-open startup tasks as a reminder to update their
- *      status before leaving.
+ * At session close this hook prints any still-open startup tasks as a
+ * reminder to update their status before leaving.
+ *
+ * It used to also store a "last active in <project> at <timestamp>" fact per
+ * session. That was removed in #151: the Stop hook already records every
+ * session into session_hooks with the full cwd and a real timestamp column,
+ * so the fact was a strictly worse duplicate (basename only) that was
+ * embedded and competed with real content in search. Query session_hooks for
+ * project activity instead.
  *
  * The hook exits 0 silently if the binary is missing or the DB does not
  * exist yet, so it is safe to deploy before memstore is initialized.
@@ -16,34 +20,16 @@ import { execSync } from 'child_process';
 
 const MEMSTORE_BIN = process.env.MEMSTORE_BIN || '__MEMSTORE_BIN__';
 
-// SessionEnd hook input arrives on stdin as JSON.
-// Fields: sessionId, directory (cwd at session end).
-let input = {};
+// SessionEnd hook input arrives on stdin as JSON (sessionId, directory).
+// Nothing here needs those fields any more, but stdin is still drained so the
+// caller's write completes rather than hitting a closed pipe.
 try {
-  const raw = await stdinText();
-  input = JSON.parse(raw);
+  await stdinText();
 } catch {
-  // No stdin or invalid JSON — proceed with empty input.
+  // No stdin — proceed.
 }
 
-const cwd = input.directory || process.cwd();
-const now = new Date().toISOString();
-
-// 1. Record a "last active" fact for this working directory.
-try {
-  const project = cwd.split('/').filter(Boolean).pop() || cwd;
-  const metadata = JSON.stringify({ directory: cwd, timestamp: now });
-  execSync(
-    `${MEMSTORE_BIN} store --subject "session-activity" --category "note" ` +
-    `--content "Active in ${project} at ${now}" ` +
-    `--metadata '${metadata}'`,
-    { encoding: 'utf-8', timeout: 4000, stdio: ['pipe', 'pipe', 'pipe'] }
-  );
-} catch {
-  // Store failed — not fatal.
-}
-
-// 2. Print open startup tasks as a reminder.
+// Print open startup tasks as a reminder.
 try {
   const output = execSync(`${MEMSTORE_BIN} tasks --surface startup`, {
     encoding: 'utf-8',

--- a/cmd/memstore/hooks/memstore-session-end.test.mjs
+++ b/cmd/memstore/hooks/memstore-session-end.test.mjs
@@ -1,0 +1,85 @@
+// Behavioural tests for memstore-session-end.mjs.
+// Run: node --test cmd/memstore/hooks/memstore-session-end.test.mjs
+//
+// The hook is a script with top-level side effects rather than exported
+// functions, so it is exercised as a subprocess against a stub MEMSTORE_BIN
+// that records its own argv. That is the behaviour worth pinning: which
+// memstore subcommands the hook invokes at session end.
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HOOK = join(dirname(fileURLToPath(import.meta.url)), 'memstore-session-end.mjs');
+
+let dir, stubBin, argvLog;
+
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), 'memstore-session-end-'));
+  stubBin = join(dir, 'memstore-stub');
+  argvLog = join(dir, 'argv.log');
+  // Records each invocation's arguments, one line per call.
+  writeFileSync(stubBin, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${argvLog}\n`);
+  chmodSync(stubBin, 0o755);
+});
+
+after(() => rmSync(dir, { recursive: true, force: true }));
+
+beforeEach(() => rmSync(argvLog, { force: true }));
+
+function runHook(input = { sessionId: 's-1', directory: '/home/matthew/git/matthewjhunter/memstore' }) {
+  const result = spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+    env: { ...process.env, MEMSTORE_BIN: stubBin },
+    timeout: 10000,
+  });
+  const calls = existsSync(argvLog)
+    ? readFileSync(argvLog, 'utf-8').trim().split('\n').filter(Boolean)
+    : [];
+  return { ...result, calls };
+}
+
+describe('memstore-session-end', () => {
+  it('does not write a session-activity fact', () => {
+    // Session activity is already recorded in session_hooks by the Stop hook,
+    // with a full cwd and a real timestamp column. A duplicate fact row adds
+    // nothing retrievable and competes with real content in search. See #151.
+    const { calls } = runHook();
+    const stores = calls.filter((c) => c.startsWith('store'));
+    assert.deepEqual(stores, [], `hook shelled out to memstore store: ${stores.join(' | ')}`);
+    assert.ok(
+      !calls.some((c) => c.includes('session-activity')),
+      'hook referenced the session-activity subject',
+    );
+  });
+
+  it('still reports open startup tasks', () => {
+    const { calls } = runHook();
+    assert.ok(
+      calls.some((c) => c.startsWith('tasks') && c.includes('--surface startup')),
+      `expected a tasks --surface startup call, got: ${calls.join(' | ')}`,
+    );
+  });
+
+  it('emits the continue directive on stdout', () => {
+    const { stdout, status } = runHook();
+    assert.equal(status, 0);
+    assert.deepEqual(JSON.parse(stdout.trim()), { continue: true });
+  });
+
+  it('exits cleanly when stdin is not valid JSON', () => {
+    const result = spawnSync(process.execPath, [HOOK], {
+      input: 'not json',
+      encoding: 'utf-8',
+      env: { ...process.env, MEMSTORE_BIN: stubBin },
+      timeout: 10000,
+    });
+    assert.equal(result.status, 0);
+    assert.deepEqual(JSON.parse(result.stdout.trim()), { continue: true });
+  });
+});

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -244,7 +244,7 @@ Hooks are embedded in the `memstore` binary and installed automatically by `mems
 | `memstore-edit.mjs` | PreToolUse:Edit | 5s | Inject file/symbol constraints |
 | `store-nudge.mjs` | PostToolUse:Write,Bash | 2s | Nudge to store after key actions |
 | `stop-hook.mjs` | Stop | 10s | Session tracking + transcript upload (daemon) |
-| `memstore-session-end.mjs` | SessionEnd | 5s | Record activity + task reminders |
+| `memstore-session-end.mjs` | SessionEnd | 5s | Task reminders |
 
 Hook scripts are installed to `~/.claude/hooks/` and registered in `~/.claude/settings.json` (Claude Code's `userSettings` source). Note that `~/.claude/settings.local.json` is **not** read by Claude Code — its `localSettings` source is project-scoped at `<cwd>/.claude/settings.local.json`.
 


### PR DESCRIPTION
Closes #151.

`memstore-session-end` wrote one `Active in <project> at <timestamp>` fact per session. Those had grown to 1,134 of 5,791 active facts -- the largest subject by 3.5x over the next one -- and every one was embedded, occupying ~1,100 of 7,400 chunk rows and competing with real content in the first-stage search candidate pool.

They were redundant from the start. The Stop hook already records every session into `session_hooks` with `session_id`, the full cwd, and a real `timestamptz`; that table holds 1,160 sessions against the 1,134 facts and carries strictly better data (full path, not just the basename). Project activity is a query against `session_hooks`.

This drops the fact-writing block and keeps the open-task reminder. It also adds the first test coverage for these hooks: a behavioural harness that runs the hook against a stub `MEMSTORE_BIN` and asserts which subcommands it invokes.

Worth noting for review: `httpapi/recall.go` already filtered `subject=session-activity`, so recall was clean and only `memory_search` paid the cost -- which is why this stayed invisible. I left that filter in place as defense rather than removing it as dead code.

The 1,134 existing rows were deleted separately, with a full-fidelity backup (embeddings included) at `/opt/docker/pg-dumps/session-activity-backup-2026-08-23.json` on docker-memstore.
