### PR TITLE
fix: report a config file that cannot be read to the end

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package memstore
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -96,6 +97,7 @@ func LoadIngestToken() string {
 					token = value
 				}
 			}
+			warnIfUnreadable(scanner, path)
 			f.Close()
 		}
 	}
@@ -317,6 +319,7 @@ func LoadConfig() AppConfig {
 					cfg.TLSClientKeyFile = expandTilde(value)
 				}
 			}
+			warnIfUnreadable(scanner, path)
 			f.Close()
 		}
 	}
@@ -455,4 +458,25 @@ func defaultDBPath() string {
 		return "memory.db"
 	}
 	return filepath.Join(home, ".local", "share", "memstore", "memory.db")
+}
+
+// warnIfUnreadable reports a config file that could not be read to the end.
+//
+// Both config readers are documented as returning defaults rather than an
+// error, and callers depend on that -- a missing config file is the ordinary
+// first-run case. But a scan that stops early is different from a file that is
+// absent: the keys below the failure are silently unread, so the caller gets a
+// config that looks complete and is not.
+//
+// That matters most for `remote`. Losing it makes memstore-mcp fall back to an
+// empty local SQLite database instead of the daemon, which presents as an empty
+// corpus rather than as a misconfiguration. bufio.Scanner reports a line past
+// its 64KB buffer as an error rather than a short read, so this is the only
+// place that distinction is visible. Warn rather than fail: the partial config
+// is still the best available answer, but the silence has to go.
+func warnIfUnreadable(scanner *bufio.Scanner, path string) {
+	if err := scanner.Err(); err != nil {
+		log.Printf("memstore: config %s could not be read to the end (%v); "+
+			"any settings after the failure were ignored", path, err)
+	}
 }

--- a/config_scanner_test.go
+++ b/config_scanner_test.go
@@ -1,0 +1,105 @@
+package memstore
+
+import (
+	"bufio"
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeConfig points ConfigPath at a temp dir and writes body to the config
+// file inside it.
+func writeConfig(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	path := filepath.Join(dir, "memstore", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// captureLog redirects the standard logger for the duration of fn.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	old := log.Writer()
+	flags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() { log.SetOutput(old); log.SetFlags(flags) })
+	fn()
+	return buf.String()
+}
+
+// A line past bufio.Scanner's 64KB buffer stops the scan. Everything after it
+// is silently unread, so a config whose `remote` sits below such a line loads
+// as if remote were unset -- and an unset remote makes memstore-mcp fall back
+// to an empty local SQLite database rather than the daemon. That failure is
+// indistinguishable from an empty corpus, so the read must at least say so.
+func TestLoadConfigWarnsOnUnreadableFile(t *testing.T) {
+	writeConfig(t, strings.Repeat("x", bufio.MaxScanTokenSize+1)+"\nremote = \"http://example:8230\"\n")
+
+	var cfg AppConfig
+	out := captureLog(t, func() { cfg = LoadConfig() })
+
+	if out == "" {
+		t.Error("LoadConfig read a truncated config silently; expected a warning on the log")
+	}
+	if !strings.Contains(out, "config") {
+		t.Errorf("warning does not name the config file: %q", out)
+	}
+	// The contract stays "defaults on unreadable" -- this test pins the
+	// warning, not a behaviour change.
+	if cfg.Remote != "" {
+		t.Errorf("remote = %q; the line after the overlong one is genuinely unread", cfg.Remote)
+	}
+}
+
+func TestLoadIngestTokenWarnsOnUnreadableFile(t *testing.T) {
+	writeConfig(t, strings.Repeat("x", bufio.MaxScanTokenSize+1)+"\ningest_token = \"mst_example\"\n")
+
+	var tok string
+	out := captureLog(t, func() { tok = LoadIngestToken() })
+
+	if out == "" {
+		t.Error("LoadIngestToken read a truncated config silently; expected a warning on the log")
+	}
+	if tok != "" {
+		t.Errorf("token = %q; the line after the overlong one is genuinely unread", tok)
+	}
+}
+
+// A normal config must stay quiet, or the warning becomes noise nobody reads.
+func TestLoadConfigSilentOnGoodFile(t *testing.T) {
+	writeConfig(t, "# comment\nremote = \"http://example:8230\"\nnamespace = \"probe\"\n")
+
+	var cfg AppConfig
+	out := captureLog(t, func() { cfg = LoadConfig() })
+
+	if out != "" {
+		t.Errorf("LoadConfig logged on a well-formed config: %q", out)
+	}
+	if cfg.Remote != "http://example:8230" {
+		t.Errorf("remote = %q, want the configured value", cfg.Remote)
+	}
+	if cfg.Namespace != "probe" {
+		t.Errorf("namespace = %q, want probe", cfg.Namespace)
+	}
+}
+
+// A missing config file is the ordinary first-run case, not an error.
+func TestLoadConfigSilentWhenMissing(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	out := captureLog(t, func() { LoadConfig() })
+	if out != "" {
+		t.Errorf("LoadConfig logged when no config file exists: %q", out)
+	}
+}


### PR DESCRIPTION
`LoadConfig` and `LoadIngestToken` both scanned `config.toml` without checking `bufio.Scanner.Err()`. A scan that stops early -- a line past the 64KB buffer, an I/O error -- leaves every key below the failure silently unread, so the caller gets a config that looks complete and is not.

That matters most for `remote`. Losing it makes `memstore-mcp` fall back to an empty local SQLite database instead of the daemon, which presents as an *empty corpus* rather than as a misconfiguration -- the failure is invisible at exactly the moment it is most confusing.

Both functions are documented as returning defaults rather than an error, and callers depend on that since a missing config file is the ordinary first-run case. So this warns rather than failing: the partial config is still the best available answer, but the silence goes. Changing the signatures would ripple through every caller for a case that is already contractually non-fatal.

Adds the first tests for either reader, including that a well-formed config and a missing one both stay quiet -- a warning nobody can trust to be meaningful is one nobody reads.

Same pattern as the `tls_cmd.go` fix in #154; the linter only surfaced that one at the time.
