### PR TITLE
fix: report a missing id as invalid input, not a store failure

### DIFF
--- a/httpapi/handler.go
+++ b/httpapi/handler.go
@@ -437,7 +437,7 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := storeFromCtx(r.Context(), h.store).Delete(r.Context(), id); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
@@ -453,7 +453,7 @@ func (h *Handler) handleUpdateMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := storeFromCtx(r.Context(), h.store).UpdateMetadata(r.Context(), id, patch); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
@@ -487,7 +487,7 @@ func (h *Handler) handleConfirm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := storeFromCtx(r.Context(), h.store).Confirm(r.Context(), id); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "confirmed"})
@@ -701,7 +701,7 @@ func (h *Handler) handleLinkFacts(w http.ResponseWriter, r *http.Request) {
 	}
 	id, err := storeFromCtx(r.Context(), h.store).LinkFacts(r.Context(), input.SourceID, input.TargetID, input.LinkType, input.Bidirectional, input.Label, input.Metadata)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]int64{"id": id})
@@ -762,7 +762,7 @@ func (h *Handler) handleUpdateLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := storeFromCtx(r.Context(), h.store).UpdateLink(r.Context(), id, input.Label, input.Metadata); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
@@ -774,7 +774,7 @@ func (h *Handler) handleDeleteLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := storeFromCtx(r.Context(), h.store).DeleteLink(r.Context(), id); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
@@ -849,6 +849,18 @@ func writeJSON(w http.ResponseWriter, code int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(v)
+}
+
+// writeStoreError maps a store error to a status code. A miss is the caller
+// naming a row that does not exist, which is a 404, not a server fault; the
+// client turns that back into memstore.ErrNotFound so the sentinel survives the
+// hop (#165). Everything else is a genuine failure.
+func writeStoreError(w http.ResponseWriter, err error) {
+	if errors.Is(err, memstore.ErrNotFound) {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeError(w, http.StatusInternalServerError, err.Error())
 }
 
 func writeError(w http.ResponseWriter, code int, msg string) {

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -638,6 +638,18 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("memstored %d: %s", e.Code, e.Message)
 }
 
+// Unwrap maps a 404 onto memstore.ErrNotFound so errors.Is works the same
+// against the daemon as it does in-process. The MCP server runs over this
+// client in the deployed configuration, and it routes a miss and a store
+// failure to different channels (#165); without this the daemon collapses that
+// distinction at the network boundary.
+func (e *HTTPError) Unwrap() error {
+	if e.Code == http.StatusNotFound {
+		return memstore.ErrNotFound
+	}
+	return nil
+}
+
 func isNotFound(err error) bool {
 	if he, ok := err.(*HTTPError); ok {
 		return he.Code == http.StatusNotFound

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -362,6 +363,43 @@ func TestClient_Breakdown(t *testing.T) {
 	}
 	if _, ok := bd.Kinds[""]; ok {
 		t.Error("Kinds carries an empty-kind bucket; it should be dropped in SQL")
+	}
+}
+
+// TestClient_NotFoundSentinel pins the sentinel across the HTTP boundary. The
+// MCP server runs against the daemon in the deployed configuration, so a
+// sentinel that only survives in-process would leave every miss looking like a
+// store outage exactly where it matters (#165).
+func TestClient_NotFoundSentinel(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	const missing = int64(999999)
+
+	cases := []struct {
+		name string
+		op   func() error
+	}{
+		{"Delete", func() error { return c.Delete(ctx, missing) }},
+		{"Confirm", func() error { return c.Confirm(ctx, missing) }},
+		{"UpdateMetadata", func() error { return c.UpdateMetadata(ctx, missing, map[string]any{"k": "v"}) }},
+		{"DeleteLink", func() error { return c.DeleteLink(ctx, missing) }},
+		{"UpdateLink", func() error { return c.UpdateLink(ctx, missing, "label", nil) }},
+		{"LinkFacts", func() error {
+			_, err := c.LinkFacts(ctx, missing, missing, "reference", false, "", nil)
+			return err
+		}},
+	}
+
+	for _, tc := range cases {
+		err := tc.op()
+		if err == nil {
+			t.Errorf("%s: expected an error, got nil", tc.name)
+			continue
+		}
+		if !errors.Is(err, memstore.ErrNotFound) {
+			t.Errorf("%s: errors.Is(err, ErrNotFound) = false; err = %v", tc.name, err)
+		}
 	}
 }
 

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -17,6 +17,7 @@ package conformance
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"testing"
@@ -69,6 +70,9 @@ func Run(t *testing.T, opts Options) {
 	})
 	t.Run("BreakdownAggregates", func(t *testing.T) {
 		testBreakdownAggregates(t, opts.NewStore(t))
+	})
+	t.Run("NotFoundSentinel", func(t *testing.T) {
+		testNotFoundSentinel(t, opts.NewStore(t))
 	})
 	t.Run("SupersedeAndHistory", func(t *testing.T) {
 		testSupersedeAndHistory(t, opts.NewStore(t))
@@ -353,6 +357,69 @@ func testBreakdownAggregates(t *testing.T, s memstore.Store) {
 	}
 	if int64(summed) != active {
 		t.Errorf("Subjects sum to %d, ActiveCount says %d", summed, active)
+	}
+}
+
+// testNotFoundSentinel pins the contract that an id-targeted mutation naming a
+// row that does not exist reports memstore.ErrNotFound rather than an opaque
+// error. The MCP layer needs to tell that case apart from a real store failure:
+// the two report on different channels, and without a sentinel every miss looks
+// like an outage. Both backends must agree, including LinkFacts, where the miss
+// surfaces as a foreign-key violation rather than a zero-row update.
+func testNotFoundSentinel(t *testing.T, s memstore.Store) {
+	t.Helper()
+	ctx := context.Background()
+
+	const missing = int64(999999)
+
+	realID, err := s.Insert(ctx, memstore.Fact{Content: "anchor fact", Subject: "anchor", Category: "note"})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	linkID, err := s.LinkFacts(ctx, realID, realID, "reference", false, "", nil)
+	if err != nil {
+		t.Fatalf("LinkFacts: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		op   func() error
+	}{
+		{"Delete", func() error { return s.Delete(ctx, missing) }},
+		{"Confirm", func() error { return s.Confirm(ctx, missing) }},
+		{"UpdateMetadata", func() error { return s.UpdateMetadata(ctx, missing, map[string]any{"k": "v"}) }},
+		{"DeleteLink", func() error { return s.DeleteLink(ctx, missing) }},
+		{"UpdateLink", func() error { return s.UpdateLink(ctx, missing, "label", nil) }},
+		{"LinkFactsMissingSource", func() error {
+			_, err := s.LinkFacts(ctx, missing, realID, "reference", false, "", nil)
+			return err
+		}},
+		{"LinkFactsMissingTarget", func() error {
+			_, err := s.LinkFacts(ctx, realID, missing, "reference", false, "", nil)
+			return err
+		}},
+	}
+
+	for _, tc := range cases {
+		err := tc.op()
+		if err == nil {
+			t.Errorf("%s(%d): expected an error, got nil", tc.name, missing)
+			continue
+		}
+		if !errors.Is(err, memstore.ErrNotFound) {
+			t.Errorf("%s(%d): errors.Is(err, ErrNotFound) = false; err = %v", tc.name, missing, err)
+		}
+	}
+
+	// The sentinel must not leak onto operations that succeed.
+	if err := s.Confirm(ctx, realID); err != nil {
+		t.Errorf("Confirm(existing): %v", err)
+	}
+	if err := s.UpdateLink(ctx, linkID, "new label", nil); err != nil {
+		t.Errorf("UpdateLink(existing): %v", err)
+	}
+	if err := s.Delete(ctx, realID); err != nil {
+		t.Errorf("Delete(existing): %v", err)
 	}
 }
 

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -7,6 +7,7 @@ package mcpserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -1445,6 +1446,9 @@ func (ms *MemoryServer) HandleDelete(ctx context.Context, _ *mcp.CallToolRequest
 
 	err := ms.store.Delete(ctx, input.ID)
 	if err != nil {
+		if errors.Is(err, memstore.ErrNotFound) {
+			return invalidWrite[DeleteResult](err.Error())
+		}
 		return textResult(fmt.Sprintf("Error: %v", err), true), DeleteResult{}, nil
 	}
 
@@ -1606,6 +1610,9 @@ func (ms *MemoryServer) HandleConfirm(ctx context.Context, _ *mcp.CallToolReques
 	}
 
 	if err := ms.store.Confirm(ctx, input.ID); err != nil {
+		if errors.Is(err, memstore.ErrNotFound) {
+			return invalidWrite[ConfirmResult](err.Error())
+		}
 		return textResult(fmt.Sprintf("Error: %v", err), true), ConfirmResult{}, nil
 	}
 
@@ -1658,6 +1665,9 @@ func (ms *MemoryServer) HandleUpdate(ctx context.Context, _ *mcp.CallToolRequest
 	}
 
 	if err := ms.store.UpdateMetadata(ctx, input.ID, input.Metadata); err != nil {
+		if errors.Is(err, memstore.ErrNotFound) {
+			return invalidWrite[UpdateResult](err.Error())
+		}
 		return textResult(fmt.Sprintf("Error: %v", err), true), UpdateResult{}, nil
 	}
 
@@ -1915,6 +1925,9 @@ func (ms *MemoryServer) HandleLink(ctx context.Context, _ *mcp.CallToolRequest, 
 
 	id, err := ms.store.LinkFacts(ctx, input.SourceID, input.TargetID, linkType, input.Bidirectional, input.Label, input.Metadata)
 	if err != nil {
+		if errors.Is(err, memstore.ErrNotFound) {
+			return invalidWrite[LinkResult](err.Error())
+		}
 		return textResult(fmt.Sprintf("Error creating link: %v", err), true), LinkResult{}, nil
 	}
 
@@ -1938,6 +1951,9 @@ func (ms *MemoryServer) HandleUnlink(ctx context.Context, _ *mcp.CallToolRequest
 		return invalidWrite[UnlinkResult]("link_id is required")
 	}
 	if err := ms.store.DeleteLink(ctx, input.LinkID); err != nil {
+		if errors.Is(err, memstore.ErrNotFound) {
+			return invalidWrite[UnlinkResult](err.Error())
+		}
 		return textResult(fmt.Sprintf("Error deleting link: %v", err), true), UnlinkResult{}, nil
 	}
 	out := UnlinkResult{Status: "deleted", LinkID: input.LinkID}
@@ -2037,6 +2053,9 @@ func (ms *MemoryServer) HandleUpdateLink(ctx context.Context, _ *mcp.CallToolReq
 		return invalidWrite[UpdateLinkResult]("link_id is required")
 	}
 	if err := ms.store.UpdateLink(ctx, input.LinkID, input.Label, input.Metadata); err != nil {
+		if errors.Is(err, memstore.ErrNotFound) {
+			return invalidWrite[UpdateLinkResult](err.Error())
+		}
 		return textResult(fmt.Sprintf("Error updating link: %v", err), true), UpdateLinkResult{}, nil
 	}
 	out := UpdateLinkResult{Status: "updated", LinkID: input.LinkID}

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -83,10 +83,13 @@ func assertRejected(t *testing.T, r *mcp.CallToolResult) {
 	}
 }
 
-// assertStoreError is assertRejected's counterpart: naming a fact or link that
-// does not exist comes back from the store as an ordinary error with no sentinel
-// to test for, so the handler cannot tell it from a query that failed and keeps
-// IsError. Reclassifying these needs a memstore.ErrNotFound first.
+// assertStoreError is assertRejected's counterpart: memstore failing at
+// something it was asked to do keeps IsError, so a client that honours the flag
+// is told the result is not trustworthy.
+//
+// A missing id used to land here too, for want of a sentinel to test for. It no
+// longer does -- memstore.ErrNotFound made that a caller mistake (#165) -- so
+// what is left is a genuine failure: an outage, a broken query, a failed seal.
 func assertStoreError(t *testing.T, r *mcp.CallToolResult) {
 	t.Helper()
 	if !r.IsError {
@@ -665,20 +668,96 @@ func TestHandleDelete_Basic(t *testing.T) {
 	}
 }
 
-func TestHandleDelete_NotFound(t *testing.T) {
-	srv, _, _ := newTestServer(t)
-	ctx := context.Background()
-
-	result, _, _ := srv.HandleDelete(ctx, nil, mcpserver.DeleteInput{ID: 99999})
-	assertStoreError(t, result)
-}
-
 func TestHandleDelete_InvalidID(t *testing.T) {
 	srv, _, _ := newTestServer(t)
 	ctx := context.Background()
 
 	result, _, _ := srv.HandleDelete(ctx, nil, mcpserver.DeleteInput{ID: 0})
 	assertRejected(t, result)
+}
+
+// TestMissingIDIsInvalidInput covers #165: naming a fact or link that does not
+// exist is a caller mistake, not memstore failing at something it was asked to
+// do. Before the ErrNotFound sentinel these six could not tell the two apart
+// and took the pessimistic branch, so a bad id set IsError and a client that
+// honours it dropped the typed result.
+func TestMissingIDIsInvalidInput(t *testing.T) {
+	srv, store, emb := newTestServer(t)
+	ctx := context.Background()
+
+	realID := insertFact(t, store, emb, "anchor fact", "anchor", "note")
+	const missing = int64(999999)
+
+	cases := []struct {
+		name string
+		call func() (*mcp.CallToolResult, error)
+	}{
+		{"delete", func() (*mcp.CallToolResult, error) {
+			r, _, err := srv.HandleDelete(ctx, nil, mcpserver.DeleteInput{ID: missing})
+			return r, err
+		}},
+		{"confirm", func() (*mcp.CallToolResult, error) {
+			r, _, err := srv.HandleConfirm(ctx, nil, mcpserver.ConfirmInput{ID: missing})
+			return r, err
+		}},
+		{"update", func() (*mcp.CallToolResult, error) {
+			r, _, err := srv.HandleUpdate(ctx, nil, mcpserver.UpdateInput{ID: missing, Metadata: map[string]any{"k": "v"}})
+			return r, err
+		}},
+		{"unlink", func() (*mcp.CallToolResult, error) {
+			r, _, err := srv.HandleUnlink(ctx, nil, mcpserver.UnlinkInput{LinkID: missing})
+			return r, err
+		}},
+		{"update_link", func() (*mcp.CallToolResult, error) {
+			r, _, err := srv.HandleUpdateLink(ctx, nil, mcpserver.UpdateLinkInput{LinkID: missing, Label: "x"})
+			return r, err
+		}},
+		{"link", func() (*mcp.CallToolResult, error) {
+			r, _, err := srv.HandleLink(ctx, nil, mcpserver.LinkInput{SourceID: missing, TargetID: realID})
+			return r, err
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := tc.call()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertRejected(t, res)
+		})
+	}
+}
+
+// TestMissingIDStoreFailureKeepsIsError is the other half of #165: the six
+// handlers must not classify every error as a caller mistake. A real outage on
+// the same call still has to set IsError, or the sentinel would have traded one
+// misreport for its mirror image.
+func TestMissingIDStoreFailureKeepsIsError(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	embedder := &mockEmbedder{dim: 4}
+	store, err := memstore.NewSQLiteStore(db, embedder, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := mcpserver.NewMemoryServer(store, embedder)
+
+	// Pull the database out from under a live server: the id is well-formed and
+	// the failure is the store's, which is exactly the case that must keep the flag.
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	res, _, err := srv.HandleDelete(ctx, nil, mcpserver.DeleteInput{ID: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStoreError(t, res)
 }
 
 // --- memory_status tests ---
@@ -1082,12 +1161,6 @@ func TestHandleConfirm_Basic(t *testing.T) {
 	if !strings.Contains(text, "count=2") {
 		t.Errorf("expected count=2, got: %s", text)
 	}
-}
-
-func TestHandleConfirm_NotFound(t *testing.T) {
-	srv, _, _ := newTestServer(t)
-	result, _, _ := srv.HandleConfirm(context.Background(), nil, mcpserver.ConfirmInput{ID: 99999})
-	assertStoreError(t, result)
 }
 
 func TestHandleConfirm_InvalidID(t *testing.T) {
@@ -1717,17 +1790,6 @@ func TestHandleUnlink(t *testing.T) {
 	}
 }
 
-func TestHandleUnlink_NotFound(t *testing.T) {
-	srv, _, _ := newTestServer(t)
-	ctx := context.Background()
-
-	result, _, err := srv.HandleUnlink(ctx, nil, mcpserver.UnlinkInput{LinkID: 9999})
-	if err != nil {
-		t.Fatal(err)
-	}
-	assertStoreError(t, result)
-}
-
 func TestHandleGetLinks_Basic(t *testing.T) {
 	srv, store, emb := newTestServer(t)
 	ctx := context.Background()
@@ -1846,17 +1908,6 @@ func TestHandleUpdateLink(t *testing.T) {
 	if !strings.Contains(resultText(t, result), "Updated") {
 		t.Errorf("expected updated message, got: %s", resultText(t, result))
 	}
-}
-
-func TestHandleUpdateLink_NotFound(t *testing.T) {
-	srv, _, _ := newTestServer(t)
-	ctx := context.Background()
-
-	result, _, err := srv.HandleUpdateLink(ctx, nil, mcpserver.UpdateLinkInput{LinkID: 9999, Label: "x"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	assertStoreError(t, result)
 }
 
 // --- memory_get_context tests ---

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -1308,7 +1308,7 @@ func (s *PostgresStore) Confirm(ctx context.Context, id int64) error {
 		return fmt.Errorf("pgstore: confirming fact %d: %w", id, err)
 	}
 	if ct.RowsAffected() == 0 {
-		return fmt.Errorf("pgstore: fact %d not found", id)
+		return fmt.Errorf("pgstore: fact %d %w", id, memstore.ErrNotFound)
 	}
 	return nil
 }
@@ -1364,7 +1364,7 @@ func (s *PostgresStore) UpdateMetadata(ctx context.Context, id int64, patch map[
 		[]any{id, s.namespace})
 	err := s.pool.QueryRow(ctx, readQ, readArgs...).Scan(&raw)
 	if err == pgx.ErrNoRows {
-		return fmt.Errorf("pgstore: fact %d not found", id)
+		return fmt.Errorf("pgstore: fact %d %w", id, memstore.ErrNotFound)
 	}
 	if err != nil {
 		return fmt.Errorf("pgstore: reading metadata for fact %d: %w", id, err)
@@ -1427,7 +1427,7 @@ func (s *PostgresStore) Delete(ctx context.Context, id int64) error {
 		return fmt.Errorf("pgstore: deleting fact %d: %w", id, err)
 	}
 	if ct.RowsAffected() == 0 {
-		return fmt.Errorf("pgstore: fact %d not found", id)
+		return fmt.Errorf("pgstore: fact %d %w", id, memstore.ErrNotFound)
 	}
 	return nil
 }
@@ -2081,7 +2081,7 @@ func (s *PostgresStore) LinkFacts(ctx context.Context, sourceID, targetID int64,
 			s.namespace, sourceID, targetID, linkType, bidirectional, label, nullableBytes(metaJSON), time.Now().UTC(),
 		).Scan(&id)
 		if err == pgx.ErrNoRows {
-			return 0, fmt.Errorf("pgstore: creating link %d->%d: facts not found or not owned by one user", sourceID, targetID)
+			return 0, fmt.Errorf("pgstore: creating link %d->%d: facts %w or not owned by one user", sourceID, targetID, memstore.ErrNotFound)
 		}
 	} else {
 		// Guarded insert: both endpoints must exist in the store's namespace
@@ -2099,7 +2099,7 @@ func (s *PostgresStore) LinkFacts(ctx context.Context, sourceID, targetID int64,
 			s.namespace, s.userID, sourceID, targetID, linkType, bidirectional, label, nullableBytes(metaJSON), time.Now().UTC(),
 		).Scan(&id)
 		if err == pgx.ErrNoRows {
-			return 0, fmt.Errorf("pgstore: creating link %d->%d: fact not found", sourceID, targetID)
+			return 0, fmt.Errorf("pgstore: creating link %d->%d: fact %w", sourceID, targetID, memstore.ErrNotFound)
 		}
 	}
 	if err != nil {
@@ -2175,7 +2175,7 @@ func (s *PostgresStore) UpdateLink(ctx context.Context, linkID int64, label stri
 		[]any{linkID, s.namespace})
 	err := s.pool.QueryRow(ctx, readQ, readArgs...).Scan(&currentLabel, &metaRaw)
 	if err == pgx.ErrNoRows {
-		return fmt.Errorf("pgstore: link %d not found", linkID)
+		return fmt.Errorf("pgstore: link %d %w", linkID, memstore.ErrNotFound)
 	}
 	if err != nil {
 		return fmt.Errorf("pgstore: reading link %d: %w", linkID, err)
@@ -2228,7 +2228,7 @@ func (s *PostgresStore) DeleteLink(ctx context.Context, linkID int64) error {
 		return fmt.Errorf("pgstore: deleting link %d: %w", linkID, err)
 	}
 	if ct.RowsAffected() == 0 {
-		return fmt.Errorf("pgstore: link %d not found", linkID)
+		return fmt.Errorf("pgstore: link %d %w", linkID, memstore.ErrNotFound)
 	}
 	return nil
 }

--- a/sqlite.go
+++ b/sqlite.go
@@ -1182,7 +1182,7 @@ func (s *SQLiteStore) Confirm(ctx context.Context, id int64) error {
 		return fmt.Errorf("memstore: checking confirm result: %w", err)
 	}
 	if rows == 0 {
-		return fmt.Errorf("memstore: fact %d not found", id)
+		return fmt.Errorf("memstore: fact %d %w", id, ErrNotFound)
 	}
 	return nil
 }
@@ -1267,7 +1267,7 @@ func (s *SQLiteStore) UpdateMetadata(ctx context.Context, id int64, patch map[st
 		id, s.namespace,
 	).Scan(&raw)
 	if err == sql.ErrNoRows {
-		return fmt.Errorf("memstore: fact %d not found", id)
+		return fmt.Errorf("memstore: fact %d %w", id, ErrNotFound)
 	}
 	if err != nil {
 		return fmt.Errorf("memstore: reading metadata for fact %d: %w", id, err)
@@ -1347,7 +1347,7 @@ func (s *SQLiteStore) Delete(ctx context.Context, id int64) error {
 		return fmt.Errorf("memstore: checking delete result: %w", err)
 	}
 	if rows == 0 {
-		return fmt.Errorf("memstore: fact %d not found", id)
+		return fmt.Errorf("memstore: fact %d %w", id, ErrNotFound)
 	}
 	return nil
 }
@@ -2145,6 +2145,13 @@ func (s *SQLiteStore) LinkFacts(ctx context.Context, sourceID, targetID int64, l
 		s.namespace, s.userID, sourceID, targetID, linkType, bidi, label, metaStr, time.Now().UTC().Format(time.RFC3339),
 	)
 	if err != nil {
+		// A missing endpoint arrives as a foreign-key violation, not a
+		// zero-row update, and the driver's error is opaque. Diagnose it by
+		// probing rather than parsing the driver code: only the failure path
+		// pays for it, and it does not depend on the driver's error taxonomy.
+		if missing, probeErr := s.missingFactID(ctx, sourceID, targetID); probeErr == nil && missing != 0 {
+			return 0, fmt.Errorf("memstore: creating link %d->%d: fact %d %w", sourceID, targetID, missing, ErrNotFound)
+		}
 		return 0, fmt.Errorf("memstore: creating link %d->%d: %w", sourceID, targetID, err)
 	}
 	return result.LastInsertId()
@@ -2226,7 +2233,7 @@ func (s *SQLiteStore) UpdateLink(ctx context.Context, linkID int64, label string
 		linkID, s.namespace,
 	).Scan(&currentLabel, &metaRaw)
 	if err == sql.ErrNoRows {
-		return fmt.Errorf("memstore: link %d not found", linkID)
+		return fmt.Errorf("memstore: link %d %w", linkID, ErrNotFound)
 	}
 	if err != nil {
 		return fmt.Errorf("memstore: reading link %d: %w", linkID, err)
@@ -2272,6 +2279,24 @@ func (s *SQLiteStore) UpdateLink(ctx context.Context, linkID int64, label string
 }
 
 // DeleteLink removes a link by ID. Returns an error if not found.
+// missingFactID returns the first of the given ids with no visible fact row, or
+// 0 when all of them exist. The caller holds s.mu.
+func (s *SQLiteStore) missingFactID(ctx context.Context, ids ...int64) (int64, error) {
+	for _, id := range ids {
+		var exists int
+		err := s.db.QueryRowContext(ctx,
+			`SELECT 1 FROM memstore_facts WHERE id = ? AND namespace = ?`, id, s.namespace,
+		).Scan(&exists)
+		if err == sql.ErrNoRows {
+			return id, nil
+		}
+		if err != nil {
+			return 0, err
+		}
+	}
+	return 0, nil
+}
+
 func (s *SQLiteStore) DeleteLink(ctx context.Context, linkID int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -2287,7 +2312,7 @@ func (s *SQLiteStore) DeleteLink(ctx context.Context, linkID int64) error {
 		return fmt.Errorf("memstore: checking delete result: %w", err)
 	}
 	if rows == 0 {
-		return fmt.Errorf("memstore: link %d not found", linkID)
+		return fmt.Errorf("memstore: link %d %w", linkID, ErrNotFound)
 	}
 	return nil
 }

--- a/store.go
+++ b/store.go
@@ -3,6 +3,7 @@ package memstore
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -417,6 +418,17 @@ type Link struct {
 }
 
 // Store provides fact storage with hybrid FTS5+vector search.
+// ErrNotFound is reported by id-targeted operations when no row matches the id
+// in the caller's scope: Delete, Confirm, UpdateMetadata, DeleteLink,
+// UpdateLink, and LinkFacts naming an endpoint that does not exist.
+//
+// It exists so callers can tell a caller mistake from a store failure. The MCP
+// layer reports the two on different channels -- a bad id is invalid_input,
+// an outage is IsError -- and without a sentinel every miss reads as an outage
+// (#165). Wrap it with %w rather than returning it bare, so the message keeps
+// naming the id that missed.
+var ErrNotFound = errors.New("not found")
+
 // FactBreakdown holds per-dimension counts of active facts. Each map is keyed
 // by the dimension value and holds the number of active facts carrying it.
 type FactBreakdown struct {


### PR DESCRIPTION
Closes #165. Finishes the channel split from #164.

Naming a fact or link that does not exist is a caller mistake, but it arrived from the store as an ordinary error with no sentinel to test for. The handler could not tell it from a query that failed, so it assumed the pessimistic case and set `IsError` -- the flag Claude Code reads to decide a result is untrustworthy, at which point it renders the text block and drops `StructuredContent`. A typo in an id cost the caller the typed result.

**The sentinel.** `memstore.ErrNotFound` joins the `Store` contract, wrapped with `%w` mid-message so the existing text survives intact (`memstore: fact 5 not found`) rather than gaining a redundant second clause. Five of the six methods already detected the miss and only needed wrapping.

`LinkFacts` needed a different mechanism per backend, because a missing endpoint is a foreign-key violation rather than a zero-row update. Postgres already diagnosed it -- the guarded insert returns no rows when an endpoint is absent -- so that branch just wraps the sentinel. SQLite surfaces a driver-specific constraint code, so rather than parse the driver's error taxonomy it probes the two endpoints on the failure path and reports whichever is missing. The success path pays nothing for that.

**The network hop.** The sentinel was in-process only, and every one of these handlers returned 500 for a missing row: a server fault by status, a caller mistake by text, untestable either way. That is the configuration that matters, since the MCP server runs over `httpclient` against `memstored` -- a sentinel stopping at the network boundary would be absent exactly where this issue needs it. `writeStoreError` maps a miss to 404 and leaves everything else a 500; `HTTPError.Unwrap` turns that 404 back into `ErrNotFound`, so `errors.Is` behaves the same in-process and over the wire.

**The handlers.** All six now route a miss to `invalidWrite`, matching the validation returns added in #164: `Status: "invalid_input"`, the reason on `Error`, `IsError` unset.

Covered by conformance so the backends cannot drift -- seven operations assert the sentinel and three successful calls assert it does not leak onto them -- plus an HTTP round trip for all six and a table test at the MCP layer.

Two notes for review:

- Four `_NotFound` tests asserting the old contract are **removed rather than flipped**. `TestMissingIDIsInvalidInput` covers all six handlers in one table, including `update` and `link`, which the old four missed. Flagging it because it is a test deletion, not a rewrite.
- `assertStoreError`'s doc comment said reclassifying these "needs a `memstore.ErrNotFound` first". It is retired with the thing it was waiting for, and the helper now guards the opposite direction: an outage on the same handler must still set `IsError`, so this cannot trade one misreport for its mirror image.

Postgres conformance does not execute locally -- those tests skip without a database -- so the pgstore wrapping, including both `LinkFacts` branches, is verified by CI here rather than by the local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
