### PR TITLE
feat: default memstore search to the best available arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,32 @@ provenance can, and provenance metadata is the work `gate` mode waits on.
 Until then: run `observe`, and prefer storing preferences informationally
 ("Matthew wants honest evaluation") over imperatively ("give the real answer").
 
+### Changed -- `memstore search` defaults to the best available arm
+
+- **`--hybrid` is replaced by `--search auto|hybrid|fts`, defaulting to `auto`.**
+  The old default was keyword-only, so anyone who did not know to pass
+  `--hybrid` was searching a semantically-indexed corpus by keyword and quietly
+  missing facts that FTS cannot reach.
+
+  `auto` uses hybrid wherever it is available -- always against a daemon, where
+  the vector arm runs server-side and costs the client nothing -- and falls back
+  to `fts` locally when no embedder can be built, printing the reason to stderr.
+  `hybrid` forces it and fails if unavailable; `fts` forces keyword-only.
+
+  The asymmetry is deliberate: `auto` is a preference and degrades with a
+  warning, `hybrid` is an instruction and errors, because quietly returning
+  keyword-only results to someone who asked for semantic search makes a thin
+  result set look like a thin corpus. The same rule now governs a runtime
+  failure mid-search, which previously fell back to FTS regardless of what was
+  asked for.
+
+  `--hybrid` is removed rather than aliased. Scripts passing it fail loudly;
+  `--search hybrid` is the replacement, though against a daemon the default
+  already does the right thing.
+
+  Also stops building a local embedder in daemon mode, where it was constructed
+  and then discarded.
+
 ## [0.4.0] - unreleased
 
 Work in progress for v0.4.0: per-user data isolation. See

--- a/cmd/memstore/main.go
+++ b/cmd/memstore/main.go
@@ -106,8 +106,14 @@ func openStore(dbPath, namespace string) (memstore.Store, func(), error) {
 	return openStoreWithEmbedder(dbPath, namespace, nil)
 }
 
-// openStoreWithEmbedder is like openStore but wires in an embedder for hybrid search.
-// Always uses local SQLite — embedder is not meaningful in remote mode.
+// openStoreWithEmbedder is like openStore but wires an embedder into the local
+// SQLite store for hybrid search.
+//
+// In remote mode it returns the daemon client and the embedder is unused: the
+// daemon owns embedding, and /v1/search does the vector arm server-side.
+// Callers should not build an embedder just to reach this path -- see
+// runSearch, which builds one only when the resolved mode is hybrid AND the
+// store is local.
 func openStoreWithEmbedder(dbPath, namespace string, embedder embedding.Embedder) (memstore.Store, func(), error) {
 	if cliConfig.Remote != "" {
 		client, err := newRemoteClient()

--- a/cmd/memstore/search_cmd.go
+++ b/cmd/memstore/search_cmd.go
@@ -22,7 +22,7 @@ func runSearch(args []string) {
 	category := fs.String("category", "", "filter by category")
 	limit := fs.Int("limit", 5, "max results")
 	onlyActive := fs.Bool("active", true, "exclude superseded facts")
-	hybrid := fs.Bool("hybrid", false, "use hybrid FTS+vector search (requires an embedder)")
+	searchMode := fs.String("search", modeAuto, searchModeUsage)
 	fs.Parse(args)
 
 	if *query == "" {
@@ -37,19 +37,28 @@ func runSearch(args []string) {
 		OnlyActive: *onlyActive,
 	}
 
+	// Against a daemon the vector search runs server-side, so no local
+	// embedder is built and its configuration cannot affect the outcome. Only
+	// local mode needs one, and only when an arm that uses it might be chosen.
+	remote := cliConfig.Remote != ""
+	var embedder embedding.Embedder
+	var embErr error
+	if !remote && *searchMode != modeFTS {
+		embedder, embErr = newLocalEmbedder()
+	}
+
+	useHybrid, note, err := resolveSearchMode(*searchMode, remote, embErr)
+	if err != nil {
+		log.Fatalf("search: %v", err)
+	}
+	if note != "" {
+		// stderr, so the degrade is visible without corrupting piped output.
+		fmt.Fprintf(os.Stderr, "search: %s\n", note)
+	}
+
 	var store memstore.Store
 	var closeStore func()
-	var err error
-
-	if *hybrid {
-		embCfg, embErr := memstore.EmbedConfigFromEnv()
-		if embErr != nil {
-			log.Fatalf("search: embedder config: %v", embErr)
-		}
-		embedder, embErr := embedding.New(embCfg)
-		if embErr != nil {
-			log.Fatalf("search: create embedder: %v", embErr)
-		}
+	if useHybrid && !remote {
 		store, closeStore, err = openStoreWithEmbedder(*dbPath, *namespace, embedder)
 	} else {
 		store, closeStore, err = openStore(*dbPath, *namespace)
@@ -63,11 +72,15 @@ func runSearch(args []string) {
 	defer closeStore()
 
 	var results []memstore.SearchResult
-	if *hybrid {
+	if useHybrid {
 		results, err = store.Search(context.Background(), *query, opts)
-		if err != nil {
-			// Ollama may be unavailable; fall back to FTS and warn.
-			fmt.Fprintf(os.Stderr, "search: hybrid search failed (%v), falling back to FTS\n", err)
+		// A runtime failure (embedding endpoint down, daemon unreachable) is
+		// treated the same way as an unavailable embedder above: auto degrades
+		// with a warning, an explicit --search hybrid does not, because the
+		// caller asked for semantic search and thin results would look like a
+		// thin corpus.
+		if err != nil && *searchMode == modeAuto {
+			fmt.Fprintf(os.Stderr, "search: hybrid search failed (%v), falling back to %s\n", err, modeFTS)
 			results, err = store.SearchFTS(context.Background(), *query, opts)
 		}
 	} else {

--- a/cmd/memstore/search_mode.go
+++ b/cmd/memstore/search_mode.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/matthewjhunter/go-embedding"
+	"github.com/matthewjhunter/memstore"
+)
+
+// newLocalEmbedder builds an embedder from the environment for local-mode
+// hybrid search. Its error is returned rather than fatal: whether an
+// unbuildable embedder is fatal depends on the search mode, which is
+// resolveSearchMode's call to make.
+func newLocalEmbedder() (embedding.Embedder, error) {
+	cfg, err := memstore.EmbedConfigFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("embedder config: %w", err)
+	}
+	emb, err := embedding.New(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create embedder: %w", err)
+	}
+	return emb, nil
+}
+
+// Search arm selection for `memstore search`.
+//
+// The default is auto rather than a fixed arm because the right answer depends
+// on how the CLI is configured, not on what the caller remembered to type.
+// Against a daemon the vector search runs server-side and costs the client
+// nothing, so keyword-only results there are strictly worse for no saving. In
+// local mode it depends on whether an embedder can be built at all.
+const (
+	modeAuto   = "auto"
+	modeHybrid = "hybrid"
+	modeFTS    = "fts"
+)
+
+const searchModeUsage = "search arm: auto|hybrid|fts. " +
+	"auto uses hybrid FTS+vector wherever it is available (always, against a daemon) " +
+	"and falls back to fts locally when no embedder can be built. " +
+	"hybrid forces it and fails if unavailable; fts forces keyword-only."
+
+// resolveSearchMode decides which search arm to use.
+//
+// embErr is the result of trying to build a local embedder, and is consulted
+// only in local mode -- against a daemon the embedder lives server-side, so a
+// local embedder is never built and its configuration is irrelevant.
+//
+// The asymmetry between auto and hybrid is deliberate. Auto is a preference,
+// so it degrades and returns a note explaining why. Hybrid is an instruction,
+// so it fails: quietly returning keyword-only results to someone who asked for
+// semantic search is how an empty result set gets mistaken for an empty
+// corpus.
+func resolveSearchMode(mode string, remote bool, embErr error) (hybrid bool, note string, err error) {
+	switch mode {
+	case modeFTS:
+		return false, "", nil
+
+	case modeHybrid:
+		if !remote && embErr != nil {
+			return false, "", fmt.Errorf(
+				"--search %s needs a local embedder and none could be built: %w\n"+
+					"Configure one (MEMSTORE_EMBED_*) or use --search %s for keyword-only search",
+				modeHybrid, embErr, modeFTS)
+		}
+		return true, "", nil
+
+	case modeAuto:
+		if !remote && embErr != nil {
+			return false, fmt.Sprintf(
+				"no local embedder (%v); falling back to --search %s (keyword-only)", embErr, modeFTS), nil
+		}
+		return true, "", nil
+
+	default:
+		return false, "", fmt.Errorf("unknown --search mode %q: want %s, %s, or %s",
+			mode, modeAuto, modeHybrid, modeFTS)
+	}
+}

--- a/cmd/memstore/search_mode_test.go
+++ b/cmd/memstore/search_mode_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestResolveSearchMode(t *testing.T) {
+	embFailed := errors.New("embedder config: unknown provider")
+
+	tests := []struct {
+		name       string
+		mode       string
+		remote     bool
+		embErr     error
+		wantHybrid bool
+		wantNote   bool
+		wantErr    bool
+	}{
+		// Remote: the daemon owns the embedder, so hybrid costs the CLI
+		// nothing and is what "as configured" means here. A local embedder is
+		// never built, so its config cannot matter.
+		{name: "auto remote is hybrid", mode: modeAuto, remote: true, wantHybrid: true},
+		{name: "auto remote ignores local embedder trouble", mode: modeAuto, remote: true, embErr: embFailed, wantHybrid: true},
+		{name: "explicit hybrid remote", mode: modeHybrid, remote: true, wantHybrid: true},
+
+		// Local with a usable embedder behaves the same.
+		{name: "auto local with embedder is hybrid", mode: modeAuto, wantHybrid: true},
+		{name: "explicit hybrid local with embedder", mode: modeHybrid, wantHybrid: true},
+
+		// Local with no usable embedder: auto degrades and says so, an
+		// explicit request fails rather than quietly returning less.
+		{name: "auto local without embedder degrades", mode: modeAuto, embErr: embFailed, wantHybrid: false, wantNote: true},
+		{name: "explicit hybrid local without embedder errors", mode: modeHybrid, embErr: embFailed, wantErr: true},
+
+		// fts is a forced choice and never errors or warns.
+		{name: "fts remote", mode: modeFTS, remote: true, wantHybrid: false},
+		{name: "fts local", mode: modeFTS, wantHybrid: false},
+		{name: "fts local ignores embedder trouble", mode: modeFTS, embErr: embFailed, wantHybrid: false},
+
+		{name: "unknown mode is rejected", mode: "semantic", wantErr: true},
+		{name: "empty mode is rejected", mode: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hybrid, note, err := resolveSearchMode(tt.mode, tt.remote, tt.embErr)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got hybrid=%v note=%q", hybrid, note)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if hybrid != tt.wantHybrid {
+				t.Errorf("hybrid = %v, want %v", hybrid, tt.wantHybrid)
+			}
+			if gotNote := note != ""; gotNote != tt.wantNote {
+				t.Errorf("note = %q, want a note: %v", note, tt.wantNote)
+			}
+		})
+	}
+}
+
+// The degrade note has to name the cause, or a user seeing keyword-only
+// results has nothing to act on.
+func TestResolveSearchModeNoteExplainsItself(t *testing.T) {
+	_, note, err := resolveSearchMode(modeAuto, false, errors.New("boom: bad provider"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(note, "boom: bad provider") {
+		t.Errorf("note %q does not carry the underlying reason", note)
+	}
+	if !strings.Contains(note, modeFTS) {
+		t.Errorf("note %q does not say which mode it fell back to", note)
+	}
+}
+
+// An explicit hybrid request that cannot be honoured must say what to do about
+// it, not just report the failure.
+func TestResolveSearchModeErrorSuggestsFallback(t *testing.T) {
+	_, _, err := resolveSearchMode(modeHybrid, false, errors.New("bad provider"))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "--search "+modeFTS) {
+		t.Errorf("error %q does not point at --search %s", err, modeFTS)
+	}
+}
+
+func TestSearchModesAreDocumented(t *testing.T) {
+	// The usage string is how anyone discovers these; it must list every mode
+	// the resolver accepts.
+	for _, mode := range []string{modeAuto, modeHybrid, modeFTS} {
+		if !strings.Contains(searchModeUsage, mode) {
+			t.Errorf("usage string does not mention %q: %s", mode, searchModeUsage)
+		}
+	}
+}


### PR DESCRIPTION
Closes #149.

The CLI's search default was keyword-only, so anyone who did not know to pass `--hybrid` was querying a semantically-indexed corpus by keyword and quietly missing facts FTS cannot reach. Demonstrated on the live corpus: the default returned nothing for a plain-language query that hybrid answered with the right fact as its top hit.

Replaces `--hybrid` with `--search auto|hybrid|fts`, defaulting to `auto`.

| mode | remote | local + embedder | local, no embedder |
|---|---|---|---|
| `auto` | hybrid | hybrid | fts + stderr note |
| `hybrid` | hybrid | hybrid | error |
| `fts` | fts | fts | fts |

`auto` uses hybrid wherever it is available -- always against a daemon, where the vector arm runs server-side and costs the client nothing.

**`auto` and `hybrid` are deliberately asymmetric.** `auto` is a preference, so it degrades with a warning; `hybrid` is an instruction, so it errors. Quietly handing keyword-only results to someone who asked for semantic search makes a thin result set look like a thin corpus. That rule now also governs a runtime failure mid-search (daemon unreachable, embedding endpoint down), which previously fell back to FTS regardless of what was asked for.

`--hybrid` is removed rather than aliased: the flag's whole purpose was opting in to what is now the default. Scripts passing it fail loudly.

Also stops constructing a local embedder in daemon mode, where `openStoreWithEmbedder` returned the remote client and discarded it, and corrects that function's comment claiming it always uses local SQLite.

## Verification

Against the live daemon:

| invocation | result |
|---|---|
| default (`auto`) | finds fact 8066 -- the fact the old default missed |
| `--search fts` | finds nothing, reproducing the old behaviour |
| `--search bogus` | `unknown --search mode "bogus": want auto, hybrid, or fts` |
| `--hybrid` | `flag provided but not defined` |

The resolver is a pure function with table-driven tests covering all twelve mode/transport/embedder combinations, plus assertions that the degrade note names its cause and that the error points at `--search fts`.

## Note for whoever merges second

This branch and #153 both add sections to the `Unreleased` block in `CHANGELOG.md` and will conflict there. Trivial to resolve, but real.
