### PR TITLE
fix: address three lint findings

### DIFF
--- a/cmd/memstore/backfill_feedback_cmd.go
+++ b/cmd/memstore/backfill_feedback_cmd.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
+// The command takes no flags. It still accepts args so the dispatch in main.go
+// stays uniform, and rejects them rather than ignoring them: silently
+// discarding `--pg ...` would leave the caller believing an option took effect.
 func runBackfillFeedback(args []string) {
+	if len(args) > 0 {
+		log.Fatalf("backfill-feedback takes no arguments, got %q", strings.Join(args, " "))
+	}
 	if cliConfig.Remote == "" {
 		log.Fatal("backfill-feedback requires a remote memstored (set remote in config)")
 	}

--- a/cmd/memstore/tls_cmd.go
+++ b/cmd/memstore/tls_cmd.go
@@ -393,6 +393,13 @@ func appendTLSConfigKeys(path string, kv map[string]string) ([]string, error) {
 				existing[key] = true
 			}
 		}
+		// A scanner that stopped early leaves `existing` partial, and a
+		// partial map means appending a key the file already has --
+		// duplicating it silently. Refuse rather than write a half-informed
+		// edit; the caller's config is not ours to corrupt.
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("reading %s: %w", path, err)
+		}
 	case errors.Is(err, os.ErrNotExist):
 		// fine — we'll create it
 	default:

--- a/cmd/memstore/tls_config_test.go
+++ b/cmd/memstore/tls_config_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppendTLSConfigKeysSkipsExisting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("# comment\n\ntls_ca_file = \"/old/ca.pem\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := appendTLSConfigKeys(path, map[string]string{
+		"tls_ca_file":   "/new/ca.pem",
+		"tls_cert_file": "/new/client.pem",
+	})
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	if len(written) != 1 || written[0] != "tls_cert_file" {
+		t.Errorf("written = %v, want [tls_cert_file] only", written)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(body), "tls_ca_file"); got != 1 {
+		t.Errorf("tls_ca_file appears %d times, want 1; the existing key was duplicated", got)
+	}
+}
+
+// A scanner that stops early leaves the existing-keys map partial, and a
+// partial map makes the caller append a key that is already in the file --
+// silently duplicating it. bufio.Scanner reports a line over its 64KB buffer
+// as an error rather than a short read, so the error has to be checked before
+// the map is trusted.
+func TestAppendTLSConfigKeysFailsOnUnreadableConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+
+	// One line past the scanner's limit, then a key that a partial read
+	// would never reach.
+	var b strings.Builder
+	b.WriteString(strings.Repeat("x", bufio.MaxScanTokenSize+1))
+	b.WriteString("\ntls_ca_file = \"/existing/ca.pem\"\n")
+	if err := os.WriteFile(path, []byte(b.String()), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := appendTLSConfigKeys(path, map[string]string{"tls_ca_file": "/new/ca.pem"})
+	if err == nil {
+		t.Fatal("append succeeded on a config it could not fully read; tls_ca_file would be duplicated")
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(body), "tls_ca_file"); got != 1 {
+		t.Errorf("tls_ca_file appears %d times, want 1; the file was modified despite the read failing", got)
+	}
+}

--- a/httpapi/handler.go
+++ b/httpapi/handler.go
@@ -769,8 +769,7 @@ func (h *Handler) handleDeleteLink(w http.ResponseWriter, r *http.Request) {
 
 func readJSON(r *http.Request, w http.ResponseWriter, v any) bool {
 	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
 			return false
 		}


### PR DESCRIPTION
Three pre-existing lint findings, unrelated to each other and grouped only because that is what they are. Kept on their own branch so neither in-flight feature branch carries an unrelated fix.

**`appendTLSConfigKeys` ignored `bufio.Scanner.Err()`** -- the one that is more than a nit. The map it builds is the "which keys are already present" check. A scanner that stops early (a line past the 64KB buffer, an I/O error) leaves that map partial, and a partial map makes the function append a key the config already has, duplicating it silently. It now refuses rather than writing a half-informed edit.

The function had no tests. Adds two: one pinning the skip-existing behaviour, and one building a config the scanner cannot finish, asserting both that the call fails and that the file is left untouched. The second fails before this change and passes after.

**`runBackfillFeedback` took an unused `args` parameter.** The signature stays so the dispatch in `main.go` remains uniform, but the arguments are now rejected instead of ignored -- silently discarding `--pg ...` would leave the caller believing an option took effect. Note this is a `log.Fatal` path in a file with no coverage, so unlike the scanner fix it is unverified beyond compiling; renaming the parameter to `_` is the smaller alternative if you would rather not change behaviour here.

**`readJSON`'s `errors.As` is now `errors.AsType[*http.MaxBytesError]`**, dropping the out-parameter. Covered by the existing 413 test (`TestBodyLimit_OversizedRequestRejected`), which still passes.
