### PR TITLE
chore: log the extraction duplicate count

### DIFF
--- a/httpapi/extractqueue.go
+++ b/httpapi/extractqueue.go
@@ -368,8 +368,12 @@ func (q *ExtractQueue) processJob(job extractJob) {
 	linked := q.linkInsertedScoped(ctx, job.SessionID, projectName, result.Inserted, jobStore)
 
 	errCount := len(result.Errors)
-	log.Printf("extract: session %s: %d inserted, %d superseded, %d linked, %d errors",
-		job.SessionID, len(result.Inserted), result.Superseded, linked, errCount)
+	// Duplicates is logged for #160. Extraction drops a fact that already exists,
+	// and how often that happens decides whether a restated fact is a usable
+	// confirmation signal or too rare to build on. The counter has always been
+	// computed and never recorded, so the rate is currently unknown.
+	log.Printf("extract: session %s: %d inserted, %d superseded, %d duplicates, %d linked, %d errors",
+		job.SessionID, len(result.Inserted), result.Superseded, result.Duplicates, linked, errCount)
 
 	// Stage 2: generate context hints for the next session.
 	if jobHintStore != nil {


### PR DESCRIPTION
`ExtractResult.Duplicates` has always been computed (`extract.go:186,198`) and never recorded -- the session summary line logged inserted, superseded, linked, and errors and dropped it. So the rate has never been observable.

That rate gates #160. A fact restated by a human, unprompted, is the only zero-keystroke confirmation signal available, but if it fires twice a month it cannot carry search weighting and the batched review becomes the primary path instead. One number over a couple of weeks of real sessions decides which, and it costs a format verb to find out.

No behavior change. See the discussion on #160 for why the extraction path is not buildable until this number exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
