### PR TITLE
ci: run the Node hook tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,11 @@ name: Test
 # container, the MEMSTORE_TEST_PG env, and a coverage upload, none of which a
 # reusable workflow can express. The static-analysis quartet is delegated to
 # infodancer/workflows in ci.yml.
+#
+# The hooks job covers the Node test files (the Claude Code hook shims and the
+# Codex example). Those are not Go, so ci.yml's path filters skip them and the
+# Go test job never touches them -- without this job their coverage would only
+# ever run on a developer's machine.
 on:
   push:
     branches: [main]
@@ -46,3 +51,17 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           files: coverage.out
+
+  hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      # Bare `node --test` discovers **/*.test.mjs from the repo root, so a new
+      # hook test is picked up without editing this workflow.
+      - name: Run Node tests
+        run: node --test


### PR DESCRIPTION
The `.mjs` test files were never executed by CI. `ci.yml` delegates to `infodancer/workflows` and path-filters on Go sources, so a change touching only hooks skips the test job entirely -- exactly what happened on #152, where the four new hook tests were verified only locally. The Codex example test has been in the repo unrun since it was added.

Adds a `hooks` job running bare `node --test`, which discovers `**/*.test.mjs` from the repo root so new hook tests need no workflow edit. No Postgres and no Go toolchain, so it runs alongside the Go job rather than after it.

Verified the job can actually fail: a deliberately failing test makes `node --test` exit 1. A test job that cannot fail would be worse than none.

Two choices worth a look:

- **Bare `node --test` over an explicit file list.** It self-discovers, so adding a hook test never requires touching the workflow -- which is what keeps this from rotting the way the Codex test did. The tradeoff is that it picks up any future `*.test.mjs` anywhere in the tree. With no `node_modules` and no npm surface here that seems the right side of the trade; an explicit glob is a one-line change otherwise.
- **`test.yml` rather than `ci.yml`.** `ci.yml` is a thin caller into the shared `infodancer/workflows` repo and this is repo-specific, so it belongs with the other per-repo-variance job. If Node testing is eventually wanted across the other repos, the shared workflow is the better home, but that affects repos outside this change.
