### PR TITLE
fix: cap status subjects on the structured channel, and aggregate the histograms in SQL

### DIFF
--- a/httpapi/handler.go
+++ b/httpapi/handler.go
@@ -261,6 +261,7 @@ func (h *Handler) registerRoutes() {
 	h.mux.HandleFunc("POST /v1/facts/touch", h.requireScope(ScopeWrite, h.handleTouch), smoke.Write())
 	h.mux.HandleFunc("POST /v1/facts/exists", h.requireScope(ScopeRead, h.handleExists), smoke.Skip("POST read; needs a JSON body (phase 2)"))
 	h.mux.HandleFunc("GET /v1/facts/count", h.requireScope(ScopeRead, h.handleActiveCount))
+	h.mux.HandleFunc("GET /v1/facts/breakdown", h.requireScope(ScopeRead, h.handleBreakdown))
 	h.mux.HandleFunc("GET /v1/facts/{id}/history", h.requireScope(ScopeRead, h.handleHistoryByID), smoke.Example("id", "1"))
 	h.mux.HandleFunc("GET /v1/history/{subject}", h.requireScope(ScopeRead, h.handleHistoryBySubject), smoke.Example("subject", "smoke"))
 
@@ -529,6 +530,15 @@ func (h *Handler) handleActiveCount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]int64{"count": count})
+}
+
+func (h *Handler) handleBreakdown(w http.ResponseWriter, r *http.Request) {
+	bd, err := storeFromCtx(r.Context(), h.store).Breakdown(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, bd)
 }
 
 // --- History ---

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -188,6 +188,14 @@ func (c *Client) ActiveCount(ctx context.Context) (int64, error) {
 	return result.Count, nil
 }
 
+func (c *Client) Breakdown(ctx context.Context) (memstore.FactBreakdown, error) {
+	var bd memstore.FactBreakdown
+	if err := c.get(ctx, "/v1/facts/breakdown", &bd); err != nil {
+		return memstore.FactBreakdown{}, err
+	}
+	return bd, nil
+}
+
 func (c *Client) BySubject(ctx context.Context, subject string, onlyActive bool) ([]memstore.Fact, error) {
 	return c.List(ctx, memstore.QueryOpts{Subject: subject, OnlyActive: onlyActive})
 }

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -330,6 +330,41 @@ func TestClient_ActiveCount(t *testing.T) {
 	}
 }
 
+// TestClient_Breakdown exercises the aggregate over a real HTTP round trip:
+// route wiring, JSON encode/decode, and the empty-kind exclusion holding across
+// the wire. It cannot catch a JSON tag mismatch -- both ends marshal the same
+// FactBreakdown, so a renamed tag moves both sides together -- but it does fail
+// if the route stops resolving, which is the live risk given that
+// /v1/facts/breakdown has to out-specify /v1/facts/{id}.
+func TestClient_Breakdown(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	c.Insert(ctx, memstore.Fact{Content: "one", Subject: "alpha", Category: "note", Kind: "decision"})
+	c.Insert(ctx, memstore.Fact{Content: "two", Subject: "alpha", Category: "note"})
+	c.Insert(ctx, memstore.Fact{Content: "three", Subject: "beta", Category: "project"})
+
+	bd, err := c.Breakdown(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := bd.Subjects["alpha"]; got != 2 {
+		t.Errorf("Subjects[alpha] = %d, want 2", got)
+	}
+	if got := bd.Subjects["beta"]; got != 1 {
+		t.Errorf("Subjects[beta] = %d, want 1", got)
+	}
+	if got := bd.Categories["note"]; got != 2 {
+		t.Errorf("Categories[note] = %d, want 2", got)
+	}
+	if got := bd.Kinds["decision"]; got != 1 {
+		t.Errorf("Kinds[decision] = %d, want 1", got)
+	}
+	if _, ok := bd.Kinds[""]; ok {
+		t.Error("Kinds carries an empty-kind bucket; it should be dropped in SQL")
+	}
+}
+
 func TestClient_Supersede(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/matthewjhunter/memstore"
@@ -65,6 +66,9 @@ func Run(t *testing.T, opts Options) {
 	})
 	t.Run("ExistsAndDedup", func(t *testing.T) {
 		testExistsAndDedup(t, opts.NewStore(t))
+	})
+	t.Run("BreakdownAggregates", func(t *testing.T) {
+		testBreakdownAggregates(t, opts.NewStore(t))
 	})
 	t.Run("SupersedeAndHistory", func(t *testing.T) {
 		testSupersedeAndHistory(t, opts.NewStore(t))
@@ -282,6 +286,73 @@ func testInsertGetRoundTrip(t *testing.T, s memstore.Store) {
 		} else if gv != wv {
 			t.Errorf("metadata[%q] = %v, want %v", k, gv, wv)
 		}
+	}
+}
+
+// testBreakdownAggregates covers the aggregate that replaced counting rows in
+// Go. It must agree with ActiveCount, exclude superseded facts, and omit the
+// empty kind the way the caller's own loop did.
+func testBreakdownAggregates(t *testing.T, s memstore.Store) {
+	t.Helper()
+	ctx := context.Background()
+
+	seed := []memstore.Fact{
+		{Content: "alpha one", Subject: "alpha", Category: "note", Kind: "convention"},
+		{Content: "alpha two", Subject: "alpha", Category: "note", Kind: "convention"},
+		{Content: "alpha three", Subject: "alpha", Category: "project", Kind: ""},
+		{Content: "beta one", Subject: "beta", Category: "project", Kind: "decision"},
+	}
+	for _, f := range seed {
+		if _, err := s.Insert(ctx, f); err != nil {
+			t.Fatalf("Insert(%q): %v", f.Content, err)
+		}
+	}
+
+	// A superseded fact must not appear in any histogram.
+	oldID, err := s.Insert(ctx, memstore.Fact{Content: "gamma old", Subject: "gamma", Category: "note"})
+	if err != nil {
+		t.Fatalf("Insert(gamma old): %v", err)
+	}
+	newID, err := s.Insert(ctx, memstore.Fact{Content: "gamma new", Subject: "gamma", Category: "note"})
+	if err != nil {
+		t.Fatalf("Insert(gamma new): %v", err)
+	}
+	if err := s.Supersede(ctx, oldID, newID); err != nil {
+		t.Fatalf("Supersede: %v", err)
+	}
+
+	bd, err := s.Breakdown(ctx)
+	if err != nil {
+		t.Fatalf("Breakdown: %v", err)
+	}
+
+	wantSubjects := map[string]int{"alpha": 3, "beta": 1, "gamma": 1}
+	if !maps.Equal(bd.Subjects, wantSubjects) {
+		t.Errorf("Subjects = %v, want %v", bd.Subjects, wantSubjects)
+	}
+
+	wantCategories := map[string]int{"note": 3, "project": 2}
+	if !maps.Equal(bd.Categories, wantCategories) {
+		t.Errorf("Categories = %v, want %v", bd.Categories, wantCategories)
+	}
+
+	// The empty kind is omitted, matching what the pre-aggregate loop did.
+	wantKinds := map[string]int{"convention": 2, "decision": 1}
+	if !maps.Equal(bd.Kinds, wantKinds) {
+		t.Errorf("Kinds = %v, want %v", bd.Kinds, wantKinds)
+	}
+
+	// The aggregate and the counter must not disagree about what is active.
+	active, err := s.ActiveCount(ctx)
+	if err != nil {
+		t.Fatalf("ActiveCount: %v", err)
+	}
+	var summed int
+	for _, n := range bd.Subjects {
+		summed += n
+	}
+	if int64(summed) != active {
+		t.Errorf("Subjects sum to %d, ActiveCount says %d", summed, active)
 	}
 }
 

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -371,7 +371,14 @@ type StatusResult struct {
 	ActiveCount int64          `json:"active_count"`
 	Categories  map[string]int `json:"categories,omitempty"`
 	Kinds       map[string]int `json:"kinds,omitempty"`
-	Subjects    map[string]int `json:"subjects,omitempty"`
+	// Subjects holds at most statusMaxSubjects entries, the highest-count
+	// ones, matching what the text rendering shows. A live corpus reached
+	// 2,560 subjects, which serialized past the MCP result cap and spilled
+	// the whole call to a file (#150). SubjectCount reports the true total
+	// so a truncated map is never mistaken for the whole picture.
+	Subjects          map[string]int `json:"subjects,omitempty"`
+	SubjectCount      int            `json:"subject_count,omitempty"`
+	SubjectsTruncated bool           `json:"subjects_truncated,omitempty"`
 }
 
 // UpdateResult is the structured output for memory_update.
@@ -1491,11 +1498,14 @@ func (ms *MemoryServer) HandleStatus(ctx context.Context, _ *mcp.CallToolRequest
 		writeSubjectSummary(&b, subjects)
 	}
 
+	topSubjects, truncated := capSubjects(subjects)
 	out := StatusResult{
-		ActiveCount: count,
-		Categories:  categories,
-		Kinds:       kinds,
-		Subjects:    subjects,
+		ActiveCount:       count,
+		Categories:        categories,
+		Kinds:             kinds,
+		Subjects:          topSubjects,
+		SubjectCount:      len(subjects),
+		SubjectsTruncated: truncated,
 	}
 	return textResult(b.String(), false), out, nil
 }
@@ -2630,6 +2640,22 @@ func sortedMapDesc(m map[string]int) []kvPair {
 		return pairs[i].key < pairs[j].key
 	})
 	return pairs
+}
+
+// capSubjects reduces the subject histogram to the highest-count
+// statusMaxSubjects entries, reporting whether anything was dropped. It shares
+// sortedMapDesc with writeSubjectSummary so the structured channel and the text
+// channel always show the same subjects rather than two different top-20s.
+func capSubjects(subjects map[string]int) (map[string]int, bool) {
+	if len(subjects) <= statusMaxSubjects {
+		return subjects, false
+	}
+	sorted := sortedMapDesc(subjects)
+	capped := make(map[string]int, statusMaxSubjects)
+	for _, kv := range sorted[:statusMaxSubjects] {
+		capped[kv.key] = kv.val
+	}
+	return capped, true
 }
 
 func writeSubjectSummary(b *strings.Builder, subjects map[string]int) {

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -1458,22 +1458,14 @@ func (ms *MemoryServer) HandleStatus(ctx context.Context, _ *mcp.CallToolRequest
 		return textResult(fmt.Sprintf("Error: %v", err), true), StatusResult{}, nil
 	}
 
-	// Get subject and category breakdown.
-	facts, err := ms.store.List(ctx, memstore.QueryOpts{OnlyActive: true})
+	// Aggregated in the database. This used to List every active fact and
+	// count them in Go, which pulled 5,791 full rows -- content and embedding
+	// included -- across the wire to build three small maps (#150).
+	bd, err := ms.store.Breakdown(ctx)
 	if err != nil {
 		return textResult(fmt.Sprintf("Error: %v", err), true), StatusResult{}, nil
 	}
-
-	subjects := make(map[string]int)
-	categories := make(map[string]int)
-	kinds := make(map[string]int)
-	for _, f := range facts {
-		subjects[f.Subject]++
-		categories[f.Category]++
-		if f.Kind != "" {
-			kinds[f.Kind]++
-		}
-	}
+	subjects, categories, kinds := bd.Subjects, bd.Categories, bd.Kinds
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "Active memories: %d\n\n", count)

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -721,6 +721,73 @@ func TestHandleStatus_WithFacts(t *testing.T) {
 	}
 }
 
+// TestHandleStatus_StructuredSubjectsAreCapped covers #150: the text rendering
+// capped subjects at statusMaxSubjects while the structured channel shipped the
+// whole map, so a real corpus (2,560 subjects) serialized past the MCP result
+// cap and the entire call got spilled to a file.
+func TestHandleStatus_StructuredSubjectsAreCapped(t *testing.T) {
+	srv, store, emb := newTestServer(t)
+	ctx := context.Background()
+
+	// One fact per subject, with descending counts so the ordering is
+	// deterministic and the top-N is a known set.
+	const subjectCount = 25
+	for i := range subjectCount {
+		subject := fmt.Sprintf("subject-%02d", i)
+		for j := 0; j <= subjectCount-i; j++ {
+			insertFact(t, store, emb, fmt.Sprintf("fact %d for %s", j, subject), subject, "note")
+		}
+	}
+
+	_, out, err := srv.HandleStatus(ctx, nil, mcpserver.StatusInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(out.Subjects) != 20 {
+		t.Errorf("Subjects length = %d, want 20 (the cap)", len(out.Subjects))
+	}
+	if out.SubjectCount != subjectCount {
+		t.Errorf("SubjectCount = %d, want %d", out.SubjectCount, subjectCount)
+	}
+	if !out.SubjectsTruncated {
+		t.Error("SubjectsTruncated = false, want true when subjects exceed the cap")
+	}
+
+	// The cap must keep the highest-count subjects, not an arbitrary 20.
+	if _, ok := out.Subjects["subject-00"]; !ok {
+		t.Error("expected the highest-count subject to survive the cap")
+	}
+	if _, ok := out.Subjects["subject-24"]; ok {
+		t.Error("expected the lowest-count subject to be dropped by the cap")
+	}
+}
+
+// TestHandleStatus_StructuredSubjectsUnderCap keeps the untruncated case honest:
+// below the cap nothing is dropped and the truncation flag stays off.
+func TestHandleStatus_StructuredSubjectsUnderCap(t *testing.T) {
+	srv, store, emb := newTestServer(t)
+	ctx := context.Background()
+
+	insertFact(t, store, emb, "Matthew prefers dark mode", "matthew", "preference")
+	insertFact(t, store, emb, "memstore uses SQLite", "memstore", "project")
+
+	_, out, err := srv.HandleStatus(ctx, nil, mcpserver.StatusInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(out.Subjects) != 2 {
+		t.Errorf("Subjects length = %d, want 2", len(out.Subjects))
+	}
+	if out.SubjectCount != 2 {
+		t.Errorf("SubjectCount = %d, want 2", out.SubjectCount)
+	}
+	if out.SubjectsTruncated {
+		t.Error("SubjectsTruncated = true, want false when subjects fit under the cap")
+	}
+}
+
 // --- memory_supersede tests ---
 
 func TestHandleSupersede_Basic(t *testing.T) {

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -1541,6 +1541,57 @@ func (s *PostgresStore) ActiveCount(ctx context.Context) (int64, error) {
 	return count, nil
 }
 
+// Breakdown aggregates the active-fact histograms in SQL. See the Store
+// interface for why this is not a List plus a loop in Go.
+func (s *PostgresStore) Breakdown(ctx context.Context) (memstore.FactBreakdown, error) {
+	bd := memstore.FactBreakdown{
+		Subjects:   make(map[string]int),
+		Categories: make(map[string]int),
+		Kinds:      make(map[string]int),
+	}
+
+	// The empty kind is dropped in SQL rather than after scanning, so an
+	// unclassified fact never becomes a "" bucket in the result.
+	for _, dim := range []struct {
+		column string
+		extra  string
+		into   map[string]int
+	}{
+		{"subject", "", bd.Subjects},
+		{"category", "", bd.Categories},
+		{"kind", ` AND kind != ''`, bd.Kinds},
+	} {
+		q, args := s.userPredicate(
+			`SELECT `+dim.column+`, COUNT(*) FROM memstore_facts
+			 WHERE superseded_by IS NULL AND namespace = $1`+dim.extra+s.readableSQL(""),
+			[]any{s.namespace})
+		q += ` GROUP BY ` + dim.column
+		if err := s.scanCounts(ctx, q, args, dim.into); err != nil {
+			return memstore.FactBreakdown{}, fmt.Errorf("pgstore: breakdown by %s: %w", dim.column, err)
+		}
+	}
+	return bd, nil
+}
+
+// scanCounts runs a two-column (value, count) aggregate into dst.
+func (s *PostgresStore) scanCounts(ctx context.Context, q string, args []any, dst map[string]int) error {
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var key string
+		var n int
+		if err := rows.Scan(&key, &n); err != nil {
+			return err
+		}
+		dst[key] = n
+	}
+	return rows.Err()
+}
+
 // NeedingEmbedding returns facts that don't have embeddings yet.
 func (s *PostgresStore) NeedingEmbedding(ctx context.Context, limit int) ([]memstore.Fact, error) {
 	if limit <= 0 {

--- a/sqlite.go
+++ b/sqlite.go
@@ -1485,6 +1485,59 @@ func (s *SQLiteStore) ActiveCount(ctx context.Context) (int64, error) {
 	return count, nil
 }
 
+// Breakdown aggregates the active-fact histograms in SQL. See the Store
+// interface for why this is not a List plus a loop in Go.
+func (s *SQLiteStore) Breakdown(ctx context.Context) (FactBreakdown, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	bd := FactBreakdown{
+		Subjects:   make(map[string]int),
+		Categories: make(map[string]int),
+		Kinds:      make(map[string]int),
+	}
+
+	// The empty kind is dropped in SQL rather than after scanning, so an
+	// unclassified fact never becomes a "" bucket in the result.
+	for _, dim := range []struct {
+		column string
+		extra  string
+		into   map[string]int
+	}{
+		{"subject", "", bd.Subjects},
+		{"category", "", bd.Categories},
+		{"kind", ` AND kind != ''`, bd.Kinds},
+	} {
+		q := `SELECT ` + dim.column + `, COUNT(*) FROM memstore_facts
+		      WHERE superseded_by IS NULL AND namespace = ?` + dim.extra + s.readableSQL("") +
+			` GROUP BY ` + dim.column
+		if err := s.scanCounts(ctx, q, dim.into); err != nil {
+			return FactBreakdown{}, fmt.Errorf("memstore: breakdown by %s: %w", dim.column, err)
+		}
+	}
+	return bd, nil
+}
+
+// scanCounts runs a two-column (value, count) aggregate into dst. The caller
+// holds s.mu.
+func (s *SQLiteStore) scanCounts(ctx context.Context, q string, dst map[string]int) error {
+	rows, err := s.db.QueryContext(ctx, q, s.namespace)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var key string
+		var n int
+		if err := rows.Scan(&key, &n); err != nil {
+			return err
+		}
+		dst[key] = n
+	}
+	return rows.Err()
+}
+
 // NeedingEmbedding returns facts that don't have embeddings yet.
 func (s *SQLiteStore) NeedingEmbedding(ctx context.Context, limit int) ([]Fact, error) {
 	s.mu.RLock()

--- a/store.go
+++ b/store.go
@@ -417,6 +417,14 @@ type Link struct {
 }
 
 // Store provides fact storage with hybrid FTS5+vector search.
+// FactBreakdown holds per-dimension counts of active facts. Each map is keyed
+// by the dimension value and holds the number of active facts carrying it.
+type FactBreakdown struct {
+	Subjects   map[string]int `json:"subjects"`
+	Categories map[string]int `json:"categories"`
+	Kinds      map[string]int `json:"kinds"`
+}
+
 type Store interface {
 	// Writes
 	Insert(ctx context.Context, f Fact) (int64, error)
@@ -436,6 +444,13 @@ type Store interface {
 	BySubject(ctx context.Context, subject string, onlyActive bool) ([]Fact, error)
 	Exists(ctx context.Context, content, subject string) (bool, error)
 	ActiveCount(ctx context.Context) (int64, error)
+	// Breakdown returns per-subject, per-category, and per-kind counts of
+	// active facts, aggregated in the database. Callers that only need the
+	// histogram must not pull whole rows to build it: memory_status did, and
+	// on a 5,791-fact store that shipped every content field and embedding
+	// across the wire to produce three small maps (#150). Facts with an empty
+	// kind are omitted from Kinds.
+	Breakdown(ctx context.Context) (FactBreakdown, error)
 	// History returns the supersession chain for a fact. If id > 0, it walks
 	// the chain containing that fact. If subject is non-empty (and id == 0),
 	// it returns all facts for that subject ordered by creation time.


### PR DESCRIPTION
Closes #150.

`writeSubjectSummary` has capped the text rendering at 20 subjects since it was written, but `StatusResult.Subjects` was assigned the whole map. On the live corpus that is 2,560 entries and 68,883 characters of structured content, past the MCP tool-result cap: the entire call spills to a file and the caller has to `jq` it back to learn a fact count. The tool is unusable through MCP at that size.

`capSubjects` takes the top `statusMaxSubjects` by count, sharing `sortedMapDesc` with the text path so the two channels name the same subjects rather than each picking their own twenty. A truncated map that looked complete would be its own bug, so `SubjectCount` carries the real total and `SubjectsTruncated` says outright that entries were dropped -- mirroring the "(N unique)" and "... and N more" the text already prints. `Categories` (37) and `Kinds` (12) are bounded by the schema and stay whole.

The issue's second half is the reason the map was that big in the first place. `HandleStatus` called `List(QueryOpts{OnlyActive: true})` with no limit and counted rows in Go: 5,791 full fact rows, content and embedding included, pulled across the wire to produce three small maps -- and over the HTTP client, that whole corpus serialized as JSON on every status call. `Breakdown` does it as three `GROUP BY` queries in the backend, joining `Store` next to `ActiveCount` and `ListSubsystems`, which are the same shape. Facts with an empty kind are excluded in SQL rather than after scanning, so an unclassified fact cannot become a `""` bucket the way it could if the filter were dropped from the Go loop.

Implemented for SQLite and Postgres, exposed at `GET /v1/facts/breakdown`, wired into `httpclient`. Conformance covers it so both backends have to agree, including that the histogram sums to `ActiveCount` and that superseded facts are excluded from both.

Two notes from verifying it:

- The client round-trip test cannot catch a JSON tag mismatch -- both ends marshal the same `FactBreakdown`, so a renamed tag moves both sides together. Confirmed by mutation; the comment states what the test actually covers. It does catch route breakage, verified the same way.
- `/v1/facts/breakdown` has to out-specify `/v1/facts/{id}` to resolve. Go 1.22+ `ServeMux` handles that by specificity, but the failure mode when it does not is a confusing `invalid id: breakdown` rather than a 404.

Postgres conformance does not execute locally -- those tests skip without a live database -- so the pgstore implementation of `Breakdown` is verified by CI here, not by the local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
