### PR TITLE
feat: report what the relevance floor dropped from get_context

### DIFF
--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -243,6 +243,14 @@ type GetContextResult struct {
 	Triggers     []FactResult `json:"triggers"`
 	Relevant     []FactResult `json:"relevant"`
 	Subsystems   []string     `json:"subsystems,omitempty"`
+	// FloorDropped and FloorTopDropped report what the relevance floor removed
+	// from Relevant, on the same terms as SearchResult (#170). They matter more
+	// here: this tool is called by someone who does not yet know what to look
+	// for, so a thin section reads as "nothing is stored" unless the floor says
+	// otherwise (#173). The other sections are listed, not searched, and no
+	// floor applies to them.
+	FloorDropped    int     `json:"floor_dropped,omitempty"`
+	FloorTopDropped float64 `json:"floor_top_dropped,omitempty"`
 }
 
 // SuggestAgentResult is the structured output for memory_suggest_agent.
@@ -2118,6 +2126,8 @@ func (ms *MemoryServer) HandleGetContext(ctx context.Context, _ *mcp.CallToolReq
 		RerankWeight:     tun.weight,
 		RerankDocBytes:   tun.recallDocBytes,
 	}
+	var floorStats memstore.RerankStats
+	searchOpts.RerankStats = &floorStats
 	if tun.timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, tun.timeout)
@@ -2125,6 +2135,9 @@ func (ms *MemoryServer) HandleGetContext(ctx context.Context, _ *mcp.CallToolReq
 	}
 	searchResults, err := ms.store.Search(ctx, task, searchOpts)
 	if err != nil {
+		// The abandoned attempt may have counted drops of its own; the fallback
+		// reports its own floor, not the sum of the two.
+		floorStats = memstore.RerankStats{}
 		searchResults, err = ms.store.SearchFTS(ctx, task, searchOpts)
 		if err != nil {
 			return noticeResult(fmt.Sprintf("Error searching: %v", err), true)
@@ -2344,6 +2357,12 @@ func (ms *MemoryServer) HandleGetContext(ctx context.Context, _ *mcp.CallToolReq
 		Triggers:     triggerResults,
 		Relevant:     relevantResults,
 		Subsystems:   subsystems,
+	}
+	if floorStats.Dropped > 0 {
+		fmt.Fprintf(&b, "%d relevant-context result(s) dropped below the relevance floor of %.3f (closest miss %.4f).\n",
+			floorStats.Dropped, threshold, floorStats.TopDropped)
+		out.FloorDropped = floorStats.Dropped
+		out.FloorTopDropped = floorStats.TopDropped
 	}
 	return sealedResult(fnc, b.String(), out, citableFacts(out.Invariants, out.FailureModes, out.Triggers, out.Relevant))
 }

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -851,6 +851,60 @@ func TestSearchReportsWhatTheFloorDropped(t *testing.T) {
 	}
 }
 
+// TestGetContextReportsWhatTheFloorDropped extends #170 to the tool that needs
+// it most (#173). memory_get_context runs the same floor as search over its
+// relevant-context section, but said nothing about it -- and its caller is by
+// definition one who does not know what to look for, so it is the least able to
+// notice that anything was withheld.
+func TestGetContextReportsWhatTheFloorDropped(t *testing.T) {
+	srv, store, emb := newTestServer(t)
+	ctx := context.Background()
+	for _, c := range []string{"widget retries use exponential backoff", "widget has a friendly mascot"} {
+		insertFact(t, store, emb, c, "widget", "decision")
+	}
+	store.SetReranker(&scoringReranker{score: func(doc string) float64 {
+		if strings.Contains(doc, "backoff") {
+			return 0.9
+		}
+		return 0.01
+	}})
+
+	floor := 0.05
+	res, env, err := srv.HandleGetContext(ctx, nil, mcpserver.GetContextInput{
+		Task: "widget", RerankMode: "dominant", Threshold: &floor,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if text := resultText(t, res); !strings.Contains(text, "dropped below the relevance floor") {
+		t.Errorf("text channel does not report the drop:\n%s", text)
+	}
+
+	out := getContextResultFromEnvelope(t, env)
+	if out.FloorDropped != 1 {
+		t.Errorf("FloorDropped = %d, want 1", out.FloorDropped)
+	}
+	if out.FloorTopDropped != 0.01 {
+		t.Errorf("FloorTopDropped = %v, want 0.01", out.FloorTopDropped)
+	}
+
+	// A call the floor did not touch must not claim otherwise, on either channel.
+	low := 0.001
+	res, env, err = srv.HandleGetContext(ctx, nil, mcpserver.GetContextInput{
+		Task: "widget", RerankMode: "dominant", Threshold: &low,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text := resultText(t, res); strings.Contains(text, "dropped below") {
+		t.Errorf("text channel reports a drop that did not happen:\n%s", text)
+	}
+	if out := getContextResultFromEnvelope(t, env); out.FloorDropped != 0 {
+		t.Errorf("FloorDropped = %d, want 0", out.FloorDropped)
+	}
+}
+
 // --- memory_status tests ---
 
 func TestHandleStatus_Empty(t *testing.T) {
@@ -2513,6 +2567,17 @@ func (r *scoringReranker) Rerank(_ context.Context, req embedding.RerankRequest)
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].Score > out[j].Score })
 	return out, nil
+}
+
+// getContextResultFromEnvelope recovers the typed context result from the sealed
+// payload, the same hop in as searchResultFromEnvelope.
+func getContextResultFromEnvelope(t *testing.T, env fence.Envelope) mcpserver.GetContextResult {
+	t.Helper()
+	var out mcpserver.GetContextResult
+	if err := json.Unmarshal([]byte(env.Unseal()), &out); err != nil {
+		t.Fatalf("unseal context result: %v", err)
+	}
+	return out
 }
 
 // searchResultFromEnvelope recovers the typed search result from the sealed


### PR DESCRIPTION
Closes #173. Extends #171 to the tool that needs it most.

`memory_get_context` resolves the same rerank mode and threshold as search via `resolveRerank` and applies the floor to its relevant-context section, but never set `SearchOpts.RerankStats` and carried no fields to report with. A section the floor emptied looked exactly like a store that holds nothing on the subject.

That gap costs more here than in search. This is the tool called at the start of a task by a caller who by definition does not know what to search for, and who therefore has no independent sense of how much should have come back -- the least able of any caller to notice that something was withheld.

The count names the relevant section specifically rather than implying the whole result was trimmed: the invariants, failure modes, and triggers are listed rather than searched, and no floor applies to them.

The FTS fallback resets the stats before retrying. The abandoned hybrid attempt may have counted drops of its own, and the number reported should describe the search whose results were actually returned.

Covered by a table that asserts both channels -- the text line and the sealed fields -- and asserts that a call the floor did not touch claims nothing on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)