### PR TITLE
feat: count recall injections as a separate usage signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,36 @@ Until then: run `observe`, and prefer storing preferences informationally
   In read-only mode the server instructions say the session is retrieval-only,
   so a model is not left hunting for a storage tool that was never registered.
 
+### Added -- recall injections are counted
+
+- **`inject_count` / `last_injected_at`**, bumped by `handleRecall` for every
+  fact it surfaces. Previously `use_count` was incremented in exactly one place
+  -- an explicit `memory_search` -- so the highest-volume read path in the
+  system left no trace and a fact injected into hundreds of prompts read as
+  never used. On the live corpus that was 3,538 of 4,657 facts (76%) sitting at
+  zero.
+
+  Kept as its own pair rather than folded into `use_count`, because the two are
+  different evidence: a fact the model went looking for is a stronger signal
+  than one the daemon offered unprompted, and #157's prune predicate has to tell
+  them apart.
+
+  The recording lives in the daemon, not in a hook or a model-initiated tool
+  call. Both of those have been tried and both went silent --
+  `context_injections` stopped 2026-05-27, `context_feedback` 2026-06-07, and
+  `confirmed_count` is zero across the entire corpus. A signal the daemon
+  derives from its own work cannot drift out of use.
+
+  `memory_get_context` now calls `Touch` as well; it is a genuine retrieval and
+  was the other read path recording nothing.
+
+  Migration `V17` (SQLite) / `V10` (Postgres). The Postgres migration seeds the
+  new counter from the historical `context_injections` rows, guarded on that
+  table existing since it belongs to the session store and is absent from a
+  fresh facts-only database. On the live corpus that backfill seeds 402 active
+  facts, 96 of which a 90-day prune would otherwise have deleted despite recall
+  having injected them repeatedly -- one of them 57 times.
+
 ### Changed -- `memstore search` defaults to the best available arm
 
 - **`--hybrid` is replaced by `--search auto|hybrid|fts`, defaulting to `auto`.**

--- a/factcolumns_test.go
+++ b/factcolumns_test.go
@@ -1,0 +1,61 @@
+package memstore
+
+import (
+	"strings"
+	"testing"
+)
+
+// countingScanner records how many destinations a scan function asks for,
+// without needing a database.
+type countingScanner struct{ n int }
+
+func (c *countingScanner) Scan(dest ...any) error {
+	c.n = len(dest)
+	return nil
+}
+
+// scanFact and factColumns must agree on how many columns exist. This is the
+// invariant CLAUDE.md names, and it is checked here rather than only by a live
+// query because the live queries that would catch it are backend-specific: the
+// pgstore ones need a Postgres service, so on a machine without one they skip
+// and the mismatch ships.
+//
+// That is not hypothetical. Adding inject_count/last_injected_at (#158) passed
+// a full local `go test ./...` and failed in CI with "number of field
+// descriptions must equal number of destinations, got 20 and 18", because
+// pgstore's vector search selected prefixedFactColumns and scanned into a
+// hand-written list. This test fails on any machine, with no service
+// container.
+func TestFactColumnsMatchesScanFactArity(t *testing.T) {
+	want := len(strings.Split(factColumns, ", "))
+
+	var c countingScanner
+	if _, err := scanFact(&c); err != nil {
+		t.Fatalf("scanFact against a no-op scanner: %v", err)
+	}
+
+	if c.n != want {
+		t.Errorf("scanFact asks for %d destinations, factColumns lists %d columns.\n"+
+			"Adding a column means updating BOTH, plus pgstore's copies and ExportedFact.\ncolumns: %s",
+			c.n, want, factColumns)
+	}
+}
+
+// The prefixed form is what the join queries select, so it must stay a
+// faithful rendering of the same list -- same count, every entry aliased.
+func TestPrefixedFactColumnsMatchesFactColumns(t *testing.T) {
+	plain := strings.Split(factColumns, ", ")
+	prefixed := strings.Split(prefixedFactColumns("f."), ", ")
+
+	if len(prefixed) != len(plain) {
+		t.Fatalf("prefixedFactColumns has %d columns, factColumns has %d", len(prefixed), len(plain))
+	}
+	for i, col := range prefixed {
+		if !strings.HasPrefix(strings.TrimSpace(col), "f.") {
+			t.Errorf("column %d (%q) is not aliased; an unaliased column resolves by luck and breaks when a joined table gains the same name", i, col)
+		}
+		if strings.TrimSpace(col) != "f."+strings.TrimSpace(plain[i]) {
+			t.Errorf("column %d: prefixed %q does not correspond to plain %q", i, col, plain[i])
+		}
+	}
+}

--- a/httpapi/recall.go
+++ b/httpapi/recall.go
@@ -137,7 +137,36 @@ func (h *Handler) handleRecall(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	recordRecallInjection(r.Context(), storeFromCtx(r.Context(), h.store), resp.Facts)
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// recordRecallInjection bumps inject_count for the facts this recall surfaced.
+//
+// This is the whole point of the counter: recall runs on every prompt and used
+// to leave no trace, so a fact injected hundreds of times was indistinguishable
+// from one nobody ever saw. It records here, in the daemon, because it is the
+// only place that both knows the IDs and cannot be skipped -- every earlier
+// attempt put this in a client (the prompt hook, or a model-initiated tool
+// call) and every one of them silently stopped.
+//
+// Best-effort, like the search-side Touch: a failed counter update must never
+// cost the caller their context. The error is dropped rather than logged
+// because this runs on every prompt and a persistent failure would flood the
+// log faster than anyone would read it.
+func recordRecallInjection(ctx context.Context, store any, facts []recallFact) {
+	if len(facts) == 0 {
+		return
+	}
+	rec, ok := store.(memstore.InjectionRecorder)
+	if !ok {
+		return
+	}
+	ids := make([]int64, 0, len(facts))
+	for _, f := range facts {
+		ids = append(ids, f.ID)
+	}
+	_ = rec.RecordInjection(ctx, ids)
 }
 
 func (h *Handler) recall(ctx context.Context, req recallRequest) (*recallResponse, error) {

--- a/httpapi/recall_injection_test.go
+++ b/httpapi/recall_injection_test.go
@@ -1,0 +1,132 @@
+package httpapi_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/matthewjhunter/memstore"
+)
+
+// Recall is the highest-volume read path in the system and, before this, the
+// only one that left no trace: a fact injected into hundreds of prompts read as
+// never used. The recording lives in the daemon rather than in the hook or in a
+// model-initiated tool call, because both of those have already been tried and
+// both went silent (context_injections stopped 2026-05-27, context_feedback
+// 2026-06-07, confirmed_count is zero corpus-wide).
+func TestRecallRecordsInjection(t *testing.T) {
+	h, store, _ := newTestHandlerWithRecall(t)
+	seedFacts(t, store)
+	ctx := context.Background()
+
+	resp := doJSON(t, h, "POST", "/v1/recall", map[string]any{
+		"prompt": "tell me about the herald feed aggregator",
+	})
+
+	var out struct {
+		Facts []struct {
+			ID int64 `json:"id"`
+		} `json:"facts"`
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("recall status = %d, want 200", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode recall response: %v", err)
+	}
+	if len(out.Facts) == 0 {
+		t.Fatal("recall returned no facts; cannot assert injection recording")
+	}
+
+	for _, rf := range out.Facts {
+		f, err := store.Get(ctx, rf.ID)
+		if err != nil {
+			t.Fatalf("get fact %d: %v", rf.ID, err)
+		}
+		if f == nil {
+			t.Fatalf("fact %d vanished", rf.ID)
+		}
+		if f.InjectCount != 1 {
+			t.Errorf("fact %d: inject_count = %d, want 1", rf.ID, f.InjectCount)
+		}
+		if f.LastInjectedAt == nil {
+			t.Errorf("fact %d: last_injected_at not set", rf.ID)
+		}
+		// Injection must not masquerade as an explicit search hit; #157's
+		// prune predicate has to be able to tell the two apart.
+		if f.UseCount != 0 {
+			t.Errorf("fact %d: use_count = %d, want 0 -- recall must not bump the search counter", rf.ID, f.UseCount)
+		}
+	}
+}
+
+// Counting has to accumulate, or "how often is this surfaced" is unanswerable.
+func TestRecallInjectionAccumulates(t *testing.T) {
+	h, store, _ := newTestHandlerWithRecall(t)
+	seedFacts(t, store)
+	ctx := context.Background()
+
+	const rounds = 3
+	var ids []int64
+	for range rounds {
+		resp := doJSON(t, h, "POST", "/v1/recall", map[string]any{
+			"prompt": "tell me about the herald feed aggregator",
+		})
+		var out struct {
+			Facts []struct {
+				ID int64 `json:"id"`
+			} `json:"facts"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(out.Facts) == 0 {
+			t.Fatal("recall returned no facts")
+		}
+		if ids == nil {
+			for _, rf := range out.Facts {
+				ids = append(ids, rf.ID)
+			}
+		}
+	}
+
+	for _, id := range ids {
+		f, err := store.Get(ctx, id)
+		if err != nil || f == nil {
+			t.Fatalf("get fact %d: %v", id, err)
+		}
+		if f.InjectCount != rounds {
+			t.Errorf("fact %d: inject_count = %d after %d recalls, want %d", id, f.InjectCount, rounds, rounds)
+		}
+	}
+}
+
+// The two counters are independent: a search bumps use_count and leaves
+// inject_count alone.
+func TestSearchDoesNotBumpInjectCount(t *testing.T) {
+	_, store, _ := newTestHandlerWithRecall(t)
+	seedFacts(t, store)
+	ctx := context.Background()
+
+	facts, err := store.List(ctx, memstore.QueryOpts{Subject: "herald", OnlyActive: true})
+	if err != nil || len(facts) == 0 {
+		t.Fatalf("list herald facts: %v", err)
+	}
+	id := facts[0].ID
+
+	if err := store.Touch(ctx, []int64{id}); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+
+	f, err := store.Get(ctx, id)
+	if err != nil || f == nil {
+		t.Fatalf("get: %v", err)
+	}
+	if f.UseCount != 1 {
+		t.Errorf("use_count = %d, want 1", f.UseCount)
+	}
+	if f.InjectCount != 0 {
+		t.Errorf("inject_count = %d, want 0 -- Touch must not bump the injection counter", f.InjectCount)
+	}
+}

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -902,6 +902,11 @@ func testMutationsIsolated(t *testing.T, a, b memstore.Store) {
 
 	check("Confirm", func(x int64) error { return b.Confirm(ctx, x) })
 	check("Touch", func(x int64) error { return b.Touch(ctx, []int64{x}) })
+	// RecordInjection is a counter bump like Touch and has to respect the same
+	// boundary. Optional on the interface, so probe it only where implemented.
+	if rec, ok := b.(memstore.InjectionRecorder); ok {
+		check("RecordInjection", func(x int64) error { return rec.RecordInjection(ctx, []int64{x}) })
+	}
 	check("UpdateMetadata", func(x int64) error { return b.UpdateMetadata(ctx, x, map[string]any{"k": "hacked"}) })
 	check("Supersede", func(x int64) error { return b.Supersede(ctx, x, x) })
 	check("SetEmbedding", func(x int64) error { return b.SetEmbedding(ctx, x, []float32{0.1, 0.2, 0.3, 0.4}) })

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -2125,6 +2125,17 @@ func (ms *MemoryServer) HandleGetContext(ctx context.Context, _ *mcp.CallToolReq
 		return textResult("No relevant context found for this task.", false), GetContextResult{}, nil
 	}
 
+	// Count this as use, the same as a search hit: the model asked for context
+	// and these facts are what it got. Without this, a fact that only ever
+	// arrives through get_context looks untouched, which is exactly the blind
+	// spot #157's prune predicate would act on. seen holds every ID surfaced
+	// across all four sections.
+	touched := make([]int64, 0, len(seen))
+	for id := range seen {
+		touched = append(touched, id)
+	}
+	_ = ms.store.Touch(ctx, touched) // best-effort; don't fail the lookup
+
 	fnc, err := fence.New()
 	if err != nil {
 		return textResult(fmt.Sprintf("Error: %v", err), true), GetContextResult{}, nil

--- a/pgstore/factcolumns_test.go
+++ b/pgstore/factcolumns_test.go
@@ -1,0 +1,48 @@
+package pgstore
+
+import (
+	"strings"
+	"testing"
+)
+
+type countingScanner struct{ n int }
+
+func (c *countingScanner) Scan(dest ...any) error {
+	c.n = len(dest)
+	return nil
+}
+
+// The pgstore mirror of the root-package guard, and the one that would have
+// caught #158's CI failure locally.
+//
+// Every pgstore test that touches a real query is gated on MEMSTORE_TEST_PG, so
+// on a machine without a Postgres service the whole package skips and a column
+// mismatch is invisible until CI. This test needs no service.
+func TestFactColumnsMatchesScanFactArity(t *testing.T) {
+	want := len(strings.Split(factColumns, ", "))
+
+	var c countingScanner
+	if _, err := scanFact(&c); err != nil {
+		t.Fatalf("scanFact against a no-op scanner: %v", err)
+	}
+
+	if c.n != want {
+		t.Errorf("scanFact asks for %d destinations, factColumns lists %d columns.\n"+
+			"Search paths must go through scanFact rather than keeping their own destination list.\ncolumns: %s",
+			c.n, want, factColumns)
+	}
+}
+
+func TestPrefixedFactColumnsMatchesFactColumns(t *testing.T) {
+	plain := strings.Split(factColumns, ", ")
+	prefixed := strings.Split(prefixedFactColumns("f."), ", ")
+
+	if len(prefixed) != len(plain) {
+		t.Fatalf("prefixedFactColumns has %d columns, factColumns has %d", len(prefixed), len(plain))
+	}
+	for i, col := range prefixed {
+		if strings.TrimSpace(col) != "f."+strings.TrimSpace(plain[i]) {
+			t.Errorf("column %d: prefixed %q does not correspond to plain %q", i, col, plain[i])
+		}
+	}
+}

--- a/pgstore/search.go
+++ b/pgstore/search.go
@@ -2,9 +2,7 @@ package pgstore
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/matthewjhunter/memstore"
 	pgvector "github.com/pgvector/pgvector-go"
@@ -131,9 +129,7 @@ func (s *PostgresStore) searchFTS(ctx context.Context, query string, opts memsto
 	}
 
 	var b queryBuilder
-	b.write(`SELECT f.id, f.namespace, f.user_id, f.content, f.subject, f.category, f.kind, f.subsystem, f.metadata,
-	                f.superseded_by, f.superseded_at, f.confirmed_count, f.last_confirmed_at,
-	                f.use_count, f.last_used_at, f.embedding, f.created_at,
+	b.write(`SELECT `+prefixedFactColumns("f.")+`,
 	                ts_rank(f.fts, plainto_tsquery('english', `, tsquery)
 	b.q += `)) AS rank
 	         FROM memstore_facts f
@@ -174,40 +170,16 @@ func (s *PostgresStore) searchFTS(ctx context.Context, query string, opts memsto
 
 	var results []memstore.SearchResult
 	for rows.Next() {
-		var f memstore.Fact
-		var metadata []byte
-		var supersededBy *int64
-		var supersededAt *time.Time
-		var lastConfirmedAt *time.Time
-		var lastUsedAt *time.Time
-		var emb *pgvector.Vector
 		var rank float64
 
-		err := rows.Scan(
-			&f.ID, &f.Namespace, &f.UserID, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
-			&metadata, &supersededBy, &supersededAt,
-			&f.ConfirmedCount, &lastConfirmedAt,
-			&f.UseCount, &lastUsedAt,
-			&emb, &f.CreatedAt, &rank,
-		)
+		f, err := scanFact(scanWithExtra{row: rows, extra: []any{&rank}})
 		if err != nil {
 			return nil, fmt.Errorf("pgstore: scanning FTS result: %w", err)
 		}
 
-		if len(metadata) > 0 {
-			f.Metadata = json.RawMessage(metadata)
-		}
-		f.SupersededBy = supersededBy
-		f.SupersededAt = supersededAt
-		f.LastConfirmedAt = lastConfirmedAt
-		f.LastUsedAt = lastUsedAt
-		if emb != nil {
-			f.Embedding = emb.Slice()
-		}
-
 		// ts_rank returns positive scores (higher = better match).
 		results = append(results, memstore.SearchResult{
-			Fact:     f,
+			Fact:     *f,
 			FTSScore: rank,
 		})
 	}
@@ -272,44 +244,39 @@ func (s *PostgresStore) searchVector(ctx context.Context, queryEmb []float32, op
 
 	var results []memstore.SearchResult
 	for rows.Next() {
-		var f memstore.Fact
-		var metadata []byte
-		var supersededBy *int64
-		var supersededAt *time.Time
-		var lastConfirmedAt *time.Time
-		var lastUsedAt *time.Time
-		var emb *pgvector.Vector
 		var similarity float64
 
-		err := rows.Scan(
-			&f.ID, &f.Namespace, &f.UserID, &f.Content, &f.Subject, &f.Category, &f.Kind, &f.Subsystem,
-			&metadata, &supersededBy, &supersededAt,
-			&f.ConfirmedCount, &lastConfirmedAt,
-			&f.UseCount, &lastUsedAt,
-			&emb, &f.CreatedAt, &similarity,
-		)
+		f, err := scanFact(scanWithExtra{row: rows, extra: []any{&similarity}})
 		if err != nil {
 			return nil, fmt.Errorf("pgstore: scanning vector result: %w", err)
 		}
 
-		if len(metadata) > 0 {
-			f.Metadata = json.RawMessage(metadata)
-		}
-		f.SupersededBy = supersededBy
-		f.SupersededAt = supersededAt
-		f.LastConfirmedAt = lastConfirmedAt
-		f.LastUsedAt = lastUsedAt
-		if emb != nil {
-			f.Embedding = emb.Slice()
-		}
-
 		if similarity > 0 {
 			results = append(results, memstore.SearchResult{
-				Fact:     f,
+				Fact:     *f,
 				VecScore: similarity,
 			})
 		}
 	}
 
 	return results, rows.Err()
+}
+
+// scanWithExtra adapts a row so scanFact can consume the canonical fact
+// columns while the caller appends its own trailing values (a rank, a
+// similarity).
+//
+// This exists so the search paths do not keep their own copy of the fact
+// column list. They used to, and it drifted the moment a column was added:
+// pgstore's vector search selected prefixedFactColumns and scanned into a
+// hand-written destination list, so adding inject_count broke it with "number
+// of field descriptions must equal number of destinations, got 20 and 18".
+// One scan function, one column list.
+type scanWithExtra struct {
+	row   scanner
+	extra []any
+}
+
+func (p scanWithExtra) Scan(dest ...any) error {
+	return p.row.Scan(append(dest, p.extra...)...)
 }

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -20,11 +20,11 @@ import (
 	pgvector "github.com/pgvector/pgvector-go"
 )
 
-const schemaVersion = 9
+const schemaVersion = 10
 
 // factColumns is the canonical SELECT list for fact queries.
 // searchFTS has its own column list because it joins and adds ts_rank.
-const factColumns = `id, namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, embedding, created_at`
+const factColumns = `id, namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, inject_count, last_injected_at, embedding, created_at`
 
 // prefixedFactColumns renders factColumns with a table alias applied to each
 // column, for queries that join memstore_facts to another table and would
@@ -528,6 +528,12 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		}
 	}
 
+	if version < 10 {
+		if err := s.migrateV10(ctx); err != nil {
+			return err
+		}
+	}
+
 	if version == 0 {
 		_, err = s.pool.Exec(ctx, `INSERT INTO memstore_version (version) VALUES ($1)`, schemaVersion)
 	} else {
@@ -671,6 +677,58 @@ func (s *PostgresStore) migrateV9(ctx context.Context) error {
 		if _, err := s.pool.Exec(ctx, q); err != nil {
 			return fmt.Errorf("pgstore: migrateV9: %w", err)
 		}
+	}
+	return nil
+}
+
+// migrateV10 records recall injections separately from search hits, and seeds
+// the new counter from the historical context_injections log.
+//
+// use_count only ever counted explicit memory_search results, so the
+// highest-volume read path -- per-prompt recall injection -- left no trace and
+// a fact surfaced in hundreds of prompts read as never used. Kept as its own
+// pair rather than folded into use_count because the two are different
+// evidence: being sought is stronger than being offered, and #157's prune
+// predicate has to tell them apart.
+//
+// The backfill is guarded on context_injections existing. That table belongs to
+// the session store, which migrates independently and is absent on a fresh
+// facts-only database; an unguarded reference would make this migration fail
+// there. Where it does exist it holds the injections recorded before the
+// client-side logging stopped, which is the only history of this signal.
+// Mirrors SQLite migrateV17, which has no backfill because SQLite has no
+// session store.
+func (s *PostgresStore) migrateV10(ctx context.Context) error {
+	stmts := []string{
+		`ALTER TABLE memstore_facts ADD COLUMN IF NOT EXISTS inject_count INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE memstore_facts ADD COLUMN IF NOT EXISTS last_injected_at TIMESTAMPTZ`,
+	}
+	for _, q := range stmts {
+		if _, err := s.pool.Exec(ctx, q); err != nil {
+			return fmt.Errorf("pgstore: migrateV10: %w", err)
+		}
+	}
+
+	// ref_id is text and holds a fact id only when ref_type = 'fact'; the
+	// regex guard keeps a non-numeric ref from aborting the cast.
+	backfill := `
+		UPDATE memstore_facts f
+		SET inject_count = agg.n, last_injected_at = agg.last_at
+		FROM (
+			SELECT ref_id::bigint AS id, count(*) AS n, max(injected_at) AS last_at
+			FROM context_injections
+			WHERE ref_type = 'fact' AND ref_id ~ '^[0-9]+$'
+			GROUP BY 1
+		) agg
+		WHERE f.id = agg.id`
+	if _, err := s.pool.Exec(ctx, `
+		DO $$
+		BEGIN
+			IF to_regclass('public.context_injections') IS NOT NULL THEN
+				`+backfill+`;
+			END IF;
+		END $$`); err != nil {
+		return fmt.Errorf("pgstore: migrateV10 backfill: %w", err)
 	}
 	return nil
 }
@@ -1270,6 +1328,29 @@ func (s *PostgresStore) Touch(ctx context.Context, ids []int64) error {
 	_, err := s.pool.Exec(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("pgstore: touching facts: %w", err)
+	}
+	return nil
+}
+
+// RecordInjection increments inject_count and updates last_injected_at for the
+// given fact IDs.
+//
+// Separate from Touch because recall injection and an explicit search are
+// different evidence: a fact the model went looking for is a stronger signal
+// than one the daemon offered unprompted. See SQLite RecordInjection.
+func (s *PostgresStore) RecordInjection(ctx context.Context, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	q, args := s.userPredicate(
+		`UPDATE memstore_facts SET inject_count = inject_count + 1, last_injected_at = $1
+		 WHERE namespace = $2 AND id = ANY($3::bigint[])`,
+		[]any{now, s.namespace, ids})
+	_, err := s.pool.Exec(ctx, q, args...)
+	if err != nil {
+		return fmt.Errorf("pgstore: recording injection: %w", err)
 	}
 	return nil
 }
@@ -2115,6 +2196,7 @@ func scanFact(row scanner) (*memstore.Fact, error) {
 	var supersededAt *time.Time
 	var lastConfirmedAt *time.Time
 	var lastUsedAt *time.Time
+	var lastInjectedAt *time.Time
 	var emb *pgvector.Vector
 
 	err := row.Scan(
@@ -2122,6 +2204,7 @@ func scanFact(row scanner) (*memstore.Fact, error) {
 		&metadata, &supersededBy, &supersededAt,
 		&f.ConfirmedCount, &lastConfirmedAt,
 		&f.UseCount, &lastUsedAt,
+		&f.InjectCount, &lastInjectedAt,
 		&emb, &f.CreatedAt,
 	)
 	if err != nil {
@@ -2135,6 +2218,7 @@ func scanFact(row scanner) (*memstore.Fact, error) {
 	f.SupersededAt = supersededAt
 	f.LastConfirmedAt = lastConfirmedAt
 	f.LastUsedAt = lastUsedAt
+	f.LastInjectedAt = lastInjectedAt
 	if emb != nil {
 		f.Embedding = emb.Slice()
 	}

--- a/sqlite.go
+++ b/sqlite.go
@@ -17,11 +17,11 @@ import (
 	"github.com/matthewjhunter/go-embedding"
 )
 
-const schemaVersion = 16
+const schemaVersion = 17
 
 // factColumns is the canonical SELECT list for fact queries.
 // searchFTS has its own column list because it joins and adds rank.
-const factColumns = `id, namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, embedding, created_at`
+const factColumns = `id, namespace, user_id, content, subject, category, kind, subsystem, metadata, superseded_by, superseded_at, confirmed_count, last_confirmed_at, use_count, last_used_at, inject_count, last_injected_at, embedding, created_at`
 
 // prefixedFactColumns renders factColumns with a table alias applied to each
 // column, for queries that join memstore_facts to another table and would
@@ -430,6 +430,12 @@ func (s *SQLiteStore) migrate() error {
 
 	if version < 16 {
 		if err := s.migrateV16(); err != nil {
+			return err
+		}
+	}
+
+	if version < 17 {
+		if err := s.migrateV17(); err != nil {
 			return err
 		}
 	}
@@ -1210,6 +1216,42 @@ func (s *SQLiteStore) Touch(ctx context.Context, ids []int64) error {
 	return nil
 }
 
+// RecordInjection increments inject_count and updates last_injected_at for the
+// given fact IDs. Silently ignores IDs that don't exist or belong to other
+// namespaces.
+//
+// Separate from Touch because recall injection and an explicit search are
+// different evidence: a fact the model went looking for is a stronger signal
+// than one the daemon offered unprompted. Blending them would make a fact that
+// is injected constantly indistinguishable from one that is actively sought,
+// and #157's prune predicate has to tell those apart.
+func (s *SQLiteStore) RecordInjection(ctx context.Context, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	placeholders := "?" + strings.Repeat(", ?", len(ids)-1)
+	args := make([]any, 0, len(ids)+2)
+	args = append(args, now, s.namespace)
+	for _, id := range ids {
+		args = append(args, id)
+	}
+
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE memstore_facts SET inject_count = inject_count + 1, last_injected_at = ?
+		 WHERE namespace = ? AND id IN (`+placeholders+`)`,
+		args...,
+	)
+	if err != nil {
+		return fmt.Errorf("memstore: recording injection: %w", err)
+	}
+	return nil
+}
+
 // UpdateMetadata merges a patch into the metadata JSON for a fact.
 // Keys with non-nil values are set; keys with nil values are deleted.
 // Returns an error if the fact doesn't exist in this namespace.
@@ -1552,6 +1594,27 @@ func (s *SQLiteStore) migrateV16() error {
 	for _, q := range stmts {
 		if _, err := s.db.Exec(q); err != nil {
 			return fmt.Errorf("memstore: migrateV16: %w", err)
+		}
+	}
+	return nil
+}
+
+// migrateV17 records recall injections separately from search hits.
+//
+// use_count only ever counted explicit memory_search results, so the
+// highest-volume read path -- per-prompt recall injection -- left no trace and
+// a fact surfaced in hundreds of prompts read as never used. Kept as its own
+// pair rather than folded into use_count because the two are different
+// evidence: being sought is a stronger signal than being offered, and a prune
+// predicate needs to tell them apart.
+func (s *SQLiteStore) migrateV17() error {
+	stmts := []string{
+		`ALTER TABLE memstore_facts ADD COLUMN inject_count INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE memstore_facts ADD COLUMN last_injected_at TEXT`,
+	}
+	for _, q := range stmts {
+		if _, err := s.db.Exec(q); err != nil {
+			return fmt.Errorf("memstore: migrateV17: %w", err)
 		}
 	}
 	return nil
@@ -2189,6 +2252,7 @@ func scanFact(row scanner) (*Fact, error) {
 	var supersededAt sql.NullString
 	var lastConfirmedAt sql.NullString
 	var lastUsedAt sql.NullString
+	var lastInjectedAt sql.NullString
 	var embBlob []byte
 	var createdAt string
 
@@ -2197,6 +2261,7 @@ func scanFact(row scanner) (*Fact, error) {
 		&metadata, &supersededBy, &supersededAt,
 		&f.ConfirmedCount, &lastConfirmedAt,
 		&f.UseCount, &lastUsedAt,
+		&f.InjectCount, &lastInjectedAt,
 		&embBlob, &createdAt,
 	)
 	if err != nil {
@@ -2221,6 +2286,10 @@ func scanFact(row scanner) (*Fact, error) {
 	if lastUsedAt.Valid {
 		t, _ := time.Parse(time.RFC3339, lastUsedAt.String)
 		f.LastUsedAt = &t
+	}
+	if lastInjectedAt.Valid {
+		t, _ := time.Parse(time.RFC3339, lastInjectedAt.String)
+		f.LastInjectedAt = &t
 	}
 	if len(embBlob) > 0 {
 		f.Embedding = embedding.DecodeFloat32s(embBlob)

--- a/store.go
+++ b/store.go
@@ -244,8 +244,10 @@ type Fact struct {
 	SupersededAt    *time.Time      // when supersession occurred
 	ConfirmedCount  int             // explicit "I verified this is accurate" count
 	LastConfirmedAt *time.Time      // when last confirmed
-	UseCount        int             // auto-incremented when retrieved via search
-	LastUsedAt      *time.Time      // when last retrieved
+	UseCount        int             // auto-incremented when retrieved via an explicit search
+	LastUsedAt      *time.Time      // when last retrieved by search
+	InjectCount     int             // auto-incremented when surfaced by recall injection
+	LastInjectedAt  *time.Time      // when last injected
 	Embedding       []float32       // nil until computed
 	CreatedAt       time.Time
 }
@@ -534,4 +536,22 @@ type JSONSchemaGenerator interface {
 	// some providers for caching and telemetry). schema is a JSON Schema
 	// object (typically map[string]any).
 	GenerateJSONSchema(ctx context.Context, prompt, name string, schema any) (string, error)
+}
+
+// InjectionRecorder is implemented by stores that can record recall
+// injections. It is deliberately NOT part of Store.
+//
+// Only the daemon calls it, on its own local store, from handleRecall -- the
+// one place that knows which facts were injected. Putting it on Store would
+// oblige httpclient to implement it and require an endpoint no client would
+// ever call, so it stays an optional capability that the concrete backends
+// provide and handleRecall type-asserts for.
+//
+// The reason this lives server-side at all is that every previous attempt to
+// record usage lived in a client -- a hook, or a model-initiated tool call --
+// and each one silently stopped: context_injections went quiet in May 2026,
+// context_feedback in June, and confirmed_count is zero across the corpus.
+// A signal the daemon derives from its own work cannot drift out of use.
+type InjectionRecorder interface {
+	RecordInjection(ctx context.Context, ids []int64) error
 }

--- a/transfer.go
+++ b/transfer.go
@@ -37,6 +37,8 @@ type ExportedFact struct {
 	LastConfirmedAt *time.Time      `json:"last_confirmed_at,omitempty"`
 	UseCount        int             `json:"use_count,omitempty"`
 	LastUsedAt      *time.Time      `json:"last_used_at,omitempty"`
+	InjectCount     int             `json:"inject_count,omitempty"`
+	LastInjectedAt  *time.Time      `json:"last_injected_at,omitempty"`
 	CreatedAt       time.Time       `json:"created_at"`
 }
 
@@ -65,7 +67,7 @@ func Export(ctx context.Context, db *sql.DB) (*ExportData, error) {
 	rows, err := db.QueryContext(ctx,
 		`SELECT f.id, f.namespace, COALESCE(u.name, ''), f.content, f.subject, f.category, f.kind, f.subsystem, f.metadata,
 		        f.superseded_by, f.superseded_at, f.confirmed_count, f.last_confirmed_at,
-		        f.use_count, f.last_used_at, f.created_at
+		        f.use_count, f.last_used_at, f.inject_count, f.last_injected_at, f.created_at
 		 FROM memstore_facts f
 		 LEFT JOIN memstore_users u ON u.id = f.user_id
 		 ORDER BY f.id`)
@@ -81,12 +83,14 @@ func Export(ctx context.Context, db *sql.DB) (*ExportData, error) {
 		var supersededAt sql.NullString
 		var lastConfirmedAt sql.NullString
 		var lastUsedAt sql.NullString
+		var lastInjectedAt sql.NullString
 		var createdAt string
 
 		if err := rows.Scan(&ef.ID, &ef.Namespace, &ef.User, &ef.Content, &ef.Subject, &ef.Category,
 			&ef.Kind, &ef.Subsystem, &metadata, &supersededBy, &supersededAt,
 			&ef.ConfirmedCount, &lastConfirmedAt,
-			&ef.UseCount, &lastUsedAt, &createdAt); err != nil {
+			&ef.UseCount, &lastUsedAt,
+			&ef.InjectCount, &lastInjectedAt, &createdAt); err != nil {
 			return nil, fmt.Errorf("memstore export: scanning fact: %w", err)
 		}
 
@@ -105,6 +109,10 @@ func Export(ctx context.Context, db *sql.DB) (*ExportData, error) {
 		if lastUsedAt.Valid {
 			t, _ := time.Parse(time.RFC3339, lastUsedAt.String)
 			ef.LastUsedAt = &t
+		}
+		if lastInjectedAt.Valid {
+			t, _ := time.Parse(time.RFC3339, lastInjectedAt.String)
+			ef.LastInjectedAt = &t
 		}
 		ef.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
 


### PR DESCRIPTION
Unblocks #157.

`use_count` was incremented in exactly one place -- an explicit `memory_search` -- so the highest-volume read path in the system left no trace. A fact injected into hundreds of prompts by recall read as never used: 3,538 of 4,657 active facts (76%) sat at zero.

Adds `inject_count` / `last_injected_at`, bumped by `handleRecall` for every fact it surfaces. `memory_get_context` now calls `Touch` as well; it is a genuine retrieval and was the other read path recording nothing.

## Why two counters rather than one

A fact the model went looking for is stronger evidence than one the daemon offered unprompted, and #157's prune predicate has to tell them apart. The backfill makes that concrete: **96 active facts would be deleted by a 90-day prune on `use_count` alone, despite recall having injected them repeatedly** -- one of them 57 times.

## Why the daemon and not a hook

Every previous attempt to record usage lived in a client, and every one of them went silent:

- `context_injections`: 5,143 rows, last written 2026-05-27
- `context_feedback`: 4,979 rows, last written 2026-06-07
- `confirmed_count`: 0 across the entire corpus -- `memory_confirm` is model-initiated and never called

`handleRecall` already holds the fact IDs. Recording there cannot be skipped, because it is the same function that does the work. Same principle as #153: derive the signal from the authoritative source instead of asking a client to report it faithfully.

## Shape

`RecordInjection` is an optional `InjectionRecorder` interface, not a `Store` method. Only the daemon calls it, on its own local store, so putting it on `Store` would oblige `httpclient` to implement it behind an endpoint no client would ever call. It is added to the cross-user isolation conformance battery alongside `Touch`, since it is the same kind of counter mutation and would leak across users if it skipped the predicate.

Recording is best-effort, like the existing search-side `Touch`: a failed counter update must never cost the caller their context.

## Migration

`V17` (SQLite) / `V10` (Postgres). Additive columns plus, on Postgres, a backfill from the historical `context_injections` rows -- 4,990 fact injections across 476 distinct facts, seeding 402 active ones.

The backfill is guarded on `context_injections` existing. That table belongs to the session store, which migrates independently and is absent from a fresh facts-only database; an unguarded reference would fail there. SQLite gets no backfill because it has no session store.

## Column sync points

All six were updated: `factColumns` and `scanFact` in both backends, `ExportedFact` and its query, and the `Fact` struct. Note `prefixedFactColumns` derives from `factColumns`, so the `searchFTS` list that CLAUDE.md warns about separately is now automatic rather than a fourth hand-maintained copy.

## Note

This runs a schema change against the live store when the image redeploys. Additive and idempotent, but it is a production migration.
