### PR TITLE
feat: report what the relevance floor dropped

### DIFF
--- a/httpapi/handler.go
+++ b/httpapi/handler.go
@@ -598,10 +598,18 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if opts.RerankThreshold == nil && h.rerankThreshold > 0 {
 		opts.RerankThreshold = &h.rerankThreshold
 	}
+	var stats memstore.RerankStats
+	opts.RerankStats = &stats
 	results, err := storeFromCtx(r.Context(), h.store).Search(r.Context(), input.Query, opts)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
+	}
+	// Only when the floor actually removed something: a header on every search
+	// saying "dropped 0" is noise, and its absence already means the same thing.
+	if stats.Dropped > 0 {
+		w.Header().Set(memstore.RerankDroppedHeader, strconv.Itoa(stats.Dropped))
+		w.Header().Set(memstore.RerankTopDroppedHeader, strconv.FormatFloat(stats.TopDropped, 'f', -1, 64))
 	}
 	writeJSON(w, http.StatusOK, results)
 }

--- a/httpapi/recall_rerank_test.go
+++ b/httpapi/recall_rerank_test.go
@@ -170,3 +170,39 @@ func TestSearch_UsesDaemonThresholdWhenRequestOmitsIt(t *testing.T) {
 		t.Error("explicit threshold 0 did not disable the daemon floor; 0 must mean no floor")
 	}
 }
+
+// TestSearch_FloorTelemetryCrossesTheWire covers #170. The floor runs
+// daemon-side, so a client learns what it dropped only if the daemon says so.
+// Without this the count exists but never reaches the one place it would be
+// read, which is the same as not having it.
+func TestSearch_FloorTelemetryCrossesTheWire(t *testing.T) {
+	rr := fakeRecallReranker{score: func(doc string) float64 {
+		if strings.Contains(doc, "backoff") {
+			return 0.9
+		}
+		return 0.1
+	}}
+	h, store := recallHandlerWithReranker(t, rr, memstore.RerankDominant, 0.5)
+	store.SetReranker(rr)
+	seedWidgetFacts(t, store)
+
+	resp := doJSON(t, h, "POST", "/v1/search", map[string]any{
+		"query": "widget", "rerank_mode": "dominant",
+	})
+	if got := resp.Header.Get(memstore.RerankDroppedHeader); got != "1" {
+		t.Errorf("%s = %q, want \"1\"", memstore.RerankDroppedHeader, got)
+	}
+	if got := resp.Header.Get(memstore.RerankTopDroppedHeader); got != "0.1" {
+		t.Errorf("%s = %q, want \"0.1\"", memstore.RerankTopDroppedHeader, got)
+	}
+
+	// Nothing dropped means no headers at all: their absence already says zero,
+	// and a "dropped 0" header on every search is noise.
+	zero := 0.0
+	resp = doJSON(t, h, "POST", "/v1/search", map[string]any{
+		"query": "widget", "rerank_mode": "dominant", "rerank_threshold": zero,
+	})
+	if got := resp.Header.Get(memstore.RerankDroppedHeader); got != "" {
+		t.Errorf("%s = %q, want it absent when the floor dropped nothing", memstore.RerankDroppedHeader, got)
+	}
+}

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -217,8 +217,21 @@ func (c *Client) History(ctx context.Context, id int64, subject string) ([]memst
 func (c *Client) Search(ctx context.Context, query string, opts memstore.SearchOpts) ([]memstore.SearchResult, error) {
 	body := searchBody(query, opts)
 	var results []memstore.SearchResult
-	if err := c.post(ctx, "/v1/search", body, &results); err != nil {
+	var hdr http.Header
+	if err := c.doWithRetryCapturing(ctx, "POST", "/v1/search", body, &results, &hdr); err != nil {
 		return nil, err
+	}
+	// The floor runs daemon-side, so its telemetry only reaches the caller by
+	// coming back over the wire. A daemon too old to send the headers leaves the
+	// stats zeroed, which reads as "dropped nothing" -- honest, since this
+	// client cannot know otherwise.
+	if opts.RerankStats != nil {
+		if n, err := strconv.Atoi(hdr.Get(memstore.RerankDroppedHeader)); err == nil {
+			opts.RerankStats.Dropped = n
+		}
+		if f, err := strconv.ParseFloat(hdr.Get(memstore.RerankTopDroppedHeader), 64); err == nil {
+			opts.RerankStats.TopDropped = f
+		}
 	}
 	return results, nil
 }
@@ -476,11 +489,15 @@ func (c *Client) post(ctx context.Context, path string, body, result any) error 
 // Retries on timeouts, connection errors, and 429/502/503/504 responses.
 // Non-retryable errors (other 4xx, context cancellation) return immediately.
 func (c *Client) doWithRetry(ctx context.Context, method, path string, body, result any) error {
+	return c.doWithRetryCapturing(ctx, method, path, body, result, nil)
+}
+
+func (c *Client) doWithRetryCapturing(ctx context.Context, method, path string, body, result any, respHdr *http.Header) error {
 	const maxAttempts = 4
 	backoff := 500 * time.Millisecond
 
 	for attempt := range maxAttempts {
-		err := c.do(ctx, method, path, body, result)
+		err := c.doCapturing(ctx, method, path, body, result, respHdr)
 		if err == nil {
 			return nil
 		}
@@ -524,6 +541,15 @@ func isRetryable(err error) bool {
 }
 
 func (c *Client) do(ctx context.Context, method, path string, body, result any) error {
+	return c.doCapturing(ctx, method, path, body, result, nil)
+}
+
+// doCapturing is do with access to the response headers. Search reads the
+// relevance-floor telemetry from them: the count rides in headers rather than
+// the body because /v1/search is a documented public surface that returns a
+// bare JSON array, and wrapping it in an envelope to carry two numbers would
+// break every existing consumer (#170).
+func (c *Client) doCapturing(ctx context.Context, method, path string, body, result any, respHdr *http.Header) error {
 	// Apply a default timeout if the caller hasn't set one.
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
@@ -555,6 +581,10 @@ func (c *Client) do(ctx context.Context, method, path string, body, result any) 
 		return fmt.Errorf("memstored request failed: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if respHdr != nil {
+		*respHdr = resp.Header
+	}
 
 	if resp.StatusCode >= 400 {
 		var apiErr struct {

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -203,6 +203,14 @@ func (m Metadata) String(key string) (string, bool) {
 type SearchResult struct {
 	Query   string       `json:"query"`
 	Results []FactResult `json:"results"`
+	// FloorDropped and FloorTopDropped report what the relevance floor removed,
+	// omitted when it removed nothing. A result set the floor trimmed otherwise
+	// looks identical to one that was always that short, which is the whole
+	// reason the floor needs to account for itself (#170). FloorTopDropped is
+	// the closest miss: several facts dropped just under the floor argue it is
+	// set too high, several dropped far below argue it is working.
+	FloorDropped    int     `json:"floor_dropped,omitempty"`
+	FloorTopDropped float64 `json:"floor_top_dropped,omitempty"`
 }
 
 // FactResult represents a single search result with typed fields.
@@ -1169,6 +1177,9 @@ func (ms *MemoryServer) HandleSearch(ctx context.Context, _ *mcp.CallToolRequest
 			"note": 720 * time.Hour, // 30 days
 		},
 	}
+	var floorStats memstore.RerankStats
+	opts.RerankStats = &floorStats
+
 	// Bound rerank latency when the model set a timeout: on deadline the rerank
 	// call is cancelled and the store degrades to first-stage order.
 	if tun.timeout > 0 {
@@ -1262,6 +1273,12 @@ func (ms *MemoryServer) HandleSearch(ctx context.Context, _ *mcp.CallToolRequest
 	}
 
 	out := SearchResult{Query: input.Query, Results: facts}
+	if floorStats.Dropped > 0 {
+		fmt.Fprintf(&b, "%d result(s) dropped below the relevance floor of %.3f (closest miss %.4f).\n",
+			floorStats.Dropped, threshold, floorStats.TopDropped)
+		out.FloorDropped = floorStats.Dropped
+		out.FloorTopDropped = floorStats.TopDropped
+	}
 	return sealedResult(fnc, b.String(), out, ids)
 }
 

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -5,11 +5,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/matthewjhunter/go-embedding"
 	"github.com/matthewjhunter/memstore"
+	"github.com/matthewjhunter/memstore/internal/fence"
 	"github.com/matthewjhunter/memstore/mcpserver"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	_ "modernc.org/sqlite"
@@ -793,6 +795,59 @@ func TestSearchEmptyNamesTheFloor(t *testing.T) {
 	}
 	if !strings.Contains(env.Framing, "relevance floor of 0.500") {
 		t.Errorf("framing = %q, want it to name the floor", env.Framing)
+	}
+}
+
+// TestSearchReportsWhatTheFloorDropped is the non-empty half of #170. The empty
+// case already names the floor; a search that returns six results after the
+// floor removed four otherwise looks exactly like one that only ever had six.
+func TestSearchReportsWhatTheFloorDropped(t *testing.T) {
+	srv, store, emb := newTestServer(t)
+	ctx := context.Background()
+	for _, c := range []string{"widget retries use exponential backoff", "widget has a friendly mascot"} {
+		insertFact(t, store, emb, c, "widget", "decision")
+	}
+	store.SetReranker(&scoringReranker{score: func(doc string) float64 {
+		if strings.Contains(doc, "backoff") {
+			return 0.9
+		}
+		return 0.01
+	}})
+
+	floor := 0.05
+	res, env, err := srv.HandleSearch(ctx, nil, mcpserver.SearchInput{
+		Query: "widget", RerankMode: "dominant", Threshold: &floor,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if text := resultText(t, res); !strings.Contains(text, "dropped below the relevance floor") {
+		t.Errorf("text channel does not report the drop:\n%s", text)
+	}
+
+	out := searchResultFromEnvelope(t, env)
+	if out.FloorDropped != 1 {
+		t.Errorf("FloorDropped = %d, want 1", out.FloorDropped)
+	}
+	if out.FloorTopDropped != 0.01 {
+		t.Errorf("FloorTopDropped = %v, want 0.01", out.FloorTopDropped)
+	}
+
+	// A search the floor did not touch must not claim otherwise, on either channel.
+	high := 0.001
+	res, env, err = srv.HandleSearch(ctx, nil, mcpserver.SearchInput{
+		Query: "widget", RerankMode: "dominant", Threshold: &high,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text := resultText(t, res); strings.Contains(text, "dropped below") {
+		t.Errorf("text channel reports a drop that did not happen:\n%s", text)
+	}
+	out = searchResultFromEnvelope(t, env)
+	if out.FloorDropped != 0 {
+		t.Errorf("FloorDropped = %d, want 0", out.FloorDropped)
 	}
 }
 
@@ -2443,4 +2498,30 @@ func TestHandleSuggestAgent_ConfidenceLevels(t *testing.T) {
 	if !strings.Contains(text, "high") {
 		t.Fatalf("expected high confidence for top match, got: %s", text)
 	}
+}
+
+// scoringReranker is a deterministic reranker for floor tests: the floor only
+// engages when rerank actually ran, so exercising it needs a scorer.
+type scoringReranker struct{ score func(doc string) float64 }
+
+func (r *scoringReranker) Model() string { return "fake-reranker" }
+
+func (r *scoringReranker) Rerank(_ context.Context, req embedding.RerankRequest) ([]embedding.RerankResult, error) {
+	out := make([]embedding.RerankResult, len(req.Documents))
+	for i, d := range req.Documents {
+		out[i] = embedding.RerankResult{Index: i, Score: r.score(d)}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Score > out[j].Score })
+	return out, nil
+}
+
+// searchResultFromEnvelope recovers the typed search result from the sealed
+// payload. Read tools return an envelope, so the struct comes back one hop in.
+func searchResultFromEnvelope(t *testing.T, env fence.Envelope) mcpserver.SearchResult {
+	t.Helper()
+	var out mcpserver.SearchResult
+	if err := json.Unmarshal([]byte(env.Unseal()), &out); err != nil {
+		t.Fatalf("unseal search result: %v", err)
+	}
+	return out
 }

--- a/score.go
+++ b/score.go
@@ -212,10 +212,24 @@ func fuseRerank(ctx context.Context, rr embedding.Reranker, query string, merged
 	if opts.RerankThreshold != nil && *opts.RerankThreshold > 0 {
 		floor := *opts.RerankThreshold
 		kept := make([]SearchResult, 0, len(merged))
+		var dropped int
+		var topDropped float64
 		for i := range merged {
 			if i < n && reranked[i] && merged[i].RerankScore >= floor {
 				kept = append(kept, merged[i])
+				continue
 			}
+			// Only reranked facts have a score worth reporting. Ones outside the
+			// pool were never scored, so counting them would inflate the number
+			// with facts the floor did not actually judge.
+			if i < n && reranked[i] {
+				dropped++
+				topDropped = max(topDropped, merged[i].RerankScore)
+			}
+		}
+		if opts.RerankStats != nil {
+			opts.RerankStats.Dropped = dropped
+			opts.RerankStats.TopDropped = topDropped
 		}
 		return kept, nil
 	}

--- a/score_test.go
+++ b/score_test.go
@@ -338,6 +338,75 @@ func equalIDs(a, b []int64) bool {
 	return true
 }
 
+// TestFuseRerank_RecordsWhatTheFloorDropped covers #170. The floor is only as
+// good as the number behind it, and 0.05 was calibrated from three queries.
+// Without a count, a floor set too high looks exactly like a store with little
+// on the subject -- the same indistinguishability the empty-result framing
+// already closes for the empty case.
+//
+// TopDropped is what makes the count actionable: four facts dropped at 0.049
+// argues the floor is too high, four dropped at 0.0001 argues it is working.
+func TestFuseRerank_RecordsWhatTheFloorDropped(t *testing.T) {
+	ctx := context.Background()
+	scores := map[string]float64{"a": 0.9, "b": 0.048, "c": 0.001}
+	rr := &fakeReranker{score: func(doc string) float64 { return scores[doc] }}
+	merged := []SearchResult{
+		{Fact: Fact{Content: "a"}, Combined: 0.9},
+		{Fact: Fact{Content: "b"}, Combined: 0.5},
+		{Fact: Fact{Content: "c"}, Combined: 0.4},
+	}
+
+	var stats RerankStats
+	opts := SearchOpts{
+		RerankMode:      RerankDominant,
+		RerankThreshold: ptrFloat(0.05),
+		RerankStats:     &stats,
+	}
+	got, err := fuseRerank(ctx, rr, "q", merged, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("kept %d results, want 1", len(got))
+	}
+	if stats.Dropped != 2 {
+		t.Errorf("Dropped = %d, want 2", stats.Dropped)
+	}
+	// The near-miss, not the worst offender: that is the one that says whether
+	// the floor is set too high.
+	if stats.TopDropped != 0.048 {
+		t.Errorf("TopDropped = %v, want 0.048 (the closest miss)", stats.TopDropped)
+	}
+}
+
+// TestFuseRerank_StatsStayZeroWhenNothingDropped keeps the reporting honest at
+// the other end: a search the floor did not touch must not claim it did.
+func TestFuseRerank_StatsStayZeroWhenNothingDropped(t *testing.T) {
+	ctx := context.Background()
+	scores := map[string]float64{"a": 0.9, "b": 0.8}
+	rr := &fakeReranker{score: func(doc string) float64 { return scores[doc] }}
+	merged := []SearchResult{
+		{Fact: Fact{Content: "a"}, Combined: 0.9},
+		{Fact: Fact{Content: "b"}, Combined: 0.8},
+	}
+
+	var stats RerankStats
+	got, err := fuseRerank(ctx, rr, "q", merged, SearchOpts{
+		RerankMode:      RerankDominant,
+		RerankThreshold: ptrFloat(0.05),
+		RerankStats:     &stats,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("kept %d, want 2", len(got))
+	}
+	if stats.Dropped != 0 || stats.TopDropped != 0 {
+		t.Errorf("stats = %+v, want zero when the floor dropped nothing", stats)
+	}
+}
+
 // ptrFloat is a test helper for SearchOpts.RerankThreshold, which is a pointer
 // so that nil ("no opinion") and 0 ("no floor") stay distinguishable.
 func ptrFloat(f float64) *float64 { return &f }

--- a/store.go
+++ b/store.go
@@ -364,6 +364,12 @@ type SearchOpts struct {
 	// zero — the moment a default floor existed, no caller could turn it off
 	// (#163).
 	RerankThreshold *float64
+	// RerankStats, when non-nil, receives what the floor dropped. It is an
+	// out-parameter rather than a return value so that reporting costs no change
+	// to the Store interface: SearchOpts is copied by value, but the pointer
+	// survives the copy, so every backend routing through ScoreResults fills it
+	// in without knowing it exists.
+	RerankStats *RerankStats
 }
 
 // SearchResult holds a fact with its relevance scores.
@@ -436,6 +442,35 @@ type Link struct {
 // (#165). Wrap it with %w rather than returning it bare, so the message keeps
 // naming the id that missed.
 var ErrNotFound = errors.New("not found")
+
+// Relevance-floor telemetry headers, carried on the /v1/search response. They
+// ride on the response rather than in it because /v1/search returns a bare JSON
+// array and is a documented public surface: wrapping it in an envelope to carry
+// two numbers would break every existing consumer (#170).
+//
+// They live here, not in httpapi, so the client can name them without importing
+// the server package.
+const (
+	RerankDroppedHeader    = "X-Memstore-Rerank-Dropped"
+	RerankTopDroppedHeader = "X-Memstore-Rerank-Top-Dropped"
+)
+
+// RerankStats reports what the relevance floor removed from a search. It is
+// filled in only when SearchOpts.RerankStats points at one.
+//
+// The floor is only as trustworthy as the number behind it, and the default was
+// calibrated from a handful of queries. Without this a floor set too high is
+// indistinguishable from a store that holds little on the subject -- results
+// simply do not appear, and nothing says why (#170).
+type RerankStats struct {
+	// Dropped is how many reranked facts scored below the floor.
+	Dropped int
+	// TopDropped is the highest rerank score among them, or 0 when none were
+	// dropped. It is the number that makes Dropped actionable: several facts
+	// missing by a hair says the floor is too high, several missing by three
+	// orders of magnitude says it is doing its job.
+	TopDropped float64
+}
 
 // FactBreakdown holds per-dimension counts of active facts. Each map is keyed
 // by the dimension value and holds the number of active facts carrying it.


### PR DESCRIPTION
Closes #170.

The floor from #168 removes results and nothing counted them, so `0.05` was unfalsifiable: calibrated from three queries, with no mechanism that could ever show it wrong.

The empty case already reported itself -- the framing names the floor when the floor is what emptied the set. The gap was every other search. One returning six results after the floor removed four was indistinguishable from one that only ever had six: the same "a filter set wrong looks exactly like a sparse store" problem, still open for the common case.

**Plumbing.** `RerankStats` rides in as an out-parameter on `SearchOpts`. `SearchOpts` is copied by value but the pointer survives the copy, so no `Store` method changes and both backends fill it in without knowing it exists.

**It carries the closest miss, not just the count.** The count alone does not answer the question: four facts dropped at 0.049 argue the floor is too high, four dropped at 0.0001 argue it is working. Same plumbing, and only the second number decides anything.

**Over HTTP it travels as response headers.** `/v1/search` returns a bare JSON array and is documented as a public surface (README, `docs/architecture.md`), so wrapping it in an envelope to carry two numbers would break every consumer. Headers are additive. They are omitted when nothing was dropped -- their absence already means zero, and a "dropped 0" header on every search is noise. A daemon too old to send them leaves the stats zeroed, which reads as "dropped nothing": the only honest answer a client that cannot know has.

Reported on both MCP channels, and only when non-zero, so quiet searches stay quiet.

Produces no data until memstored is rebuilt and redeployed -- same dependency as #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
