### PR TITLE
fix: report a missing id from history and supersede as invalid input

### DIFF
--- a/httpapi/handler.go
+++ b/httpapi/handler.go
@@ -475,7 +475,7 @@ func (h *Handler) handleSupersede(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := storeFromCtx(r.Context(), h.store).Supersede(r.Context(), oldID, input.NewID); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "superseded"})
@@ -550,7 +550,7 @@ func (h *Handler) handleHistoryByID(w http.ResponseWriter, r *http.Request) {
 	}
 	entries, err := storeFromCtx(r.Context(), h.store).History(r.Context(), id, "")
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeStoreError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, entries)

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -389,6 +389,11 @@ func TestClient_NotFoundSentinel(t *testing.T) {
 			_, err := c.LinkFacts(ctx, missing, missing, "reference", false, "", nil)
 			return err
 		}},
+		{"Supersede", func() error { return c.Supersede(ctx, missing, missing) }},
+		{"History", func() error {
+			_, err := c.History(ctx, missing, "")
+			return err
+		}},
 	}
 
 	for _, tc := range cases {

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -360,9 +360,10 @@ func testBreakdownAggregates(t *testing.T, s memstore.Store) {
 	}
 }
 
-// testNotFoundSentinel pins the contract that an id-targeted mutation naming a
+// testNotFoundSentinel pins the contract that an id-targeted operation naming a
 // row that does not exist reports memstore.ErrNotFound rather than an opaque
-// error. The MCP layer needs to tell that case apart from a real store failure:
+// error. History is here as well as the mutations: it is a read, but it is
+// id-targeted, so a typo in the id reaches the caller the same way (#172). The MCP layer needs to tell that case apart from a real store failure:
 // the two report on different channels, and without a sentinel every miss looks
 // like an outage. Both backends must agree, including LinkFacts, where the miss
 // surfaces as a foreign-key violation rather than a zero-row update.
@@ -396,6 +397,11 @@ func testNotFoundSentinel(t *testing.T, s memstore.Store) {
 		}},
 		{"LinkFactsMissingTarget", func() error {
 			_, err := s.LinkFacts(ctx, realID, missing, "reference", false, "", nil)
+			return err
+		}},
+		{"Supersede", func() error { return s.Supersede(ctx, missing, realID) }},
+		{"History", func() error {
+			_, err := s.History(ctx, missing, "")
 			return err
 		}},
 	}

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -1584,6 +1584,12 @@ func (ms *MemoryServer) HandleHistory(ctx context.Context, _ *mcp.CallToolReques
 
 	entries, err := ms.store.History(ctx, input.ID, input.Subject)
 	if err != nil {
+		// An id that names nothing is the caller's typo, not an outage. History
+		// is a read, so #167 left it behind when it split the channels for the
+		// mutations; the flag costs a caller here what it cost them there (#172).
+		if errors.Is(err, memstore.ErrNotFound) {
+			return invalidInputResult(fmt.Sprintf("Error: %v", err))
+		}
 		return noticeResult(fmt.Sprintf("Error: %v", err), true)
 	}
 

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -680,7 +680,7 @@ func TestHandleDelete_InvalidID(t *testing.T) {
 
 // TestMissingIDIsInvalidInput covers #165: naming a fact or link that does not
 // exist is a caller mistake, not memstore failing at something it was asked to
-// do. Before the ErrNotFound sentinel these six could not tell the two apart
+// do. Before the ErrNotFound sentinel these handlers could not tell the two apart
 // and took the pessimistic branch, so a bad id set IsError and a client that
 // honours it dropped the typed result.
 func TestMissingIDIsInvalidInput(t *testing.T) {
@@ -716,6 +716,12 @@ func TestMissingIDIsInvalidInput(t *testing.T) {
 		}},
 		{"link", func() (*mcp.CallToolResult, error) {
 			r, _, err := srv.HandleLink(ctx, nil, mcpserver.LinkInput{SourceID: missing, TargetID: realID})
+			return r, err
+		}},
+		// history is a read rather than a mutation, but it is id-targeted, so a
+		// typo in the id lands the caller in the same place (#172).
+		{"history", func() (*mcp.CallToolResult, error) {
+			r, _, err := srv.HandleHistory(ctx, nil, mcpserver.HistoryInput{ID: missing})
 			return r, err
 		}},
 	}
@@ -760,6 +766,15 @@ func TestMissingIDStoreFailureKeepsIsError(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertStoreError(t, res)
+
+	// History reads the same closed database. Its miss branch tests a sentinel
+	// rather than the presence of an error, so a query that fails outright must
+	// still reach the caller flagged (#172).
+	hist, _, err := srv.HandleHistory(ctx, nil, mcpserver.HistoryInput{ID: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStoreError(t, hist)
 }
 
 // TestSearchEmptyNamesTheFloor covers the observability half of #163: an empty

--- a/pgstore/store.go
+++ b/pgstore/store.go
@@ -1291,7 +1291,7 @@ func (s *PostgresStore) Supersede(ctx context.Context, oldID, newID int64) error
 		return fmt.Errorf("pgstore: superseding fact %d: %w", oldID, err)
 	}
 	if ct.RowsAffected() == 0 {
-		return fmt.Errorf("pgstore: fact %d not found or already superseded", oldID)
+		return fmt.Errorf("pgstore: fact %d %w or already superseded", oldID, memstore.ErrNotFound)
 	}
 	return nil
 }
@@ -1871,7 +1871,12 @@ func (s *PostgresStore) historyByID(ctx context.Context, id int64) ([]memstore.H
 	row := s.pool.QueryRow(ctx, anchorQ, anchorArgs...)
 	anchor, err := scanFact(row)
 	if err != nil {
-		return nil, fmt.Errorf("pgstore: fact %d not found: %w", id, err)
+		// Only a missing anchor is the caller's mistake; a scan or query failure
+		// on the same statement is still the store's (#172).
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("pgstore: fact %d %w", id, memstore.ErrNotFound)
+		}
+		return nil, fmt.Errorf("pgstore: reading fact %d: %w", id, err)
 	}
 
 	// Walk backward.

--- a/sqlite.go
+++ b/sqlite.go
@@ -1159,7 +1159,7 @@ func (s *SQLiteStore) Supersede(ctx context.Context, oldID, newID int64) error {
 		return fmt.Errorf("memstore: checking rows affected: %w", err)
 	}
 	if rows == 0 {
-		return fmt.Errorf("memstore: fact %d not found or already superseded", oldID)
+		return fmt.Errorf("memstore: fact %d %w or already superseded", oldID, ErrNotFound)
 	}
 	return nil
 }
@@ -1960,7 +1960,12 @@ func (s *SQLiteStore) historyByID(ctx context.Context, id int64) ([]HistoryEntry
 			s.readableSQL(""), id, s.namespace)
 	anchor, err := scanFact(row)
 	if err != nil {
-		return nil, fmt.Errorf("memstore: fact %d not found: %w", id, err)
+		// Only a missing anchor is the caller's mistake; a scan or query failure
+		// on the same statement is still the store's (#172).
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("memstore: fact %d %w", id, ErrNotFound)
+		}
+		return nil, fmt.Errorf("memstore: reading fact %d: %w", id, err)
 	}
 
 	// Walk backward: find predecessors (facts whose superseded_by points to us).

--- a/store.go
+++ b/store.go
@@ -434,7 +434,9 @@ type Link struct {
 // Store provides fact storage with hybrid FTS5+vector search.
 // ErrNotFound is reported by id-targeted operations when no row matches the id
 // in the caller's scope: Delete, Confirm, UpdateMetadata, DeleteLink,
-// UpdateLink, and LinkFacts naming an endpoint that does not exist.
+// UpdateLink, Supersede, History by id, and LinkFacts naming an endpoint that
+// does not exist. History is the one read in that list -- it is id-targeted, so
+// a caller can miss with it the same way (#172).
 //
 // It exists so callers can tell a caller mistake from a store failure. The MCP
 // layer reports the two on different channels -- a bad id is invalid_input,


### PR DESCRIPTION
Closes #172. Finishes the sweep #167 started.

#167 gave six id-targeted mutations the `ErrNotFound` sentinel so the MCP layer could tell a caller's typo from a store outage. `History` and `Supersede` were left out, and both still reported a miss as a 500 with `IsError` set -- the flag Claude Code reads to decide a result is untrustworthy, at which point it renders the text block and drops `StructuredContent`.

`History` was the one a caller actually hit. `HandleSupersede` pre-checks both ids with `Get` and never reaches the store's error, so the 500 there was reserved for the CLI and any direct HTTP caller. Found by exercising the live daemon:

```
memory_history(id=99999999)
-> Error: memstored 500: pgstore: fact 99999999 not found: no rows in result set
```

**The stores.** Both wrap the sentinel mid-message, so the existing text survives intact rather than gaining a second clause. `historyByID` wraps only the no-rows case -- a scan or query failure on the same statement is still the store's, and reporting that as a caller mistake would trade one misreport for its mirror image.

**The network hop.** Both handlers route through `writeStoreError`, so a miss is a 404 that `HTTPError.Unwrap` turns back into `ErrNotFound`. That is the configuration that matters: the MCP server runs over `httpclient` against `memstored`, so a sentinel stopping at the boundary would be absent exactly where this issue needs it.

**Coverage.** `testNotFoundSentinel` gains both operations, so neither backend can drift. The HTTP round trip covers both. The MCP table gains `history` alongside a closed-database case asserting that a genuine failure on the same handler still arrives flagged.

Postgres conformance does not execute locally -- those tests skip without a database -- so the pgstore wrapping is verified by CI here rather than by the local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)