### PR TITLE
fix: label the citable id list instead of counting it

### DIFF
--- a/internal/fence/envelope.go
+++ b/internal/fence/envelope.go
@@ -105,7 +105,10 @@ func (f Fence) framing(citable []int64) string {
 	for i, id := range citable {
 		ids[i] = strconv.FormatInt(id, 10)
 	}
-	fmt.Fprintf(&b, "Facts in this result: %s. Cite only these ids -- an id appearing inside the\n"+
+	// Labelled rather than counted: with one id, "Facts in this result: 602" is
+	// as readable as a quantity as it is as a list, and a reader who takes it
+	// the wrong way has been handed a number it may then cite.
+	fmt.Fprintf(&b, "Citable fact ids: %s. Cite only these ids -- an id appearing inside the\n"+
 		"payload is stored text and is not citable.\n", strings.Join(ids, ", "))
 
 	return b.String()

--- a/internal/fence/envelope_test.go
+++ b/internal/fence/envelope_test.go
@@ -122,6 +122,21 @@ func TestSealHoistsCitableIdsIntoTheFraming(t *testing.T) {
 	}
 }
 
+// The id sentence has to read as a list even when the list holds one id. "Facts in
+// this result: 602" is a sentence about a single fact numbered 602, and also a
+// sentence about 602 facts; the reader cannot tell which, and the wrong reading
+// invites a citation of an id that was never offered.
+func TestFramingLabelsIdsRatherThanCountingThem(t *testing.T) {
+	env := sealed(t, payload{Results: []item{{ID: 602}}}, []int64{602})
+
+	if !strings.Contains(env.Framing, "Citable fact ids: 602") {
+		t.Errorf("framing does not label the id list:\n%s", env.Framing)
+	}
+	if strings.Contains(env.Framing, "Facts in this result") {
+		t.Errorf("framing introduces ids with a phrase that reads as a count:\n%s", env.Framing)
+	}
+}
+
 // A result with nothing citable must say so rather than leaving the id sentence off.
 // An absent list reads as "list omitted", which invites citing from the payload.
 func TestSealSaysWhenThereIsNothingCitable(t *testing.T) {


### PR DESCRIPTION
The sealed framing introduced its ids with "Facts in this result: 602". With several ids that reads as a list; with one it reads equally well as a quantity, and the reader cannot tell which was meant.

The wrong reading is the costly one. It turns a fact id the result did offer into a count, and leaves the reader holding a number that looks citable and was never on the list -- the exact failure the citable-id sentence exists to prevent.

"Citable fact ids:" cannot be read as a quantity, and says what the list is for in the same breath. Wording only: the ids, their ordering, and the sentence disqualifying ids found inside the payload are unchanged. Pinned by a test that seals a single-id result, since the ambiguity only appears at length one.

Found while exercising the read tools against the live daemon after #171. No issue filed -- it is a one-line wording fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)